### PR TITLE
Add Appveyor builds for VS2017

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 version: "{build}"
-os: Visual Studio 2015
+os: Visual Studio 2017
 clone_folder: C:\Projects\MaterialX
 
 environment:
@@ -8,7 +8,9 @@ environment:
       PYTHON: C:\Python26
     - CMAKE_PLATFORM: "Visual Studio 14 2015 Win64"
       PYTHON: C:\Python27-x64
-    - CMAKE_PLATFORM: "Visual Studio 14 2015 Win64"
+    - CMAKE_PLATFORM: "Visual Studio 15 2017"
+      PYTHON: C:\Python35
+    - CMAKE_PLATFORM: "Visual Studio 15 2017 Win64"
       PYTHON: C:\Python36-x64
 
 configuration:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,17 @@ language: cpp
 
 matrix:
   include:
-    # Standard Linux builds
+    # Standard builds
     - os: linux
       compiler: gcc
     - os: linux
       compiler: clang
-
-    # Standard OSX builds
     - os: osx
       compiler: gcc
     - os: osx
       compiler: clang
 
-    # Custom Linux builds
+    # Custom builds
     - os: linux
       compiler: gcc
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -203,7 +203,7 @@ NodeDefPtr ShaderRef::getNodeDef() const
     return NodeDefPtr();
 }
 
-bool ShaderRef::validate(string * message) const
+bool ShaderRef::validate(string* message) const
 {
     bool res = true;
     NodeDefPtr nodeDef = getNodeDef();

--- a/source/MaterialXCore/Observer.h
+++ b/source/MaterialXCore/Observer.h
@@ -131,7 +131,7 @@ class ObservedDocument : public Document
     void onAddElement(ElementPtr parent, ElementPtr elem) override
     {
         Document::onAddElement(parent, elem);
-        for (auto &item : _observerMap)
+        for (auto& item : _observerMap)
         {
             item.second->onAddElement(parent, elem);
         }
@@ -140,7 +140,7 @@ class ObservedDocument : public Document
     void onRemoveElement(ElementPtr parent, ElementPtr elem) override
     {
         Document::onRemoveElement(parent, elem);
-        for (auto &item : _observerMap)
+        for (auto& item : _observerMap)
         {
             item.second->onRemoveElement(parent, elem);
         }
@@ -149,7 +149,7 @@ class ObservedDocument : public Document
     void onSetAttribute(ElementPtr elem, const string& attrib, const string& value) override
     {
         Document::onSetAttribute(elem, attrib, value);
-        for (auto &item : _observerMap)
+        for (auto& item : _observerMap)
         {
             item.second->onSetAttribute(elem, attrib, value);
         }
@@ -158,7 +158,7 @@ class ObservedDocument : public Document
     void onRemoveAttribute(ElementPtr elem, const string& attrib) override
     {
         Document::onRemoveAttribute(elem, attrib);
-        for (auto &item : _observerMap)
+        for (auto& item : _observerMap)
         {
             item.second->onRemoveAttribute(elem, attrib);
         }
@@ -166,7 +166,7 @@ class ObservedDocument : public Document
 
     void onInitialize() override
     {
-        for (auto &item : _observerMap)
+        for (auto& item : _observerMap)
         {
             item.second->onInitialize();
         }
@@ -174,7 +174,7 @@ class ObservedDocument : public Document
 
     void onRead() override
     {
-        for (auto &item : _observerMap)
+        for (auto& item : _observerMap)
         {
             item.second->onRead();
         }
@@ -182,7 +182,7 @@ class ObservedDocument : public Document
 
     void onWrite() override
     {
-        for (auto &item : _observerMap)
+        for (auto& item : _observerMap)
         {
             item.second->onWrite();
         }
@@ -193,7 +193,7 @@ class ObservedDocument : public Document
         // Only send notification for the outermost scope.
         if (!getUpdateScope())
         {
-            for (auto &item : _observerMap)
+            for (auto& item : _observerMap)
             {
                 item.second->onBeginUpdate();
             }
@@ -209,7 +209,7 @@ class ObservedDocument : public Document
         // Only send notification for the outermost scope.
         if (!getUpdateScope())
         {
-            for (auto &item : _observerMap)
+            for (auto& item : _observerMap)
             {
                 item.second->onEndUpdate();
             }


### PR DESCRIPTION
Add Appveyor builds for VS2017 and Python 3.5, and make minor adjustments to whitespace and comments.