### PR TITLE
Added missing cms="ocio" to examples

### DIFF
--- a/documents/Examples/CustomNode.mtlx
+++ b/documents/Examples/CustomNode.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709">
 
   <!-- Parameter interface for a simple custom node -->
   <!-- The "bg" input is required, while the "fg" input and "fgamt" parameter are optional. -->

--- a/documents/Examples/GeomInfos.mtlx
+++ b/documents/Examples/GeomInfos.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709">
   <collection name="col1">
     <collectionadd name="col1_1" geom="/root/world/geo/g[123]"/>
   </collection>

--- a/documents/Examples/Looks.mtlx
+++ b/documents/Examples/Looks.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="acescg">
+<materialx version="1.35" cms="ocio" colorspace="acescg">
   <xi:include href="SimpleSrf.mtlx"/>
   <material name="Mplastic1">
     <shaderref name="sr_mp1" node="simple_srf">

--- a/documents/Examples/MaterialGraphs.mtlx
+++ b/documents/Examples/MaterialGraphs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709" require="matnodegraph,override">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709" require="matnodegraph,override">
   <xi:include href="NodeGraphs.mtlx"/>
   <xi:include href="GeomInfos.mtlx"/>
 

--- a/documents/Examples/NodeGraphs.mtlx
+++ b/documents/Examples/NodeGraphs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709">
   <nodegraph name="nodegraph1">
     <image name="img1" type="color3">
       <parameter name="file" type="filename" value="layer1.tif"/>

--- a/documents/Examples/PaintMaterials.mtlx
+++ b/documents/Examples/PaintMaterials.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709">
   <xi:include href="SimpleSrf.mtlx"/>
 
   <material name="paint_flat">

--- a/documents/Examples/PostShaderComposite.mtlx
+++ b/documents/Examples/PostShaderComposite.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709" require="shadernode">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709" require="shadernode">
   <!-- Assume an external file defines nodegraph "shaderparams", with outputs -->
   <!-- "o_diffcolor1", "o_diffcolor2", "o_speccolor1" and "o_speccolor2". -->
   <!-- Define external "alSurface" shader -->

--- a/documents/Examples/PreShaderComposite.mtlx
+++ b/documents/Examples/PreShaderComposite.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709" require="matnodegraph">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709" require="matnodegraph">
   <nodegraph name="shaderparams">
     <!-- Material constants for "steel" -->
     <constant name="steel_diffc" type="color3">

--- a/documents/Examples/SimpleSrf.mtlx
+++ b/documents/Examples/SimpleSrf.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709">
   <nodedef name="shader1" type="surfaceshader" node="simple_srf">
     <input name="diffColor" type="color3" value="0.18, 0.18, 0.18"/>
     <input name="specColor" type="color3" value="0.05, 0.05, 0.05"/>

--- a/documents/Examples/SubGraphs.mtlx
+++ b/documents/Examples/SubGraphs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" colorspace="lin_rec709" require="matnodegraph">
+<materialx version="1.35" cms="ocio" colorspace="lin_rec709" require="matnodegraph">
   <xi:include href="mx_stdlib_defs.mtlx"/>
 
   <!-- Define a node that implements a checker board pattern -->


### PR DESCRIPTION
Added missing cms="ocio" to example .mtlx files