### PR TITLE
Extend Python bindings for Document, MaterialAssign, and Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 - Added method Element\:\:setName.
+- Extended Python bindings for Document, MaterialAssign, and Collection.
+
+### Changed
+- Modified NodeGraph\:\:topologicalSort to return elements in a more intuitive top-down order, with upstream elements preceding downstream elements.
+- Updated OSL reference implementations.
 
 ### Fixed
 - Fixed handling of empty names in Element\:\:addChildOfCategory.
@@ -47,7 +52,7 @@ Updated the MaterialX library to the v1.35 specification.
 - Removed the 'default' attribute from MaterialX\:\:ValueElement.  In v1.35, this functionality is now handled by the 'value' attribute.
 - Replaced the 'matrix' type with 'matrix33' and 'matrix44', and replaced the MaterialX\:\:Matrix16 class with MaterialX\:\:Matrix3x3 and MaterialX\:\:Matrix4x4.
 - Renamed Material\:\:getMaterialAssigns to Material\:\:getReferencingMaterialAssigns.
-- Change the argument type for MaterialAssign\:\:setExclusive and MaterialAssign\:\:getExclusive to boolean.
+- Changed the argument type for MaterialAssign\:\:setExclusive and MaterialAssign\:\:getExclusive to boolean.
 
 ## [1.34.4] - 2017-06-09
 

--- a/source/PyMaterialX/PyDocument.cpp
+++ b/source/PyMaterialX/PyDocument.cpp
@@ -61,6 +61,7 @@ void bindPyDocument(py::module& mod)
         .def("getNodeDefs", &mx::Document::getNodeDefs)
         .def("removeNodeDef", &mx::Document::removeNodeDef)
         .def("getMatchingNodeDefs", &mx::Document::getMatchingNodeDefs)
+        .def("getMatchingImplementations", &mx::Document::getMatchingImplementations)
         .def("addPropertySet", &mx::Document::addPropertySet,
             py::arg("name") = mx::EMPTY_STRING)
         .def("getPropertySet", &mx::Document::getPropertySet)

--- a/source/PyMaterialX/PyGeom.cpp
+++ b/source/PyMaterialX/PyGeom.cpp
@@ -45,7 +45,17 @@ void bindPyGeom(py::module& mod)
         .def_readonly_static("CATEGORY", &mx::GeomAttr::CATEGORY);
 
     py::class_<mx::Collection, mx::CollectionPtr, mx::Element>(mod, "Collection", py::metaclass())
-        .def_readonly_static("CATEGORY", &mx::CollectionAdd::CATEGORY);
+        .def("addCollectionAdd", &mx::Collection::addCollectionAdd,
+            py::arg("name") = mx::EMPTY_STRING)
+        .def("getCollectionAdd", &mx::Collection::getCollectionAdd)
+        .def("getCollectionAdds", &mx::Collection::getCollectionAdds)
+        .def("removeCollectionAdd", &mx::Collection::removeCollectionAdd)
+        .def("addCollectionRemove", &mx::Collection::addCollectionRemove,
+            py::arg("name") = mx::EMPTY_STRING)
+        .def("getCollectionRemove", &mx::Collection::getCollectionRemove)
+        .def("getCollectionRemoves", &mx::Collection::getCollectionRemoves)
+        .def("removeCollectionRemove", &mx::Collection::removeCollectionRemove)
+        .def_readonly_static("CATEGORY", &mx::Collection::CATEGORY);
 
     py::class_<mx::CollectionAdd, mx::CollectionAddPtr, mx::GeomElement>(mod, "CollectionAdd", py::metaclass())
         .def_readonly_static("CATEGORY", &mx::CollectionAdd::CATEGORY);

--- a/source/PyMaterialX/PyLook.cpp
+++ b/source/PyMaterialX/PyLook.cpp
@@ -51,6 +51,9 @@ void bindPyLook(py::module& mod)
         .def_readonly_static("CATEGORY", &mx::Look::CATEGORY);
 
     py::class_<mx::MaterialAssign, mx::MaterialAssignPtr, mx::GeomElement>(mod, "MaterialAssign", py::metaclass())
+        .def("setMaterial", &mx::MaterialAssign::setMaterial)
+        .def("hasMaterial", &mx::MaterialAssign::hasMaterial)
+        .def("getMaterial", &mx::MaterialAssign::getMaterial)
         .def("setExclusive", &mx::MaterialAssign::setExclusive)
         .def("getExclusive", &mx::MaterialAssign::getExclusive)
         .def("getReferencedMaterial", &mx::MaterialAssign::getReferencedMaterial)


### PR DESCRIPTION
Add Python bindings for the following methods:

Document:
 - getMatchingImplementations

MaterialAssign:
 - setMaterial
 - hasMaterial
 - getMaterial

Collection:
 - addCollectionAdd
 - getCollectionAdd
 - getCollectionAdds
 - removeCollectionAdd
 - addCollectionRemove
 - getCollectionRemove
 - getCollectionRemoves
 - removeCollectionRemove

Also, fix a mismatch in the Python binding for the Collection category string.