### PR TITLE
Add explicit specifiers to VectorN and TypedValue constructors

### DIFF
--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -43,9 +43,9 @@ template <size_t N> class VectorN : public VectorBase
 {
   public:
     VectorN() : data{0.0f} { }
-    VectorN(float f) { data.fill(f); }
-    VectorN(const std::array<float, N>& arr) : data(arr) { }
-    VectorN(const vector<float>& vec) { std::copy_n(vec.begin(), N, data.begin()); }
+    explicit VectorN(float f) { data.fill(f); }
+    explicit VectorN(const std::array<float, N>& arr) : data(arr) { }
+    explicit VectorN(const vector<float>& vec) { std::copy_n(vec.begin(), N, data.begin()); }
 
     bool operator==(const VectorN& rhs) const { return data == rhs.data; }
     bool operator!=(const VectorN& rhs) const { return data != rhs.data; }

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -80,7 +80,7 @@ template <class T> class TypedValue : public Value
         _data(ZERO)
     {
     }
-    TypedValue(const T& value) :
+    explicit TypedValue(const T& value) :
         _data(value)
     {
     }


### PR DESCRIPTION
This changelist adds "explicit" specifiers to the single-argument constructors for VectorN and TypedValue, removing a potential developer trap where they would be invoked unintentionally.