### PR TITLE
Document management | Add in duplicate Element skip on XML reads

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -326,6 +326,28 @@ class TestMaterialX(unittest.TestCase):
                     self.assertTrue(elem.getNodeDef())
                     self.assertTrue(elem.getImplementation())
 
+        # Read the same documents more than once.
+        # Check that document stays valid when duplicates are skipped.
+        doc3 = mx.createDocument()
+        readOptions = mx.XmlReadOptions()
+        # Test the default state
+        self.assertTrue(readOptions.getReadXincludes() == True)
+        self.assertTrue(readOptions.getSkipDuplicates() == False)
+
+        for filename in _libraryFilenames:
+            readOptions.setSkipDuplicates(False)
+            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions)
+            self.assertTrue(doc3.validate()[0])
+            readOptions.setSkipDuplicates(True)
+            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions);
+            self.assertTrue(doc3.validate()[0])
+        
+        for filename in _exampleFilenames:
+            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions);
+            self.assertTrue(doc3.validate()[0])
+            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions);
+            self.assertTrue(doc3.validate()[0])
+
 
 #--------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -168,8 +168,7 @@ void processXIncludes(xml_node& xmlNode, const string& searchPath, bool readXInc
 void documentFromXml(DocumentPtr doc,
                      const xml_document& xmlDoc,
                      const string& searchPath = EMPTY_STRING,
-                     bool readXIncludes = false,
-                     bool skipDuplicates = false)
+                     const XmlReadOptions* readOptions = nullptr)
 {
     ScopedUpdate update(doc);
     doc->onRead();
@@ -177,8 +176,10 @@ void documentFromXml(DocumentPtr doc,
     xml_node xmlRoot = xmlDoc.child(Document::CATEGORY.c_str());
     if (xmlRoot)
     {
-        processXIncludes(xmlRoot, searchPath, readXIncludes);
-        elementFromXml(xmlRoot, doc, skipDuplicates);
+        // Note: We use the defaults as specified in XmlReadOptions if no options
+        // are passed in.
+        processXIncludes(xmlRoot, searchPath, (readOptions ? readOptions->_readXincludes : true));
+        elementFromXml(xmlRoot, doc, (readOptions ? readOptions->_skipDuplicates : false));
     }
 
     doc->upgradeVersion();
@@ -190,7 +191,7 @@ void documentFromXml(DocumentPtr doc,
 // Reading
 //
 
-void readFromXmlBuffer(DocumentPtr doc, const char* buffer, bool skipDuplicates)
+void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions* readingOptions)
 {
     xml_document xmlDoc;
     xml_parse_result result = xmlDoc.load_string(buffer);
@@ -199,10 +200,10 @@ void readFromXmlBuffer(DocumentPtr doc, const char* buffer, bool skipDuplicates)
         throw ExceptionParseError("Parse error in readFromXmlBuffer");
     }
 
-    documentFromXml(doc, xmlDoc, EMPTY_STRING, false, skipDuplicates);
+    documentFromXml(doc, xmlDoc, EMPTY_STRING, readingOptions);
 }
 
-void readFromXmlStream(DocumentPtr doc, std::istream& stream, bool skipDuplicates)
+void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptions* readingOptions)
 {
     xml_document xmlDoc;
     xml_parse_result result = xmlDoc.load(stream);
@@ -211,22 +212,22 @@ void readFromXmlStream(DocumentPtr doc, std::istream& stream, bool skipDuplicate
         throw ExceptionParseError("Parse error in readFromXmlStream");
     }
 
-    documentFromXml(doc, xmlDoc, EMPTY_STRING, false, skipDuplicates);
+    documentFromXml(doc, xmlDoc, EMPTY_STRING, readingOptions);
 }
 
-void readFromXmlFile(DocumentPtr doc, const string& filename, const string& searchPath, bool readXIncludes, bool skipDuplicates)
+void readFromXmlFile(DocumentPtr doc, const string& filename, const string& searchPath, const XmlReadOptions* readingOptions)
 {
     xml_document xmlDoc;
     xmlDocumentFromFile(xmlDoc, filename, searchPath);
 
-    documentFromXml(doc, xmlDoc, searchPath, readXIncludes, skipDuplicates);
+    documentFromXml(doc, xmlDoc, searchPath, readingOptions);
     doc->setSourceUri(filename);
 }
 
-void readFromXmlString(DocumentPtr doc, const string& str, bool skipDuplicates)
+void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions* readingOptions)
 {
     std::istringstream stream(str);
-    readFromXmlStream(doc, stream, skipDuplicates);
+    readFromXmlStream(doc, stream, readingOptions);
 }
 
 //

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -26,7 +26,7 @@ namespace {
 const string SOURCE_URI_ATTRIBUTE = "__sourceUri";
 const string XINCLUDE_TAG = "xi:include";
 
-void elementFromXml(const xml_node& xmlNode, ElementPtr elem)
+void elementFromXml(const xml_node& xmlNode, ElementPtr elem, bool skipDuplicates=false)
 {
     // Store attributes in element.
     for (const xml_attribute& xmlAttr : xmlNode.attributes())
@@ -55,8 +55,13 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem)
             }
         }
 
+        // Skip duplicate named children
+        if (skipDuplicates && elem->getChild(name))
+        {
+            continue;
+        }
         ElementPtr child = elem->addChildOfCategory(category, name);
-        elementFromXml(xmlChild, child);
+        elementFromXml(xmlChild, child, skipDuplicates);
     }
 }
 
@@ -163,7 +168,8 @@ void processXIncludes(xml_node& xmlNode, const string& searchPath, bool readXInc
 void documentFromXml(DocumentPtr doc,
                      const xml_document& xmlDoc,
                      const string& searchPath = EMPTY_STRING,
-                     bool readXIncludes = false)
+                     bool readXIncludes = false,
+                     bool skipDuplicates = false)
 {
     ScopedUpdate update(doc);
     doc->onRead();
@@ -172,7 +178,7 @@ void documentFromXml(DocumentPtr doc,
     if (xmlRoot)
     {
         processXIncludes(xmlRoot, searchPath, readXIncludes);
-        elementFromXml(xmlRoot, doc);
+        elementFromXml(xmlRoot, doc, skipDuplicates);
     }
 
     doc->upgradeVersion();
@@ -184,7 +190,7 @@ void documentFromXml(DocumentPtr doc,
 // Reading
 //
 
-void readFromXmlBuffer(DocumentPtr doc, const char* buffer)
+void readFromXmlBuffer(DocumentPtr doc, const char* buffer, bool skipDuplicates)
 {
     xml_document xmlDoc;
     xml_parse_result result = xmlDoc.load_string(buffer);
@@ -193,10 +199,10 @@ void readFromXmlBuffer(DocumentPtr doc, const char* buffer)
         throw ExceptionParseError("Parse error in readFromXmlBuffer");
     }
 
-    documentFromXml(doc, xmlDoc);
+    documentFromXml(doc, xmlDoc, EMPTY_STRING, false, skipDuplicates);
 }
 
-void readFromXmlStream(DocumentPtr doc, std::istream& stream)
+void readFromXmlStream(DocumentPtr doc, std::istream& stream, bool skipDuplicates)
 {
     xml_document xmlDoc;
     xml_parse_result result = xmlDoc.load(stream);
@@ -205,22 +211,22 @@ void readFromXmlStream(DocumentPtr doc, std::istream& stream)
         throw ExceptionParseError("Parse error in readFromXmlStream");
     }
 
-    documentFromXml(doc, xmlDoc);
+    documentFromXml(doc, xmlDoc, EMPTY_STRING, false, skipDuplicates);
 }
 
-void readFromXmlFile(DocumentPtr doc, const string& filename, const string& searchPath, bool readXIncludes)
+void readFromXmlFile(DocumentPtr doc, const string& filename, const string& searchPath, bool readXIncludes, bool skipDuplicates)
 {
     xml_document xmlDoc;
     xmlDocumentFromFile(xmlDoc, filename, searchPath);
 
-    documentFromXml(doc, xmlDoc, searchPath, readXIncludes);
+    documentFromXml(doc, xmlDoc, searchPath, readXIncludes, skipDuplicates);
     doc->setSourceUri(filename);
 }
 
-void readFromXmlString(DocumentPtr doc, const string& str)
+void readFromXmlString(DocumentPtr doc, const string& str, bool skipDuplicates)
 {
     std::istringstream stream(str);
-    readFromXmlStream(doc, stream);
+    readFromXmlStream(doc, stream, skipDuplicates);
 }
 
 //

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -29,6 +29,32 @@ struct XmlReadOptions
         skipDuplicates(false) {}
 
     virtual ~XmlReadOptions() {}
+    
+    /// Set option for whether XInclude references will be read from disk and included in the document.
+    /// @param value Option value
+    void setReadXincludes(bool value)
+    {
+        readXincludes = value;
+    }
+
+    /// Get option for whether XInclude references will be read from disk and included in the document.
+    bool getReadXincludes() const
+    {
+        return readXincludes;
+    }
+
+    /// Set option for whether to skip reading in Elements with duplicate names.
+    /// @param value Option value
+    void setSkipDuplicates(bool value)
+    {
+        skipDuplicates = value;
+    }
+
+    /// Get option for whether to skip reading in Elements with duplicate names.
+    bool getSkipDuplicates() const
+    {
+        return skipDuplicates;
+    }
 
     /// If true, XInclude references will be read from disk and included in the document. Defaults to true.
     bool readXincludes;
@@ -40,7 +66,7 @@ struct XmlReadOptions
 /// @param doc The document into which data is read.
 /// @param buffer The character buffer from which data is read.
 /// @param readOptions Options to use during reading. Default is null which indicates to use the 
-/// default values as specified in the XmlReadOptions structure.
+///    default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
 void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions* readOptions = nullptr);
 
@@ -48,7 +74,7 @@ void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions
 /// @param doc The document into which data is read.
 /// @param stream The input stream from which data is read.
 /// @param readOptions Options to use during reading. Default is null which indicates to use the 
-/// default values as specified in the XmlReadOptions structure.
+///    default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
 void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptions* readOptions = nullptr);
 
@@ -59,7 +85,7 @@ void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptio
 ///    be applied in order when searching for the given file and its includes.
 ///    Defaults to the empty string.
 /// @param readOptions Options to use during reading. Default is null which indicates to use the 
-/// default values as specified in the XmlReadOptions structure.
+///    default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
 /// @throws ExceptionFileMissing if the file cannot be opened.
 void readFromXmlFile(DocumentPtr doc,
@@ -71,7 +97,7 @@ void readFromXmlFile(DocumentPtr doc,
 /// @param doc The document into which data is read.
 /// @param str The string from which data is read.
 /// @param readOptions Options to use during reading. Default is null which indicates to use the 
-/// default values as specified in the XmlReadOptions structure.
+///    default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
 void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions* readOptions = nullptr);
 

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -25,32 +25,32 @@ namespace MaterialX
 struct XmlReadOptions
 {
     XmlReadOptions() :
-        _readXincludes(true),
-        _skipDuplicates(false) {}
+        readXincludes(true),
+        skipDuplicates(false) {}
 
     virtual ~XmlReadOptions() {}
 
     /// If true, XInclude references will be read from disk and included in the document. Defaults to true.
-    bool _readXincludes;
+    bool readXincludes;
     /// If true, Will skip reading in Elements with duplicate names. Defaults to false.
-    bool _skipDuplicates;
+    bool skipDuplicates;
 };
 
 /// Read a document as XML from the given character buffer.
 /// @param doc The document into which data is read.
 /// @param buffer The character buffer from which data is read.
-/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// @param readOptions Options to use during reading. Default is null which indicates to use the 
 /// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions* readingOptions = nullptr);
+void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions* readOptions = nullptr);
 
 /// Read a document as XML from the given input stream.
 /// @param doc The document into which data is read.
 /// @param stream The input stream from which data is read.
-/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// @param readOptions Options to use during reading. Default is null which indicates to use the 
 /// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptions* readingOptions = nullptr);
+void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptions* readOptions = nullptr);
 
 /// Read a document as XML from the given filename.
 /// @param doc The document into which data is read.
@@ -58,22 +58,22 @@ void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptio
 /// @param searchPath A semicolon-separated sequence of file paths, which will
 ///    be applied in order when searching for the given file and its includes.
 ///    Defaults to the empty string.
-/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// @param readOptions Options to use during reading. Default is null which indicates to use the 
 /// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
 /// @throws ExceptionFileMissing if the file cannot be opened.
 void readFromXmlFile(DocumentPtr doc,
                      const string& filename,
                      const string& searchPath = EMPTY_STRING,
-                     const XmlReadOptions* readingOptions = nullptr);
+                     const XmlReadOptions* readOptions = nullptr);
 
 /// Read a document as XML from the given string.
 /// @param doc The document into which data is read.
 /// @param str The string from which data is read.
-/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// @param readOptions Options to use during reading. Default is null which indicates to use the 
 /// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions* readingOptions = nullptr);
+void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions* readOptions = nullptr);
 
 /// @}
 /// @name Writing

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -22,14 +22,16 @@ namespace MaterialX
 /// Read a document as XML from the given character buffer.
 /// @param doc The document into which data is read.
 /// @param buffer The character buffer from which data is read.
+/// @param skipDuplicates Will skip reading in Elements with duplicate names
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlBuffer(DocumentPtr doc, const char* buffer);
+void readFromXmlBuffer(DocumentPtr doc, const char* buffer, bool skipDuplicates=false);
 
 /// Read a document as XML from the given input stream.
 /// @param doc The document into which data is read.
 /// @param stream The input stream from which data is read.
+/// @param skipDuplicates Will skip reading in Elements with duplicate names
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlStream(DocumentPtr doc, std::istream& stream);
+void readFromXmlStream(DocumentPtr doc, std::istream& stream, bool skipDuplicates = false);
 
 /// Read a document as XML from the given filename.
 /// @param doc The document into which data is read.
@@ -39,18 +41,21 @@ void readFromXmlStream(DocumentPtr doc, std::istream& stream);
 ///    Defaults to the empty string.
 /// @param readXIncludes If true, XInclude references will be read from disk
 ///    and included in the document.  Defaults to true.
+/// @param skipDuplicates Will skip reading in Elements with duplicate names
 /// @throws ExceptionParseError if the document cannot be parsed.
 /// @throws ExceptionFileMissing if the file cannot be opened.
 void readFromXmlFile(DocumentPtr doc,
                      const string& filename,
                      const string& searchPath = EMPTY_STRING,
-                     bool readXIncludes = true);
+                     bool readXIncludes = true,
+                     bool skipDuplicates = false);
 
 /// Read a document as XML from the given string.
 /// @param doc The document into which data is read.
 /// @param str The string from which data is read.
+/// @param skipDuplicates Will skip reading in Elements with duplicate names
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlString(DocumentPtr doc, const string& str);
+void readFromXmlString(DocumentPtr doc, const string& str, bool skipDuplicates = false);
 
 /// @}
 /// @name Writing

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -19,19 +19,38 @@ namespace MaterialX
 /// @name Reading
 /// @{
 
+/// @struct XmlReadOptions
+/// Structure to hold options to use during reading. 
+///
+struct XmlReadOptions
+{
+    XmlReadOptions() :
+        _readXincludes(true),
+        _skipDuplicates(false) {}
+
+    virtual ~XmlReadOptions() {}
+
+    /// If true, XInclude references will be read from disk and included in the document. Defaults to true.
+    bool _readXincludes;
+    /// If true, Will skip reading in Elements with duplicate names. Defaults to false.
+    bool _skipDuplicates;
+};
+
 /// Read a document as XML from the given character buffer.
 /// @param doc The document into which data is read.
 /// @param buffer The character buffer from which data is read.
-/// @param skipDuplicates Will skip reading in Elements with duplicate names
+/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlBuffer(DocumentPtr doc, const char* buffer, bool skipDuplicates=false);
+void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions* readingOptions = nullptr);
 
 /// Read a document as XML from the given input stream.
 /// @param doc The document into which data is read.
 /// @param stream The input stream from which data is read.
-/// @param skipDuplicates Will skip reading in Elements with duplicate names
+/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlStream(DocumentPtr doc, std::istream& stream, bool skipDuplicates = false);
+void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptions* readingOptions = nullptr);
 
 /// Read a document as XML from the given filename.
 /// @param doc The document into which data is read.
@@ -39,23 +58,22 @@ void readFromXmlStream(DocumentPtr doc, std::istream& stream, bool skipDuplicate
 /// @param searchPath A semicolon-separated sequence of file paths, which will
 ///    be applied in order when searching for the given file and its includes.
 ///    Defaults to the empty string.
-/// @param readXIncludes If true, XInclude references will be read from disk
-///    and included in the document.  Defaults to true.
-/// @param skipDuplicates Will skip reading in Elements with duplicate names
+/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
 /// @throws ExceptionFileMissing if the file cannot be opened.
 void readFromXmlFile(DocumentPtr doc,
                      const string& filename,
                      const string& searchPath = EMPTY_STRING,
-                     bool readXIncludes = true,
-                     bool skipDuplicates = false);
+                     const XmlReadOptions* readingOptions = nullptr);
 
 /// Read a document as XML from the given string.
 /// @param doc The document into which data is read.
 /// @param str The string from which data is read.
-/// @param skipDuplicates Will skip reading in Elements with duplicate names
+/// @param readingOptions Options to use during reading. Default is null which indicates to use the 
+/// default values as specified in the XmlReadOptions structure.
 /// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlString(DocumentPtr doc, const string& str, bool skipDuplicates = false);
+void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions* readingOptions = nullptr);
 
 /// @}
 /// @name Writing

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -137,12 +137,15 @@ TEST_CASE("Load content", "[xmlio]")
 
         // Read document without XIncludes.
         doc2 = mx::createDocument();
-        mx::readFromXmlFile(doc2, filename, searchPath, false);
+
+        mx::XmlReadOptions readingOptions;
+        readingOptions._readXincludes = false;
+        mx::readFromXmlFile(doc2, filename, searchPath, &readingOptions);
         if (*doc2 != *doc)
         {
             writtenDoc = mx::createDocument();
             xmlString = mx::writeToXmlString(doc);
-            mx::readFromXmlString(writtenDoc, xmlString);
+            mx::readFromXmlString(writtenDoc, xmlString, &readingOptions);
             REQUIRE(*doc2 == *writtenDoc);
         }
     }

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -156,17 +156,19 @@ TEST_CASE("Load content", "[xmlio]")
     // create a child with a duplicate name in the first place
     // thus no error exception is thrown.
     mx::DocumentPtr doc3 = mx::createDocument();
-    const bool readXincludes = true;
-    const bool skipDuplicates = true;
+    mx::XmlReadOptions readingOptions;
+    readingOptions._readXincludes = true;
     bool exceptionThrown = false;
     try
     {
-        mx::readFromXmlFile(doc3, libFilename, searchPath);
-        mx::readFromXmlFile(doc3, libFilename, searchPath, readXincludes, skipDuplicates);
+        readingOptions._skipDuplicates = false;
+        mx::readFromXmlFile(doc3, libFilename, searchPath, &readingOptions);
+        readingOptions._skipDuplicates = true;
+        mx::readFromXmlFile(doc3, libFilename, searchPath, &readingOptions);
         for (std::string filename : exampleFilenames)
         {
-            mx::readFromXmlFile(doc3, filename, searchPath, readXincludes, skipDuplicates);
-            mx::readFromXmlFile(doc3, filename, searchPath, readXincludes, skipDuplicates);
+            mx::readFromXmlFile(doc3, filename, searchPath, &readingOptions);
+            mx::readFromXmlFile(doc3, filename, searchPath, &readingOptions);
         }
     }
     catch (MaterialX::Exception e)

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -146,4 +146,32 @@ TEST_CASE("Load content", "[xmlio]")
             REQUIRE(*doc2 == *writtenDoc);
         }
     }
+
+    // Read the same documents more than once.
+    // When duplcate names are found an error exception is thrown.
+    // Setting to skip duplicates names first avoid trying to
+    // create a child with a duplicate name in the first place
+    // thus no error exception is thrown.
+    mx::DocumentPtr doc3 = mx::createDocument();
+    const bool readXincludes = true;
+    const bool skipDuplicates = true;
+    bool exceptionThrown = false;
+    try
+    {
+        mx::readFromXmlFile(doc3, libFilename, searchPath);
+        mx::readFromXmlFile(doc3, libFilename, searchPath, readXincludes, skipDuplicates);
+        for (std::string filename : exampleFilenames)
+        {
+            mx::readFromXmlFile(doc3, filename, searchPath, readXincludes, skipDuplicates);
+            mx::readFromXmlFile(doc3, filename, searchPath, readXincludes, skipDuplicates);
+        }
+    }
+    catch (MaterialX::Exception e)
+    {
+        exceptionThrown = true;
+    }
+    catch (...)
+    {
+    }
+    REQUIRE(exceptionThrown == false);
 }

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -161,10 +161,13 @@ TEST_CASE("Load content", "[xmlio]")
     bool exceptionThrown = false;
     try
     {
-        readingOptions._skipDuplicates = false;
-        mx::readFromXmlFile(doc3, libFilename, searchPath, &readingOptions);
-        readingOptions._skipDuplicates = true;
-        mx::readFromXmlFile(doc3, libFilename, searchPath, &readingOptions);
+        for (std::string libFilename : libraryFilenames)
+        {
+            readingOptions._skipDuplicates = false;
+            mx::readFromXmlFile(doc3, libFilename, searchPath, &readingOptions);
+            readingOptions._skipDuplicates = true;
+            mx::readFromXmlFile(doc3, libFilename, searchPath, &readingOptions);
+        }
         for (std::string filename : exampleFilenames)
         {
             mx::readFromXmlFile(doc3, filename, searchPath, &readingOptions);

--- a/source/PyMaterialX/PyDefinition.cpp
+++ b/source/PyMaterialX/PyDefinition.cpp
@@ -9,8 +9,6 @@
 
 #include <MaterialXCore/Material.h>
 
-#include <MaterialXFormat/XmlIo.h>
-
 #include <PyBind11/stl.h>
 
 namespace py = pybind11;
@@ -51,7 +49,4 @@ void bindPyDefinition(py::module& mod)
         .def("hasLanguage", &mx::Implementation::hasLanguage)
         .def("getLanguage", &mx::Implementation::getLanguage)
         .def_readonly_static("CATEGORY", &mx::Implementation::CATEGORY);
-
-    py::class_<mx::XmlReadOptions>(mod, "XmlReadOptions")
-        .def(py::init());
 }

--- a/source/PyMaterialX/PyDefinition.cpp
+++ b/source/PyMaterialX/PyDefinition.cpp
@@ -9,6 +9,8 @@
 
 #include <MaterialXCore/Material.h>
 
+#include <MaterialXFormat/XmlIo.h>
+
 #include <PyBind11/stl.h>
 
 namespace py = pybind11;
@@ -49,4 +51,7 @@ void bindPyDefinition(py::module& mod)
         .def("hasLanguage", &mx::Implementation::hasLanguage)
         .def("getLanguage", &mx::Implementation::getLanguage)
         .def_readonly_static("CATEGORY", &mx::Implementation::CATEGORY);
+
+    py::class_<mx::XmlReadOptions>(mod, "XmlReadOptions")
+        .def(py::init());
 }

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -16,7 +16,8 @@ namespace mx = MaterialX;
 void bindPyXmlIo(py::module& mod)
 {
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
-        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readXIncludes") = true);
+        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readXIncludes") = true,
+        py::arg("skipDuplicates") = false);
     mod.def("readFromXmlString", &mx::readFromXmlString);
     mod.def("writeToXmlFile", mx::writeToXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -15,6 +15,13 @@ namespace mx = MaterialX;
 
 void bindPyXmlIo(py::module& mod)
 {
+    py::class_<mx::XmlReadOptions>(mod, "XmlReadOptions")
+        .def(py::init())
+        .def("setReadXincludes", &mx::XmlReadOptions::setReadXincludes)
+        .def("getReadXincludes", &mx::XmlReadOptions::getReadXincludes)
+        .def("setSkipDuplicates", &mx::XmlReadOptions::setSkipDuplicates)
+        .def("getSkipDuplicates", &mx::XmlReadOptions::getSkipDuplicates);
+
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readOptions") = (const mx::XmlReadOptions*)nullptr);
     mod.def("readFromXmlString", &mx::readFromXmlString,

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -17,7 +17,8 @@ void bindPyXmlIo(py::module& mod)
 {
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readOptions") = (const mx::XmlReadOptions*)nullptr);
-    mod.def("readFromXmlString", &mx::readFromXmlString);
+    mod.def("readFromXmlString", &mx::readFromXmlString,
+        py::arg("doc"), py::arg("str"), py::arg("readOptions") = (const mx::XmlReadOptions*)nullptr);
     mod.def("writeToXmlFile", mx::writeToXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());
     mod.def("writeToXmlString", mx::writeToXmlString,

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -16,8 +16,7 @@ namespace mx = MaterialX;
 void bindPyXmlIo(py::module& mod)
 {
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
-        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readXIncludes") = true,
-        py::arg("skipDuplicates") = false);
+        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readingOptions") = nullptr);
     mod.def("readFromXmlString", &mx::readFromXmlString);
     mod.def("writeToXmlFile", mx::writeToXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -16,7 +16,7 @@ namespace mx = MaterialX;
 void bindPyXmlIo(py::module& mod)
 {
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
-        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readingOptions") = static_cast<mx::XmlReadOptions*>(nullptr));
+        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readOptions") = (const mx::XmlReadOptions*)nullptr);
     mod.def("readFromXmlString", &mx::readFromXmlString);
     mod.def("writeToXmlFile", mx::writeToXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -16,7 +16,7 @@ namespace mx = MaterialX;
 void bindPyXmlIo(py::module& mod)
 {
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
-        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readingOptions") = nullptr);
+        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readingOptions") = static_cast<mx::XmlReadOptions*>(nullptr));
     mod.def("readFromXmlString", &mx::readFromXmlString);
     mod.def("writeToXmlFile", mx::writeToXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());


### PR DESCRIPTION
- Replaces the old boolean argument of reading XIncludes with a new structure.
- The options includes the Xincludes option + a new option to skip duplicates on read.
- The option structure is now available on all "read" methods consistently now.
