### PR TITLE
Initial support for Python 3

### DIFF
--- a/python/MaterialX/datatype.py
+++ b/python/MaterialX/datatype.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 from MaterialX.PyMaterialX import *
 
@@ -22,7 +23,7 @@ _nameToType = { 'integer'   : int,
                 'string'    : str }
 _typeToName = dict(reversed(i) for i in _nameToType.items())
 
-_stringTypeAliases = [unicode]
+_stringTypeAliases = [unicode] if sys.version_info[0] < 3 else [bytes]
 _typeToName.update(dict.fromkeys(_stringTypeAliases, 'string'))
 
 

--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -112,14 +112,8 @@ InterfaceElement.getParameterValue = _getParameterValue
 
 def _addNode(self, category, name = '', typeString = 'color3'):
     "Add an opgraph node."
-    if not isinstance(typeString, basestring):
-        warnings.warn("The typeString argument of NodeGraph.addNode is expected to be of string type", DeprecationWarning, stacklevel = 2)
-        typeString = typeToName(typeString)
-    if category == 'output':
-        warnings.warn("To create an output element, use the method NodeGraph.addOutput", DeprecationWarning, stacklevel = 2)
-        return self.addOutput(name, typeString)
     return self._addNode(category, name, typeString)
-    
+
 NodeGraph.addNode = _addNode
 
 

--- a/source/PyMaterialX/PyBind11/common.h
+++ b/source/PyMaterialX/PyBind11/common.h
@@ -169,13 +169,6 @@
 #define PYBIND11_BYTES_AS_STRING PyString_AsString
 #define PYBIND11_BYTES_SIZE PyString_Size
 #define PYBIND11_LONG_CHECK(o) (PyInt_Check(o) || PyLong_Check(o))
-#  ifdef PYBIND11_PREFER_PYINT
-#    define PYBIND11_PYOBJECT_FROM_LONG PyInt_FromLong
-#    define PYBIND11_PYOBJECT_AS_LONG PyInt_AsLong
-#  else
-#    define PYBIND11_PYOBJECT_FROM_LONG PyLong_FromLong
-#    define PYBIND11_PYOBJECT_AS_LONG PyLong_AsLong
-#  endif
 #define PYBIND11_LONG_AS_LONGLONG(o) (PyInt_Check(o) ? (long long) PyLong_AsLong(o) : PyLong_AsLongLong(o))
 #define PYBIND11_LONG_AS_UNSIGNED_LONGLONG(o) (PyInt_Check(o) ? (unsigned long long) PyLong_AsUnsignedLong(o) : PyLong_AsUnsignedLongLong(o))
 #define PYBIND11_BYTES_NAME "str"
@@ -189,6 +182,14 @@
         (void)pybind11_init_wrapper();                      \
     }                                                       \
     PyObject *pybind11_init_wrapper()
+#endif
+
+#if PY_MAJOR_VERSION < 3 && defined(PYBIND11_PREFER_PYINT)
+#define PYBIND11_PYOBJECT_FROM_LONG PyInt_FromLong
+#define PYBIND11_PYOBJECT_AS_LONG PyInt_AsLong
+#else
+#define PYBIND11_PYOBJECT_FROM_LONG PyLong_FromLong
+#define PYBIND11_PYOBJECT_AS_LONG PyLong_AsLong
 #endif
 
 #if PY_VERSION_HEX >= 0x03050000 && PY_VERSION_HEX < 0x03050200

--- a/source/PyMaterialX/PyMaterialX.h
+++ b/source/PyMaterialX/PyMaterialX.h
@@ -17,6 +17,10 @@
 
 #include <PyBind11/pybind11.h>
 
-PYBIND11_DECLARE_HOLDER_TYPE(holder, std::shared_ptr<holder>);
+#if PY_MAJOR_VERSION < 3
+using PyDefaultString = pybind11::bytes;
+#else
+using PyDefaultString = pybind11::str;
+#endif
 
 #endif

--- a/source/PyMaterialX/PyTypes.cpp
+++ b/source/PyMaterialX/PyTypes.cpp
@@ -37,7 +37,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return py::bytes(output.str());
+                return PyDefaultString(output.str());
             }
         );
 
@@ -59,7 +59,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return py::bytes(output.str());
+                return PyDefaultString(output.str());
             }
         );
 
@@ -81,7 +81,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return py::bytes(output.str());
+                return PyDefaultString(output.str());
             }
         );
 
@@ -101,7 +101,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return py::bytes(output.str());
+                return PyDefaultString(output.str());
             }
         );
 
@@ -121,7 +121,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return py::bytes(output.str());
+                return PyDefaultString(output.str());
             }
         );
 

--- a/source/PyMaterialX/PyValue.cpp
+++ b/source/PyMaterialX/PyValue.cpp
@@ -12,7 +12,7 @@
 #define BIND_TYPE_INSTANCE(NAME, T, PYTYPE)                                                                                 \
 py::class_<mx::TypedValue<T>, std::shared_ptr< mx::TypedValue<T> >, mx::Value>(mod, "TypedValue_" #NAME, py::metaclass())   \
     .def("getData", [](const mx::TypedValue<T>& value) { return PYTYPE(value.getData()); })                                 \
-    .def("getValueString", [](const mx::TypedValue<T>& value) { return py::bytes(value.getValueString()); })                \
+    .def("getValueString", [](const mx::TypedValue<T>& value) { return PyDefaultString(value.getValueString()); })          \
     .def_static("createValue", &mx::Value::createValue<T>)                                                                  \
     .def_readonly_static("TYPE", &mx::TypedValue<T>::TYPE)                                                                  \
     .def_readonly_static("ZERO", &mx::TypedValue<T>::ZERO);
@@ -38,5 +38,5 @@ void bindPyValue(py::module& mod)
     BIND_TYPE_INSTANCE(vector4, mx::Vector4, mx::Vector4)
     BIND_TYPE_INSTANCE(matrix33, mx::Matrix3x3, mx::Matrix3x3)
     BIND_TYPE_INSTANCE(matrix44, mx::Matrix4x4, mx::Matrix4x4)
-    BIND_TYPE_INSTANCE(string, std::string, py::bytes)
+    BIND_TYPE_INSTANCE(string, std::string, PyDefaultString)
 }


### PR DESCRIPTION
- Add the PyDefaultString type and update PYBIND_PREFER_PYINT logic for Python 2/3 compatibility
- Update pure-Python wrappers for Python 2/3 compatibility