### PR TITLE
Consistently return Unicode strings in MaterialX Python

### DIFF
--- a/source/PyMaterialX/PyMaterialX.h
+++ b/source/PyMaterialX/PyMaterialX.h
@@ -17,10 +17,4 @@
 
 #include <PyBind11/pybind11.h>
 
-#if PY_MAJOR_VERSION < 3
-using PyDefaultString = pybind11::bytes;
-#else
-using PyDefaultString = pybind11::str;
-#endif
-
 #endif

--- a/source/PyMaterialX/PyTypes.cpp
+++ b/source/PyMaterialX/PyTypes.cpp
@@ -37,7 +37,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return PyDefaultString(output.str());
+                return output.str();
             }
         );
 
@@ -59,7 +59,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return PyDefaultString(output.str());
+                return output.str();
             }
         );
 
@@ -81,7 +81,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return PyDefaultString(output.str());
+                return output.str();
             }
         );
 
@@ -101,7 +101,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return PyDefaultString(output.str());
+                return output.str();
             }
         );
 
@@ -121,7 +121,7 @@ void bindPyTypes(py::module& mod)
             {
                 std::ostringstream output;
                 output << vec;
-                return PyDefaultString(output.str());
+                return output.str();
             }
         );
 

--- a/source/PyMaterialX/PyValue.cpp
+++ b/source/PyMaterialX/PyValue.cpp
@@ -15,10 +15,10 @@
 #endif
 #endif
 
-#define BIND_TYPE_INSTANCE(NAME, T, PYTYPE)                                                                                 \
+#define BIND_TYPE_INSTANCE(NAME, T)                                                                                         \
 py::class_<mx::TypedValue<T>, std::shared_ptr< mx::TypedValue<T> >, mx::Value>(mod, "TypedValue_" #NAME, py::metaclass())   \
-    .def("getData", [](const mx::TypedValue<T>& value) { return PYTYPE(value.getData()); })                                 \
-    .def("getValueString", [](const mx::TypedValue<T>& value) { return PyDefaultString(value.getValueString()); })          \
+    .def("getData", &mx::TypedValue<T>::getData)                                                                            \
+    .def("getValueString", &mx::TypedValue<T>::getValueString)                                                              \
     .def_static("createValue", &mx::Value::createValue<T>)                                                                  \
     .def_readonly_static("TYPE", &mx::TypedValue<T>::TYPE)                                                                  \
     .def_readonly_static("ZERO", &mx::TypedValue<T>::ZERO);
@@ -33,16 +33,16 @@ void bindPyValue(py::module& mod)
         .def("getTypeString", &mx::Value::getTypeString)
         .def_static("createValueFromStrings", &mx::Value::createValueFromStrings);
 
-    BIND_TYPE_INSTANCE(integer, int, py::int_)
-    BIND_TYPE_INSTANCE(boolean, bool, bool)
-    BIND_TYPE_INSTANCE(float, float, float)
-    BIND_TYPE_INSTANCE(color2, mx::Color2, mx::Color2)
-    BIND_TYPE_INSTANCE(color3, mx::Color3, mx::Color3)
-    BIND_TYPE_INSTANCE(color4, mx::Color4, mx::Color4)
-    BIND_TYPE_INSTANCE(vector2, mx::Vector2, mx::Vector2)
-    BIND_TYPE_INSTANCE(vector3, mx::Vector3, mx::Vector3)
-    BIND_TYPE_INSTANCE(vector4, mx::Vector4, mx::Vector4)
-    BIND_TYPE_INSTANCE(matrix33, mx::Matrix3x3, mx::Matrix3x3)
-    BIND_TYPE_INSTANCE(matrix44, mx::Matrix4x4, mx::Matrix4x4)
-    BIND_TYPE_INSTANCE(string, std::string, PyDefaultString)
+    BIND_TYPE_INSTANCE(integer, int)
+    BIND_TYPE_INSTANCE(boolean, bool)
+    BIND_TYPE_INSTANCE(float, float)
+    BIND_TYPE_INSTANCE(color2, mx::Color2)
+    BIND_TYPE_INSTANCE(color3, mx::Color3)
+    BIND_TYPE_INSTANCE(color4, mx::Color4)
+    BIND_TYPE_INSTANCE(vector2, mx::Vector2)
+    BIND_TYPE_INSTANCE(vector3, mx::Vector3)
+    BIND_TYPE_INSTANCE(vector4, mx::Vector4)
+    BIND_TYPE_INSTANCE(matrix33, mx::Matrix3x3)
+    BIND_TYPE_INSTANCE(matrix44, mx::Matrix4x4)
+    BIND_TYPE_INSTANCE(string, std::string)
 }


### PR DESCRIPTION
This changelist aligns MaterialX Python with the default behavior of PyBind11, where all string values are returned as Unicode strings (i.e. as 'unicode' objects in Python 2 and 'str' objects in Python 3).