### PR TITLE
Remove visibility override to fix OSX linker warnings

### DIFF
--- a/source/PyMaterialX/CMakeLists.txt
+++ b/source/PyMaterialX/CMakeLists.txt
@@ -13,8 +13,6 @@ source_group("Header Files\\PyBind11" FILES ${pybind11_headers})
 add_subdirectory(PyBind11)
 pybind11_add_module(PyMaterialX SHARED ${pymaterialx_source} ${pymaterialx_headers} ${pybind11_headers})
 
-add_definitions(-DPYBIND11_PREFER_PYINT)
-
 set_target_properties(
     PyMaterialX
     PROPERTIES

--- a/source/PyMaterialX/PyBind11/CMakeLists.txt
+++ b/source/PyMaterialX/PyBind11/CMakeLists.txt
@@ -1,8 +1,5 @@
 # A helper module for building MaterialX Python with PyBind11, based on pybind11Tools.cmake.
 
-cmake_minimum_required(VERSION 2.8.12)
-set(MIN_PYTHON_VERSION_REQ "2.6" CACHE INTERNAL "")
-
 if(MATERIALX_PYTHON_EXECUTABLE)
   set(PYTHON_EXECUTABLE ${MATERIALX_PYTHON_EXECUTABLE})
 else()
@@ -142,13 +139,6 @@ function(pybind11_add_module target_name)
   elseif(APPLE)
     set_target_properties(${target_name} PROPERTIES SUFFIX ".so")
   endif()
-
-  # -fvisibility=hidden is required to allow multiple modules compiled against
-  # different pybind versions to work properly, and for some features (e.g.
-  # py::module_local).  We force it on everything inside the `pybind11`
-  # namespace; also turning it on for a pybind module compilation here avoids
-  # potential warnings or issues from having mixed hidden/non-hidden types.
-  set_target_properties(${target_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
 
   if(WIN32 OR CYGWIN)
     # Link against the Python shared library on Windows


### PR DESCRIPTION
This changelist removes an override of the symbol visibility setting in PyMaterialX, fixing linker warnings in OSX builds.  It also removes a handful of additional build settings in PyMaterialX that are no longer needed.