### PR TITLE
Additional improvements to XmlReadOptions

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -262,7 +262,7 @@ class TestMaterialX(unittest.TestCase):
         self.assertTrue(doc.validate()[0])
 
     def test_ReadXml(self):
-        # Load the standard library.
+        # Read the standard library.
         libs = []
         for filename in _libraryFilenames:
             lib = mx.createDocument()
@@ -270,8 +270,8 @@ class TestMaterialX(unittest.TestCase):
             self.assertTrue(lib.validate()[0])
             libs.append(lib)
 
+        # Read and validate each example document.
         for filename in _exampleFilenames:
-            # Read the example document.
             doc = mx.createDocument()
             mx.readFromXmlFile(doc, filename, _searchPath)
             self.assertTrue(doc.validate()[0])
@@ -326,27 +326,14 @@ class TestMaterialX(unittest.TestCase):
                     self.assertTrue(elem.getNodeDef())
                     self.assertTrue(elem.getImplementation())
 
-        # Read the same documents more than once.
-        # Check that document stays valid when duplicates are skipped.
-        doc3 = mx.createDocument()
+        # Read the same document twice with duplicate elements skipped.
+        doc = mx.createDocument()
         readOptions = mx.XmlReadOptions()
-        # Test the default state
-        self.assertTrue(readOptions.getReadXincludes() == True)
-        self.assertTrue(readOptions.getSkipDuplicates() == False)
-
-        for filename in _libraryFilenames:
-            readOptions.setSkipDuplicates(False)
-            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions)
-            self.assertTrue(doc3.validate()[0])
-            readOptions.setSkipDuplicates(True)
-            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions);
-            self.assertTrue(doc3.validate()[0])
-        
-        for filename in _exampleFilenames:
-            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions);
-            self.assertTrue(doc3.validate()[0])
-            mx.readFromXmlFile(doc3, filename, _searchPath, readOptions);
-            self.assertTrue(doc3.validate()[0])
+        readOptions.skipDuplicateElements = True
+        filename = 'PaintMaterials.mtlx'
+        mx.readFromXmlFile(doc, filename, _searchPath, readOptions)
+        mx.readFromXmlFile(doc, filename, _searchPath, readOptions)
+        self.assertTrue(doc.validate()[0])
 
 
 #--------------------------------------------------------------------------------

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -55,11 +55,12 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
             }
         }
 
-        // Skip duplicate named children if specified
-        if ((readOptions ? readOptions->skipDuplicates : false) && elem->getChild(name))
+        // If requested, skip elements with duplicate names.
+        if (readOptions && readOptions->skipDuplicateElements && elem->getChild(name))
         {
             continue;
         }
+
         ElementPtr child = elem->addChildOfCategory(category, name);
         elementFromXml(xmlChild, child, readOptions);
     }
@@ -133,7 +134,7 @@ void processXIncludes(xml_node& xmlNode, const string& searchPath, const XmlRead
 {
     xml_node xmlChild = xmlNode.first_child();
 
-    bool readXIncludes = (readOptions ? readOptions->readXincludes : true);
+    bool readXIncludes = (readOptions ? readOptions->readXIncludes : true);
     while (xmlChild)
     {
         if (xmlChild.name() == XINCLUDE_TAG)

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -16,136 +16,26 @@
 namespace MaterialX
 {
 
-/// @name Reading
-/// @{
-
-/// @struct XmlReadOptions
-/// Structure to hold options to use during reading. 
-///
-struct XmlReadOptions
+/// @class XmlReadOptions
+/// A set of options for controlling the behavior of XML read functions.
+class XmlReadOptions
 {
+  public:
     XmlReadOptions() :
-        readXincludes(true),
-        skipDuplicates(false) {}
-
-    virtual ~XmlReadOptions() {}
+        readXIncludes(true),
+        skipDuplicateElements(false)
+    {
+    }
+    ~XmlReadOptions() { }
     
-    /// Set option for whether XInclude references will be read from disk and included in the document.
-    /// @param value Option value
-    void setReadXincludes(bool value)
-    {
-        readXincludes = value;
-    }
+    /// If true, XInclude references will be read from disk and included in the
+    /// document.  Defaults to true.
+    bool readXIncludes;
 
-    /// Get option for whether XInclude references will be read from disk and included in the document.
-    bool getReadXincludes() const
-    {
-        return readXincludes;
-    }
-
-    /// Set option for whether to skip reading in Elements with duplicate names.
-    /// @param value Option value
-    void setSkipDuplicates(bool value)
-    {
-        skipDuplicates = value;
-    }
-
-    /// Get option for whether to skip reading in Elements with duplicate names.
-    bool getSkipDuplicates() const
-    {
-        return skipDuplicates;
-    }
-
-    /// If true, XInclude references will be read from disk and included in the document. Defaults to true.
-    bool readXincludes;
-    /// If true, Will skip reading in Elements with duplicate names. Defaults to false.
-    bool skipDuplicates;
+    /// If true, elements at the same scope with duplicate names will be skipped;
+    /// otherwise, they will trigger an exception.  Defaults to false.
+    bool skipDuplicateElements;
 };
-
-/// Read a document as XML from the given character buffer.
-/// @param doc The document into which data is read.
-/// @param buffer The character buffer from which data is read.
-/// @param readOptions Options to use during reading. Default is null which indicates to use the 
-///    default values as specified in the XmlReadOptions structure.
-/// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions* readOptions = nullptr);
-
-/// Read a document as XML from the given input stream.
-/// @param doc The document into which data is read.
-/// @param stream The input stream from which data is read.
-/// @param readOptions Options to use during reading. Default is null which indicates to use the 
-///    default values as specified in the XmlReadOptions structure.
-/// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptions* readOptions = nullptr);
-
-/// Read a document as XML from the given filename.
-/// @param doc The document into which data is read.
-/// @param filename The filename from which data is read.
-/// @param searchPath A semicolon-separated sequence of file paths, which will
-///    be applied in order when searching for the given file and its includes.
-///    Defaults to the empty string.
-/// @param readOptions Options to use during reading. Default is null which indicates to use the 
-///    default values as specified in the XmlReadOptions structure.
-/// @throws ExceptionParseError if the document cannot be parsed.
-/// @throws ExceptionFileMissing if the file cannot be opened.
-void readFromXmlFile(DocumentPtr doc,
-                     const string& filename,
-                     const string& searchPath = EMPTY_STRING,
-                     const XmlReadOptions* readOptions = nullptr);
-
-/// Read a document as XML from the given string.
-/// @param doc The document into which data is read.
-/// @param str The string from which data is read.
-/// @param readOptions Options to use during reading. Default is null which indicates to use the 
-///    default values as specified in the XmlReadOptions structure.
-/// @throws ExceptionParseError if the document cannot be parsed.
-void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions* readOptions = nullptr);
-
-/// @}
-/// @name Writing
-/// @{
-
-/// Write a document as XML to the given output stream.
-/// @param doc The document to be written.
-/// @param stream The output stream to which data is written
-/// @param writeXIncludes If true, elements with source file markings will be written
-///    as XIncludes rather than explicit data.  Defaults to true.
-/// @param predicate If provided, this function will be used to exclude specific elements
-///    (those returning false) from the write operation.
-void writeToXmlStream(DocumentPtr doc, std::ostream& stream, bool writeXIncludes = true,
-                      const ElementPredicate& predicate = ElementPredicate());
-
-/// Write a document as XML to the given filename.
-/// @param doc The document to be written.
-/// @param filename The filename to which data is written
-/// @param writeXIncludes If true, elements with source file markings will be written
-///    as XIncludes rather than explicit data.  Defaults to true.
-/// @param predicate If provided, this function will be used to exclude specific elements
-///    (those returning false) from the write operation.
-void writeToXmlFile(DocumentPtr doc, const string& filename, bool writeXIncludes = true,
-                    const ElementPredicate& predicate = ElementPredicate());
-
-/// Write a document as XML to a new string, returned by value.
-/// @param doc The document to be written.
-/// @param writeXIncludes If true, elements with source file markings will be written
-///    as XIncludes rather than explicit data.  Defaults to true.
-/// @param predicate If provided, this function will be used to exclude specific elements
-///    (those returning false) from the write operation.
-/// @return The output string, returned by value
-string writeToXmlString(DocumentPtr doc, bool writeXIncludes = true,
-                        const ElementPredicate& predicate = ElementPredicate());
-
-/// @}
-/// @name Editing
-/// @{
-
-/// Add an XInclude reference to the top of the current document, creating
-/// a generic element to hold the reference filename.
-/// @param doc The document to be modified.
-/// @param filename The filename of the XInclude reference to be added.
-void prependXInclude(DocumentPtr doc, const string& filename);
-
-/// @}
 
 /// @class @ExceptionParseError
 /// An exception that is thrown when a requested document cannot be parsed.
@@ -186,6 +76,98 @@ class ExceptionFileMissing : public Exception
     {
     }
 };
+
+/// @name Read Functions
+/// @{
+
+/// Read a Document as XML from the given character buffer.
+/// @param doc The Document into which data is read.
+/// @param buffer The character buffer from which data is read.
+/// @param readOptions An optional pointer to an XmlReadOptions object.
+///    If provided, then the given options will affect the behavior of the
+///    read function.  Defaults to a null pointer.
+/// @throws ExceptionParseError if the document cannot be parsed.
+void readFromXmlBuffer(DocumentPtr doc, const char* buffer, const XmlReadOptions* readOptions = nullptr);
+
+/// Read a Document as XML from the given input stream.
+/// @param doc The Document into which data is read.
+/// @param stream The input stream from which data is read.
+/// @param readOptions An optional pointer to an XmlReadOptions object.
+///    If provided, then the given options will affect the behavior of the
+///    read function.  Defaults to a null pointer.
+/// @throws ExceptionParseError if the document cannot be parsed.
+void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptions* readOptions = nullptr);
+
+/// Read a Document as XML from the given filename.
+/// @param doc The Document into which data is read.
+/// @param filename The filename from which data is read.
+/// @param searchPath A semicolon-separated sequence of file paths, which will
+///    be applied in order when searching for the given file and its includes.
+///    Defaults to the empty string.
+/// @param readOptions An optional pointer to an XmlReadOptions object.
+///    If provided, then the given options will affect the behavior of the
+///    read function.  Defaults to a null pointer.
+/// @throws ExceptionParseError if the document cannot be parsed.
+/// @throws ExceptionFileMissing if the file cannot be opened.
+void readFromXmlFile(DocumentPtr doc,
+                     const string& filename,
+                     const string& searchPath = EMPTY_STRING,
+                     const XmlReadOptions* readOptions = nullptr);
+
+/// Read a Document as XML from the given string.
+/// @param doc The Document into which data is read.
+/// @param str The string from which data is read.
+/// @param readOptions An optional pointer to an XmlReadOptions object.
+///    If provided, then the given options will affect the behavior of the
+///    read function.  Defaults to a null pointer.
+/// @throws ExceptionParseError if the document cannot be parsed.
+void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions* readOptions = nullptr);
+
+/// @}
+/// @name Write Functions
+/// @{
+
+/// Write a Document as XML to the given output stream.
+/// @param doc The Document to be written.
+/// @param stream The output stream to which data is written
+/// @param writeXIncludes If true, elements with source file markings will be written
+///    as XIncludes rather than explicit data.  Defaults to true.
+/// @param predicate If provided, this function will be used to exclude specific elements
+///    (those returning false) from the write operation.
+void writeToXmlStream(DocumentPtr doc, std::ostream& stream, bool writeXIncludes = true,
+                      const ElementPredicate& predicate = ElementPredicate());
+
+/// Write a Document as XML to the given filename.
+/// @param doc The Document to be written.
+/// @param filename The filename to which data is written
+/// @param writeXIncludes If true, elements with source file markings will be written
+///    as XIncludes rather than explicit data.  Defaults to true.
+/// @param predicate If provided, this function will be used to exclude specific elements
+///    (those returning false) from the write operation.
+void writeToXmlFile(DocumentPtr doc, const string& filename, bool writeXIncludes = true,
+                    const ElementPredicate& predicate = ElementPredicate());
+
+/// Write a Document as XML to a new string, returned by value.
+/// @param doc The Document to be written.
+/// @param writeXIncludes If true, elements with source file markings will be written
+///    as XIncludes rather than explicit data.  Defaults to true.
+/// @param predicate If provided, this function will be used to exclude specific elements
+///    (those returning false) from the write operation.
+/// @return The output string, returned by value
+string writeToXmlString(DocumentPtr doc, bool writeXIncludes = true,
+                        const ElementPredicate& predicate = ElementPredicate());
+
+/// @}
+/// @name Edit Functions
+/// @{
+
+/// Add an XInclude reference to the top of a Document, creating a generic
+/// element to hold the reference filename.
+/// @param doc The Document to be modified.
+/// @param filename The filename of the XInclude reference to be added.
+void prependXInclude(DocumentPtr doc, const string& filename);
+
+/// @}
 
 } // namespace MaterialX
 

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Load content", "[xmlio]")
     };
     std::string searchPath = "documents/Libraries;documents/Examples";
 
-    // Load the standard library.
+    // Read the standard library.
     std::vector<mx::DocumentPtr> libs;
     for (std::string filename : libraryFilenames)
     {
@@ -37,9 +37,9 @@ TEST_CASE("Load content", "[xmlio]")
         libs.push_back(lib);
     }
 
+    // Read and validate each example document.
     for (std::string filename : exampleFilenames)
     {
-        // Load the example document.
         mx::DocumentPtr doc = mx::createDocument();
         mx::readFromXmlFile(doc, filename, searchPath);
         REQUIRE(doc->validate());
@@ -137,9 +137,8 @@ TEST_CASE("Load content", "[xmlio]")
 
         // Read document without XIncludes.
         doc2 = mx::createDocument();
-
         mx::XmlReadOptions readOptions;
-        readOptions.readXincludes = false;
+        readOptions.readXIncludes = false;
         mx::readFromXmlFile(doc2, filename, searchPath, &readOptions);
         if (*doc2 != *doc)
         {
@@ -150,26 +149,16 @@ TEST_CASE("Load content", "[xmlio]")
         }
     }
 
-    // Read the same documents more than once.
-    // Check that document stays valid when duplicates are skipped.
-    mx::DocumentPtr doc3 = mx::createDocument();
+    // Read the same document twice with duplicate elements skipped.
+    mx::DocumentPtr doc = mx::createDocument();
     mx::XmlReadOptions readOptions;
-    readOptions.readXincludes = true;
+    readOptions.skipDuplicateElements = true;
+    std::string filename = "PaintMaterials.mtlx";
+    mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
+    mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
+    REQUIRE(doc->validate());
 
-    for (std::string libFilename : libraryFilenames)
-    {
-        readOptions.skipDuplicates = false;
-        mx::readFromXmlFile(doc3, libFilename, searchPath, &readOptions);
-        REQUIRE(doc3->validate());
-        readOptions.skipDuplicates = true;
-        mx::readFromXmlFile(doc3, libFilename, searchPath, &readOptions);
-        REQUIRE(doc3->validate());
-    }
-    for (std::string filename : exampleFilenames)
-    {
-        mx::readFromXmlFile(doc3, filename, searchPath, &readOptions);
-        REQUIRE(doc3->validate());
-        mx::readFromXmlFile(doc3, filename, searchPath, &readOptions);
-        REQUIRE(doc3->validate());
-    }
+    // Read a non-existent document.
+    mx::DocumentPtr doc2 = mx::createDocument();
+    REQUIRE_THROWS_AS(mx::readFromXmlFile(doc2, "NonExistent.mtlx"), mx::ExceptionFileMissing);
 }

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -17,15 +17,13 @@ void bindPyXmlIo(py::module& mod)
 {
     py::class_<mx::XmlReadOptions>(mod, "XmlReadOptions")
         .def(py::init())
-        .def("setReadXincludes", &mx::XmlReadOptions::setReadXincludes)
-        .def("getReadXincludes", &mx::XmlReadOptions::getReadXincludes)
-        .def("setSkipDuplicates", &mx::XmlReadOptions::setSkipDuplicates)
-        .def("getSkipDuplicates", &mx::XmlReadOptions::getSkipDuplicates);
+        .def_readwrite("readXIncludes", &mx::XmlReadOptions::readXIncludes)
+        .def_readwrite("skipDuplicateElements", &mx::XmlReadOptions::skipDuplicateElements);
 
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
-        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readOptions") = (const mx::XmlReadOptions*)nullptr);
+        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("readFromXmlString", &mx::readFromXmlString,
-        py::arg("doc"), py::arg("str"), py::arg("readOptions") = (const mx::XmlReadOptions*)nullptr);
+        py::arg("doc"), py::arg("str"), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("writeToXmlFile", mx::writeToXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());
     mod.def("writeToXmlString", mx::writeToXmlString,


### PR DESCRIPTION
- Use consistent capitalization for "readXIncludes".
- Rename skipDuplicates to "skipDuplicateElements" for clarity.
- Unify the XmlReadOptions API between C++ and Python.
- Simplify unit tests to the minimal set for coverage.
- Update documentation for global functions in XmlIo.cpp.