### PR TITLE
Remove extra type aliases

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -157,7 +157,7 @@ void Document::initialize()
     setVersionString(DOCUMENT_VERSION_STRING);
 }
 
-void Document::importLibrary(ConstDocumentPtr library, ConstCopyOptionsPtr copyOptions)
+void Document::importLibrary(ConstDocumentPtr library, const CopyOptions* copyOptions)
 {
     bool skipDuplicateElements = copyOptions && copyOptions->skipDuplicateElements;
     bool copySourceUris = copyOptions && copyOptions->copySourceUris;

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -64,7 +64,7 @@ class Document : public Element
     /// @param copyOptions An optional pointer to a CopyOptions object.
     ///    If provided, then the given options will affect the behavior of the
     ///    import function.  Defaults to a null pointer.
-    void importLibrary(ConstDocumentPtr library, ConstCopyOptionsPtr copyOptions = nullptr);
+    void importLibrary(ConstDocumentPtr library, const class CopyOptions* copyOptions = nullptr);
 
     /// @name Document Versions
     /// @{

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -317,7 +317,7 @@ AncestorIterator Element::traverseAncestors() const
     return AncestorIterator(getSelf());
 }
 
-void Element::copyContentFrom(ConstElementPtr source, ConstCopyOptionsPtr copyOptions)
+void Element::copyContentFrom(ConstElementPtr source, const CopyOptions* copyOptions)
 {
     if (copyOptions && copyOptions->copySourceUris)
     {

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -36,9 +36,6 @@ using ConstValueElementPtr = shared_ptr<const class ValueElement>;
 /// A shared pointer to a StringResolver
 using StringResolverPtr = shared_ptr<class StringResolver>;
 
-/// A raw pointer to a const CopyOptions
-using ConstCopyOptionsPtr = const class CopyOptions*;
-
 /// A hash map from strings to elements
 using ElementMap = std::unordered_map<string, ElementPtr>;
 
@@ -50,7 +47,7 @@ using ElementPredicate = std::function<bool(ElementPtr)>;
 ///
 /// An Element is a named object within a Document, which may possess any
 /// number of child elements and attributes.
-class Element : public enable_shared_from_this<Element>
+class Element : public std::enable_shared_from_this<Element>
 {
   protected:
     Element(ElementPtr parent, const string& category, const string& name) :
@@ -625,7 +622,7 @@ class Element : public enable_shared_from_this<Element>
     /// @param copyOptions An optional pointer to a CopyOptions object.
     ///    If provided, then the given options will affect the behavior of the
     ///    copy function.  Defaults to a null pointer.
-    void copyContentFrom(ConstElementPtr source, ConstCopyOptionsPtr copyOptions = nullptr);
+    void copyContentFrom(ConstElementPtr source, const class CopyOptions* copyOptions = nullptr);
 
     /// Clear all attributes and descendants from this element.
     void clearContent();

--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -26,7 +26,6 @@ using std::string;
 using std::vector;
 using std::shared_ptr;
 using std::weak_ptr;
-using std::enable_shared_from_this;
 
 /// A vector of strings.
 using StringVec = vector<string>;

--- a/source/PyMaterialX/PyDocument.cpp
+++ b/source/PyMaterialX/PyDocument.cpp
@@ -18,7 +18,7 @@ void bindPyDocument(py::module& mod)
         .def("initialize", &mx::Document::initialize)
         .def("copy", &mx::Document::copy)
         .def("importLibrary", &mx::Document::importLibrary, 
-            py::arg("library"), py::arg("copyOptions") = (mx::ConstCopyOptionsPtr) nullptr)
+            py::arg("library"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
         .def("setVersionString", &mx::Document::setVersionString)
         .def("hasVersionString", &mx::Document::hasVersionString)
         .def("getVersionString", &mx::Document::getVersionString)

--- a/source/PyMaterialX/PyElement.cpp
+++ b/source/PyMaterialX/PyElement.cpp
@@ -93,7 +93,7 @@ void bindPyElement(py::module& mod)
                 return std::pair<bool, std::string>(res, message);
             })
         .def("copyContentFrom", &mx::Element::copyContentFrom,
-            py::arg("source"), py::arg("copyOptions") = (mx::ConstCopyOptionsPtr) nullptr)
+            py::arg("source"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
         .def("clearContent", &mx::Element::clearContent)
         .def("createValidChildName", &mx::Element::createValidChildName)
         .def("createStringResolver", &mx::Element::createStringResolver,


### PR DESCRIPTION
This changelist removes two type aliases from the MaterialX namespace, MaterialX::ConstCopyOptionsPtr and MaterialX::enable_shared_from_this, which weren't providing additional code clarity.