### PR TITLE
Add Material methods to access geometry bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,18 @@
 
 ### Added
 - Added Material methods getPrimaryShaderNodeDef, getPrimaryShaderName, getPrimaryShaderParameters, and getPrimaryShaderInputs.
+- Added Material methods getBoundGeomStrings and getBoundGeomCollections.
 - Added ValueElement methods getBoundValue and getDefaultValue.
 - Added InterfaceElement methods setInputValue and getInputValue.
 - Added method Element\:\:createStringResolver and class StringResolver, for applying substring substitutions to data values.
 - Added support for multi-output nodes, nodedefs, and connections.
+- Added the XmlReadOptions argument to XML read functions.
 
 ### Changed
 - Renamed method Material\:\:getReferencedShaderDefs to Material\:\:getShaderNodeDefs.
 - Renamed method ShaderRef\:\:getReferencedShaderDef to ShaderRef\:\:getNodeDef.
 - Renamed method Node\:\:getReferencedNodeDef to Node\:\:getNodeDef.
-- Added a 'string' suffix to all accessors for 'node' and 'nodedef' strings.
+- Added a 'string' suffix to all accessors for 'node', 'nodedef', and 'collection' strings.
 
 ### Removed
 - Removed method Document\:\:applyStringSubstitutions (deprecated in Python).

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -96,6 +96,9 @@ class TestMaterialX(unittest.TestCase):
         # Create a material that instantiates the shader.
         material = doc.addMaterial()
         shaderRef = material.addShaderRef('shaderRef1', 'simpleSrf')
+        self.assertTrue(material.getPrimaryShaderName() == 'simpleSrf')
+        self.assertTrue(len(material.getPrimaryShaderParameters()) == 1)
+        self.assertTrue(len(material.getPrimaryShaderInputs()) == 2)
         self.assertTrue(roughness.getBoundValue(material) == 0.25)
 
         # Bind a shader input to a value.
@@ -117,19 +120,32 @@ class TestMaterialX(unittest.TestCase):
         self.assertTrue(diffColor.getBoundValue(material) is None)
         self.assertTrue(diffColor.getDefaultValue() == mx.Color3(1.0))
 
-        # Create a collection.
-        collection = doc.addCollection()
-        self.assertTrue(doc.getCollections())
-        doc.removeCollection(collection.getName())
-        self.assertFalse(doc.getCollections())
+        # Create a look for the material.
+        look = doc.addLook()
+        self.assertTrue(len(doc.getLooks()) == 1)
 
-        # Create a property set.
-        propertySet = doc.addPropertySet()
-        property = propertySet.addProperty('twosided')
-        self.assertTrue(doc.getPropertySets())
-        self.assertTrue(propertySet.getProperties())
-        doc.removePropertySet(propertySet.getName())
-        self.assertFalse(doc.getPropertySets())
+        # Bind the material to a geometry string.
+        matAssign1 = look.addMaterialAssign("matAssign1", material.getName())
+        self.assertTrue(material.getReferencingMaterialAssigns()[0] == matAssign1)
+        matAssign1.setGeom("/robot1")
+        self.assertTrue(material.getBoundGeomStrings()[0] == "/robot1")
+
+        # Bind the material to a collection.
+        matAssign2 = look.addMaterialAssign("matAssign2", material.getName())
+        collection = doc.addCollection()
+        collectionAdd = collection.addCollectionAdd()
+        collectionAdd.setGeom("/robot2")
+        collectionRemove = collection.addCollectionRemove()
+        collectionRemove.setGeom("/robot2/left_arm")
+        matAssign2.setCollection(collection)
+        self.assertTrue(material.getBoundGeomCollections()[0] == collection)
+
+        # Create a property assignment.
+        propertyAssign = look.addPropertyAssign("twosided")
+        propertyAssign.setGeom("/robot1")
+        propertyAssign.setValue(True)
+        self.assertTrue(propertyAssign.getGeom() == "/robot1")
+        self.assertTrue(propertyAssign.getValue() == True)
 
         # Generate and verify require string.
         doc.generateRequireString()

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -166,7 +166,7 @@ class Document : public Element
     /// @param name The name of the new GeomInfo.
     ///     If no name is specified, then a unique name will automatically be
     ///     generated.
-    /// @param geom An optional geom string for the GeomInfo.
+    /// @param geom An optional geometry string for the GeomInfo.
     /// @return A shared pointer to the new GeomInfo.
     GeomInfoPtr addGeomInfo(const string& name = EMPTY_STRING, const string& geom = UNIVERSAL_GEOM_NAME)
     {

--- a/source/MaterialXCore/Geom.cpp
+++ b/source/MaterialXCore/Geom.cpp
@@ -5,6 +5,8 @@
 
 #include <MaterialXCore/Geom.h>
 
+#include <MaterialXCore/Document.h>
+
 namespace MaterialX
 {
 
@@ -31,6 +33,23 @@ bool geomStringsMatch(const string& geom1, const string& geom2)
     std::set_intersection(set1.begin(), set1.end(), set2.begin(), set2.end(), 
                           std::inserter(matches, matches.end()));
     return !matches.empty();
+}
+
+void GeomElement::setCollection(CollectionPtr collection)
+{
+    if (collection)
+    {
+        setCollectionString(collection->getName());
+    }
+    else
+    {
+        removeAttribute(COLLECTION_ATTRIBUTE);
+    }
+}
+
+CollectionPtr GeomElement::getCollection() const
+{
+    return getDocument()->getCollection(getCollectionString());
 }
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -50,13 +50,19 @@ class GeomElement : public Element
     /// @name Geometry
     /// @{
 
-    /// Set the geom string of the element.
-    void setGeom(const string& name)
+    /// Set the geometry string of this element.
+    void setGeom(const string& geom)
     {
-        setAttribute(GEOM_ATTRIBUTE, name);
+        setAttribute(GEOM_ATTRIBUTE, geom);
     }
 
-    /// Return the geom string of the element.
+    /// Return true if this element has a geometry string.
+    bool hasGeom()
+    {
+        return hasAttribute(GEOM_ATTRIBUTE);
+    }
+
+    /// Return the geometry string of this element.
     const string& getGeom() const
     {
         return getAttribute(GEOM_ATTRIBUTE);
@@ -66,17 +72,29 @@ class GeomElement : public Element
     /// @name Collection
     /// @{
 
-    /// Set the collection string of the element.
-    void setCollection(const string& name)
+    /// Set the collection string of this element.
+    void setCollectionString(const string& collection)
     {
-        setAttribute(COLLECTION_ATTRIBUTE, name);
+        setAttribute(COLLECTION_ATTRIBUTE, collection);
     }
 
-    /// Return the collection string of the element.
-    const string& getCollection() const
+    /// Return true if this element has a collection string.
+    bool hasCollectionString()
+    {
+        return hasAttribute(COLLECTION_ATTRIBUTE);
+    }
+
+    /// Return the collection string of this element.
+    const string& getCollectionString() const
     {
         return getAttribute(COLLECTION_ATTRIBUTE);
     }
+
+    /// Assign a Collection to this element.
+    void setCollection(CollectionPtr collection);
+
+    /// Return the Collection that is assigned to this element.
+    CollectionPtr getCollection() const;
 
     /// @}
 
@@ -277,9 +295,9 @@ template<class T> GeomAttrPtr GeomInfo::setGeomAttrValue(const string& name,
     return geomAttr;
 }
 
-/// Given two geom strings, each containing an array of geom names, return true
-/// if they have any geometries in common.  The universal geom name "*" matches
-/// all geometries.
+/// Given two geometry strings, each containing an array of geom names, return
+/// true if they have any geometries in common.  The universal geom name "*"
+/// matches all geometries.
 /// @todo The full set of pattern matching rules in the specification is not
 ///    yet supported, and only the universal geom name is currently handled.
 /// @relates GeomInfo

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -87,7 +87,7 @@ MaterialPtr Material::getInheritsFrom() const
     return getRoot()->getChildOfType<Material>(inherits[0]->getName());
 }
 
-vector<ParameterPtr> Material::getPrimaryShaderParameters(const string & target, const string & type) const
+vector<ParameterPtr> Material::getPrimaryShaderParameters(const string& target, const string& type) const
 {
     NodeDefPtr nodeDef = getPrimaryShaderNodeDef(target, type);
     vector<ParameterPtr> res;
@@ -103,7 +103,7 @@ vector<ParameterPtr> Material::getPrimaryShaderParameters(const string & target,
     return res;
 }
 
-vector<InputPtr> Material::getPrimaryShaderInputs(const string & target, const string & type) const
+vector<InputPtr> Material::getPrimaryShaderInputs(const string& target, const string& type) const
 {
     NodeDefPtr nodeDef = getPrimaryShaderNodeDef(target, type);
     vector<InputPtr> res;
@@ -117,6 +117,33 @@ vector<InputPtr> Material::getPrimaryShaderInputs(const string & target, const s
         }
     }
     return res;
+}
+
+vector<string> Material::getBoundGeomStrings() const
+{
+    vector<string> geomStrings;
+    for (MaterialAssignPtr matAssign : getReferencingMaterialAssigns())
+    {
+        if (matAssign->hasGeom())
+        {
+            geomStrings.push_back(matAssign->getGeom());
+        }
+    }
+    return geomStrings;
+}
+
+vector<CollectionPtr> Material::getBoundGeomCollections() const
+{
+    vector<CollectionPtr> collections;
+    for (MaterialAssignPtr matAssign : getReferencingMaterialAssigns())
+    {
+        CollectionPtr collection = matAssign->getCollection();
+        if (collection)
+        {
+            collections.push_back(collection);
+        }
+    }
+    return collections;
 }
 
 bool Material::validate(string* message) const

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -49,6 +49,7 @@ class Material : public Element
 
   protected:
     using MaterialAssignPtr = shared_ptr<class MaterialAssign>;
+    using CollectionPtr = shared_ptr<class Collection>;
 
   public:
     /// @name ShaderRef Elements
@@ -241,6 +242,22 @@ class Material : public Element
     ///    material, or an empty vector if no matching shader was found.
     vector<InputPtr> getPrimaryShaderInputs(const string& target = EMPTY_STRING,
                                             const string& type = EMPTY_STRING) const;
+
+    /// @}
+    /// @name Geometry Bindings
+    /// @{
+
+    /// Return all geometry strings that are bound to this material by Look
+    /// elements.  Note that this method only considers geometry strings,
+    /// not geometric collections.
+    /// @return A vector of geometry strings, each containing an array of
+    ///    geom names.
+    vector<string> getBoundGeomStrings() const;
+
+    /// Return all geometry collections that are bound to this material by
+    /// Look elements.
+    /// @return A vector of shared pointers to Collection elements.
+   vector<CollectionPtr> getBoundGeomCollections() const;
 
     /// @}
     /// @name Validation

--- a/source/MaterialXCore/Property.cpp
+++ b/source/MaterialXCore/Property.cpp
@@ -5,10 +5,29 @@
 
 #include <MaterialXCore/Property.h>
 
+#include <MaterialXCore/Document.h>
+
 namespace MaterialX
 {
 
 const string PropertyAssign::GEOM_ATTRIBUTE = "geom";
 const string PropertyAssign::COLLECTION_ATTRIBUTE = "collection";
+
+void PropertyAssign::setCollection(CollectionPtr collection)
+{
+    if (collection)
+    {
+        setCollectionString(collection->getName());
+    }
+    else
+    {
+        removeAttribute(COLLECTION_ATTRIBUTE);
+    }
+}
+
+CollectionPtr PropertyAssign::getCollection() const
+{
+    return getDocument()->getCollection(getCollectionString());
+}
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -54,13 +54,19 @@ class PropertyAssign : public ValueElement
     /// @name Geometry
     /// @{
 
-    /// Set the geom string of the element.
-    void setGeom(const string& name)
+    /// Set the geometry string of this element.
+    void setGeom(const string& geom)
     {
-        setAttribute(GEOM_ATTRIBUTE, name);
+        setAttribute(GEOM_ATTRIBUTE, geom);
     }
 
-    /// Return the geom string of the element.
+    /// Return true if this element has a geometry string.
+    bool hasGeom()
+    {
+        return hasAttribute(GEOM_ATTRIBUTE);
+    }
+
+    /// Return the geometry string of this element.
     const string& getGeom() const
     {
         return getAttribute(GEOM_ATTRIBUTE);
@@ -70,17 +76,29 @@ class PropertyAssign : public ValueElement
     /// @name Collection
     /// @{
 
-    /// Set the collection string of the element.
-    void setCollection(const string& name)
+    /// Set the collection string of this element.
+    void setCollectionString(const string& collection)
     {
-        setAttribute(COLLECTION_ATTRIBUTE, name);
+        setAttribute(COLLECTION_ATTRIBUTE, collection);
     }
 
-    /// Return the collection string of the element.
-    const string& getCollection() const
+    /// Return true if this element has a collection string.
+    bool hasCollectionString()
+    {
+        return hasAttribute(COLLECTION_ATTRIBUTE);
+    }
+
+    /// Return the collection string of this element.
+    const string& getCollectionString() const
     {
         return getAttribute(COLLECTION_ATTRIBUTE);
     }
+
+    /// Assign a Collection to this element.
+    void setCollection(CollectionPtr collection);
+
+    /// Return the Collection that is assigned to this element.
+    CollectionPtr getCollection() const;
 
     /// @}
 

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -133,13 +133,11 @@ void xmlDocumentFromFile(xml_document& xmlDoc, string filename, const string& se
 void processXIncludes(xml_node& xmlNode, const string& searchPath, const XmlReadOptions* readOptions)
 {
     xml_node xmlChild = xmlNode.first_child();
-
-    bool readXIncludes = (readOptions ? readOptions->readXIncludes : true);
     while (xmlChild)
     {
         if (xmlChild.name() == XINCLUDE_TAG)
         {
-            if (readXIncludes)
+            if (!readOptions || readOptions->readXIncludes)
             {
                 xml_attribute fileAttr = xmlChild.attribute("href");
                 string filename = fileAttr.value();

--- a/source/MaterialXTest/Geom.cpp
+++ b/source/MaterialXTest/Geom.cpp
@@ -14,11 +14,11 @@ TEST_CASE("Geom", "[geom]")
     mx::DocumentPtr doc = mx::createDocument();
 
     // Add geominfos and geomattrs
-    mx::GeomInfoPtr geominfo1 = doc->addGeomInfo("geominfo1", "robot1,robot2");
+    mx::GeomInfoPtr geominfo1 = doc->addGeomInfo("geominfo1", "/robot1,/robot2");
     geominfo1->setGeomAttrValue("asset", std::string("robot"));
-    mx::GeomInfoPtr geominfo2 = doc->addGeomInfo("geominfo2", "robot1");
+    mx::GeomInfoPtr geominfo2 = doc->addGeomInfo("geominfo2", "/robot1");
     geominfo2->setGeomAttrValue("id", std::string("01"));
-    mx::GeomInfoPtr geominfo3 = doc->addGeomInfo("geominfo3", "robot2");
+    mx::GeomInfoPtr geominfo3 = doc->addGeomInfo("geominfo3", "/robot2");
     geominfo3->setGeomAttrValue("id", std::string("02"));
     REQUIRE_THROWS_AS(doc->addGeomInfo("geominfo1"), mx::Exception);
 
@@ -31,24 +31,10 @@ TEST_CASE("Geom", "[geom]")
 
     // Test string substitutions.
     mx::ParameterPtr fileParam = image->getParameter("file");
-    mx::StringResolverPtr resolver1 = image->createStringResolver("robot1");
+    mx::StringResolverPtr resolver1 = image->createStringResolver("/robot1");
     resolver1->setUdimString("1001");
-    mx::StringResolverPtr resolver2 = image->createStringResolver("robot2");
+    mx::StringResolverPtr resolver2 = image->createStringResolver("/robot2");
     resolver2->setUdimString("1002");
     REQUIRE(fileParam->getResolvedValueString(resolver1) == "folder/robot01_diffuse_1001.tif");
     REQUIRE(fileParam->getResolvedValueString(resolver2) == "folder/robot02_diffuse_1002.tif");
-
-    // Collection add / remove test
-    mx::CollectionPtr collection = doc->addCollection("robot_collection"); 
-    REQUIRE(doc->getCollections().size() == 1);
-    mx::CollectionAddPtr collectadd1 = collection->addCollectionAdd("collection_add1");
-    mx::CollectionRemovePtr collectremove1 = collection->addCollectionRemove("collection_remove1");
-    REQUIRE(collection->getCollectionAdds().size() == 1);
-    REQUIRE(collection->getCollectionRemoves().size() == 1);
-    collection->removeCollectionAdd(collectadd1->getName());
-    collection->removeCollectionRemove(collectremove1->getName());
-    REQUIRE(collection->getCollectionAdds().size() == 0);
-    REQUIRE(collection->getCollectionRemoves().size() == 0);
-    doc->removeCollection(collection->getName());
-    REQUIRE(doc->getCollections().size() == 0);
 }

--- a/source/MaterialXTest/Look.cpp
+++ b/source/MaterialXTest/Look.cpp
@@ -13,40 +13,37 @@ TEST_CASE("Look", "[look]")
 {
     mx::DocumentPtr doc = mx::createDocument();
 
-    // Add look and material.
-    mx::LookPtr look = doc->addLook();
-    mx::MaterialPtr material = doc->addMaterial();
-    REQUIRE(doc->getLooks().size() == 1);
+    // Create a material and look.
+    mx::MaterialPtr material = doc->addMaterial("material1");
+    mx::LookPtr look = doc->addLook("look1");
     REQUIRE(doc->getMaterials().size() == 1);
+    REQUIRE(doc->getLooks().size() == 1);
 
-    // Add inherited look.
-    mx::LookPtr look2 = doc->addLook();
-    look2->setInheritsFrom(look);
-    REQUIRE(look2->getInheritsFrom() == look);
-    look2->setInheritsFrom(nullptr);
-    REQUIRE(look2->getInheritsFrom() == nullptr);
-    REQUIRE(look2->getLookInherits().empty());
+    // Bind the material to a geometry string.
+    mx::MaterialAssignPtr matAssign1 = look->addMaterialAssign("matAssign1", material->getName());
+    matAssign1->setGeom("/robot1");
+    REQUIRE(matAssign1->getReferencedMaterial() == material);
+    REQUIRE(material->getBoundGeomStrings()[0] == "/robot1");
 
-    // Add material assignment.
-    mx::MaterialAssignPtr materialAssign = look->addMaterialAssign("", material->getName());
-    REQUIRE(material->getReferencingMaterialAssigns()[0] == materialAssign);
-    REQUIRE(materialAssign->getReferencedMaterial() == material);
-    materialAssign->setGeom("geom1");
-    REQUIRE(materialAssign->getGeom() == "geom1");
-    materialAssign->setCollection("collection1");
-    REQUIRE(materialAssign->getCollection() == "collection1");
-    materialAssign->setExclusive(true);
-    REQUIRE(materialAssign->getExclusive());
+    // Bind the material to a geometric collection.
+    mx::MaterialAssignPtr matAssign2 = look->addMaterialAssign("matAssign2", material->getName());
+    mx::CollectionPtr collection = doc->addCollection();
+    mx::CollectionAddPtr collectionAdd = collection->addCollectionAdd();
+    collectionAdd->setGeom("/robot2");
+    mx::CollectionRemovePtr collectionRemove = collection->addCollectionRemove();
+    collectionRemove->setGeom("/robot2/left_arm");
+    matAssign2->setCollection(collection);
+    REQUIRE(material->getBoundGeomCollections()[0] == collection);
 
-    // Add property assignment.
+    // Create a property assignment.
     mx::PropertyAssignPtr propertyAssign = look->addPropertyAssign("twosided");
-    propertyAssign->setGeom("geom1");
+    propertyAssign->setGeom("/robot1");
     propertyAssign->setValue(true);
-    REQUIRE(propertyAssign->getGeom() == "geom1");
+    REQUIRE(propertyAssign->getGeom() == "/robot1");
     REQUIRE(propertyAssign->getValue()->isA<bool>());
     REQUIRE(propertyAssign->getValue()->asA<bool>() == true);
 
-    // Add property set assignment.
+    // Create a property set assignment.
     mx::PropertySetPtr propertySet = doc->addPropertySet();
     REQUIRE(doc->getPropertySets().size() == 1);
     mx::PropertyPtr property = propertySet->addProperty("matte");
@@ -56,11 +53,19 @@ TEST_CASE("Look", "[look]")
     mx::PropertySetAssignPtr propertySetAssign = look->addPropertySetAssign(propertySet->getName());
     REQUIRE(look->getPropertySetAssigns().size() == 1);
 
-    // Add visibility.
+    // Create a visibility element.
     mx::VisibilityPtr visibility = look->addVisibility();
     REQUIRE(look->getVisibilities().size() == 1);
-    visibility->setGeom("geom1");
-    REQUIRE(visibility->getGeom() == "geom1");
-    visibility->setCollection("collection1");
-    REQUIRE(visibility->getCollection() == "collection1");
+    visibility->setGeom("/robot2");
+    REQUIRE(visibility->getGeom() == "/robot2");
+    visibility->setCollection(collection);
+    REQUIRE(visibility->getCollection() == collection);
+
+    // Create an inherited look.
+    mx::LookPtr look2 = doc->addLook();
+    look2->setInheritsFrom(look);
+    REQUIRE(look2->getInheritsFrom() == look);
+    look2->setInheritsFrom(nullptr);
+    REQUIRE(look2->getInheritsFrom() == nullptr);
+    REQUIRE(look2->getLookInherits().empty());
 }

--- a/source/MaterialXTest/Material.cpp
+++ b/source/MaterialXTest/Material.cpp
@@ -32,9 +32,11 @@ TEST_CASE("Material", "[material]")
     {
         // Add a shader reference.
         mx::ShaderRefPtr shaderRef = material->addShaderRef("shaderRef1", "simpleSrf");
-        REQUIRE(material->getPrimaryShaderName() == shaderRef->getNodeString());
         REQUIRE(shaderDef->getInstantiatingShaderRefs()[0] == shaderRef);
         REQUIRE(shaderRef->getNodeDef() == shaderDef);
+        REQUIRE(material->getPrimaryShaderName() == shaderRef->getNodeString());
+        REQUIRE(material->getPrimaryShaderParameters().size() == 1);
+        REQUIRE(material->getPrimaryShaderInputs().size() == 2);
 
         // Bind a shader input to a value.
         mx::BindInputPtr bindInput = shaderRef->addBindInput("specColor");
@@ -55,8 +57,10 @@ TEST_CASE("Material", "[material]")
         // Remove shader references.
         material->removeShaderRef(shaderRef->getName());
         material->removeShaderRef(shaderRef2->getName());
-        REQUIRE(material->getPrimaryShaderName().empty());
         REQUIRE(shaderDef->getInstantiatingShaderRefs().empty());
+        REQUIRE(material->getPrimaryShaderName().empty());
+        REQUIRE(material->getPrimaryShaderParameters().empty());
+        REQUIRE(material->getPrimaryShaderInputs().empty());
     }
 
     SECTION("Overrides")

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Node", "[node]")
 
 TEST_CASE("Flatten", "[nodegraph]")
 {
-    // Load the example file.
+    // Read the example file.
     mx::DocumentPtr doc = mx::createDocument();
     mx::readFromXmlFile(doc, "SubGraphs.mtlx", "documents/Examples;documents/Libraries");
 

--- a/source/PyMaterialX/PyGeom.cpp
+++ b/source/PyMaterialX/PyGeom.cpp
@@ -19,7 +19,11 @@ void bindPyGeom(py::module& mod)
 {
     py::class_<mx::GeomElement, mx::GeomElementPtr, mx::Element>(mod, "GeomElement")
         .def("setGeom", &mx::GeomElement::setGeom)
+        .def("hasGeom", &mx::GeomElement::hasGeom)
         .def("getGeom", &mx::GeomElement::getGeom)
+        .def("setCollectionString", &mx::GeomElement::setCollectionString)
+        .def("hasCollectionString", &mx::GeomElement::hasCollectionString)
+        .def("getCollectionString", &mx::GeomElement::getCollectionString)
         .def("setCollection", &mx::GeomElement::setCollection)
         .def("getCollection", &mx::GeomElement::getCollection);
 

--- a/source/PyMaterialX/PyMaterial.cpp
+++ b/source/PyMaterialX/PyMaterial.cpp
@@ -45,6 +45,8 @@ void bindPyMaterial(py::module& mod)
             py::arg("target") = mx::EMPTY_STRING, py::arg("type") = mx::EMPTY_STRING)
         .def("getPrimaryShaderInputs", &mx::Material::getPrimaryShaderInputs,
             py::arg("target") = mx::EMPTY_STRING, py::arg("type") = mx::EMPTY_STRING)
+        .def("getBoundGeomStrings", &mx::Material::getBoundGeomStrings)
+        .def("getBoundGeomCollections", &mx::Material::getBoundGeomCollections)
         .def("setInheritsFrom", &mx::Material::setInheritsFrom)
         .def("getInheritsFrom", &mx::Material::getInheritsFrom)
         BIND_MATERIAL_FUNC_INSTANCE(integer, int)

--- a/source/PyMaterialX/PyProperty.cpp
+++ b/source/PyMaterialX/PyProperty.cpp
@@ -19,7 +19,11 @@ void bindPyProperty(py::module& mod)
 
     py::class_<mx::PropertyAssign, mx::PropertyAssignPtr, mx::ValueElement>(mod, "PropertyAssign")
         .def("setGeom", &mx::PropertyAssign::setGeom)
+        .def("hasGeom", &mx::PropertyAssign::hasGeom)
         .def("getGeom", &mx::PropertyAssign::getGeom)
+        .def("setCollectionString", &mx::PropertyAssign::setCollectionString)
+        .def("hasCollectionString", &mx::PropertyAssign::hasCollectionString)
+        .def("getCollectionString", &mx::PropertyAssign::getCollectionString)
         .def("setCollection", &mx::PropertyAssign::setCollection)
         .def("getCollection", &mx::PropertyAssign::getCollection)
         .def_readonly_static("CATEGORY", &mx::PropertyAssign::CATEGORY);


### PR DESCRIPTION
This changelist adds two new Material methods, getBoundGeomStrings and getBoundGeomCollections, which provide high-level access to the geometry bindings of a Material element.

Also:

- Improve unit tests and documentation for geometry elements and bindings.
- Add a 'string' suffix to collection string accessor methods.