### PR TITLE
InterfaceElement value accessors respect values in interface declarations

### DIFF
--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -100,10 +100,11 @@ def _setParameterValue(self, name, value, typeString = ''):
     method = getattr(self.__class__, "_setParameterValue" + typeToName(value.__class__))
     return method(self, name, value, typeString)
 
-def _getParameterValue(self, name):
-    """Return the typed value of a parameter by its name.  If the given parameter
-       is not present, then None is returned."""
-    value = self._getParameterValue(name)
+def _getParameterValue(self, name, target = ''):
+    """Return the typed value of a parameter by its name.  If the given
+       parameter is not found in either the interface or its declaration,
+       then None is returned."""
+    value = self._getParameterValue(name, target)
     return value.getData() if value else None
 
 def _getParameterValueString(self, name):
@@ -119,10 +120,11 @@ def _setInputValue(self, name, value, typeString = ''):
     method = getattr(self.__class__, "_setInputValue" + typeToName(value.__class__))
     return method(self, name, value, typeString)
 
-def _getInputValue(self, name):
-    """Return the typed value of a parameter by its name.  If the given parameter
-       is not present, then None is returned."""
-    value = self._getInputValue(name)
+def _getInputValue(self, name, target = ''):
+    """Return the typed value of an input by its name.  If the given
+       input is not found in either the interface or its declaration,
+       then None is returned."""
+    value = self._getInputValue(name, target)
     return value.getData() if value else None
 
 InterfaceElement.setParameterValue = _setParameterValue

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -100,6 +100,18 @@ class TestMaterialX(unittest.TestCase):
         image.setParameterValue('file', file, 'filename')
         self.assertTrue(image.getParameterValue('file') == file)
 
+        # Create a custom nodedef.
+        nodeDef = doc.addNodeDef('nodeDef1', 'float', 'turbulence3d');
+        nodeDef.setParameterValue('octaves', 3);
+        nodeDef.setParameterValue('lacunarity', 2.0);
+        nodeDef.setParameterValue('gain', 0.5);
+
+        # Reference the custom nodedef.
+        custom = nodeGraph.addNode('turbulence3d', 'turbulence1', 'float');
+        self.assertTrue(custom.getParameterValue('octaves') == 3)
+        custom.setParameterValue('octaves', 5);
+        self.assertTrue(custom.getParameterValue('octaves') == 5)
+
         # Validate the document.
         self.assertTrue(doc.validate()[0])
 

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -459,28 +459,17 @@ ValuePtr ValueElement::getDefaultValue() const
     {
         return getValue();
     }
-    ConstElementPtr parent = getParent();
-    if (parent->isA<Implementation>())
+
+    // Return the value, if any, stored in our declaration.
+    if (getParent()->isA<InterfaceElement>())
     {
-        ConstNodeDefPtr nodeDef = parent->asA<Implementation>()->getNodeDef();
-        if (nodeDef)
+        NodeDefPtr decl = getParent()->asA<InterfaceElement>()->getDeclaration();
+        if (decl)
         {
-            InputPtr input = nodeDef->getInput(getName());
-            if (input)
+            ValueElementPtr value = decl->getChildOfType<ValueElement>(getName());
+            if (value)
             {
-                return input->getValue();
-            }
-        }
-    }
-    if (parent->isA<Node>())
-    {
-        ConstNodeDefPtr nodeDef = parent->asA<Node>()->getNodeDef();
-        if (nodeDef)
-        {
-            InputPtr input = nodeDef->getInput(getName());
-            if (input)
-            {
-                return input->getValue();
+                return value->getValue();
             }
         }
     }

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -901,6 +901,7 @@ class ValueElement : public TypedElement
     ///
     /// If this element has no default value then an empty shared pointer is
     /// returned.
+    ///
     /// @return A shared pointer to a generic value.
     ValuePtr getDefaultValue() const;
 
@@ -1012,6 +1013,10 @@ class StringResolver
         return _filenameMap;
     }
 
+    /// @}
+    /// @name Geometry Name Substitutions
+    /// @{
+
     /// Set an arbitrary substring substitution for geometry name data values.
     void setGeomNameSubstitution(const string& key, const string& value)
     {
@@ -1023,7 +1028,6 @@ class StringResolver
     {
         return _geomNameMap;
     }
-    
 
     /// @}
     /// @name Resolution

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -205,16 +205,48 @@ bool Output::validate(string* message) const
 // InterfaceElement methods
 //
 
-ValuePtr InterfaceElement::getParameterValue(const string& name) const
+ValuePtr InterfaceElement::getParameterValue(const string& name, const string& target) const
 {
-    ParameterPtr param = getChildOfType<Parameter>(name);
-    return param ? param->getValue() : ValuePtr();
+    ParameterPtr param = getParameter(name);
+    if (param)
+    {
+        return param->getValue();
+    }
+
+    // Return the value, if any, stored in our declaration.
+    NodeDefPtr decl = getDeclaration(target);
+    if (decl)
+    {
+        param = decl->getParameter(name);
+        if (param)
+        {
+            return param->getValue();
+        }
+    }
+
+    return ValuePtr();
 }
 
-ValuePtr InterfaceElement::getInputValue(const string& name) const
+ValuePtr InterfaceElement::getInputValue(const string& name, const string& target) const
 {
-    InputPtr input = getChildOfType<Input>(name);
-    return input ? input->getValue() : ValuePtr();
+    InputPtr input = getInput(name);
+    if (input)
+    {
+        return input->getValue();
+    }
+
+    // Return the value, if any, stored in our declaration.
+    NodeDefPtr decl = getDeclaration(target);
+    if (decl)
+    {
+        input = decl->getInput(name);
+        if (input)
+        {
+            return input->getValue();
+        }
+    }
+
+    return ValuePtr();
 }
 
 void InterfaceElement::registerChildElement(ElementPtr child)
@@ -249,6 +281,24 @@ void InterfaceElement::unregisterChildElement(ElementPtr child)
     {
         _outputCount--;
     }
+}
+
+NodeDefPtr InterfaceElement::getDeclaration(const string& target) const
+{
+    if (isA<Node>())
+    {
+        return asA<Node>()->getNodeDef(target);
+    }
+    else if (isA<NodeGraph>())
+    {
+        return asA<NodeGraph>()->getNodeDef();
+    }
+    else if (isA<Implementation>())
+    {
+        return asA<Implementation>()->getNodeDef();
+    }
+
+    return NodeDefPtr();
 }
 
 bool InterfaceElement::isTypeCompatible(InterfaceElementPtr rhs) const

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -189,9 +189,6 @@ class Input : public PortElement
     }
     virtual ~Input() { }
 
-  protected:
-    using NodePtr = shared_ptr<class Node>;
-
   public:
     /// @name Traversal
     /// @{
@@ -223,9 +220,6 @@ class Output : public PortElement
     {
     }
     virtual ~Output() { }
-
-  protected:
-    using NodePtr = shared_ptr<class Node>;
 
   public:
     /// @name Traversal
@@ -278,7 +272,7 @@ class InterfaceElement : public TypedElement
     virtual ~InterfaceElement() { }
 
   protected:
-    using NodePtr = shared_ptr<class Node>;
+    using NodeDefPtr = shared_ptr<class NodeDef>;
 
   public:
     /// @name Parameters
@@ -414,11 +408,15 @@ class InterfaceElement : public TypedElement
                                                      const T& value,
                                                      const string& type = EMPTY_STRING);
 
-    /// Return the typed value of a parameter by its name.
+    /// Return the typed value of a parameter by its name, with interface
+    /// declarations optionally filtered by the given target string.
     /// @param name The name of the parameter to be evaluated.
-    /// @return If the given parameter is present, then a shared pointer to its
-    ///    value is returned; otherwise, an empty shared pointer is returned.
-    ValuePtr getParameterValue(const string& name) const;
+    /// @param target An optional target name, which will be used to filter
+    ///    the declarations that are considered.
+    /// @return If the given parameter is found in this interface or its
+    ///    declaration, then a shared pointer to its value is returned;
+    ///    otherwise, an empty shared pointer is returned.
+    ValuePtr getParameterValue(const string& name, const string& target = EMPTY_STRING) const;
 
     /// Set the typed value of an input by its name, creating a child element
     /// to hold the input if needed.
@@ -426,15 +424,26 @@ class InterfaceElement : public TypedElement
                                              const T& value,
                                              const string& type = EMPTY_STRING);
 
-    /// Return the typed value of an input by its name.
-    /// @param name The name of the input to be evaluated.
-    /// @return If the given input is present, then a shared pointer to its
-    ///    value is returned; otherwise, an empty shared pointer is returned.
-    ValuePtr getInputValue(const string& name) const;
+    /// Return the typed value of an input by its name, with interface
+    /// declarations optionally filtered by the given target string.
+    /// @param target An optional target name, which will be used to filter
+    ///    the declarations that are considered.
+    /// @return If the given parameter is found in this interface or its
+    ///    declaration, then a shared pointer to its value is returned;
+    ///    otherwise, an empty shared pointer is returned.
+    ValuePtr getInputValue(const string& name, const string& target = EMPTY_STRING) const;
 
     /// @}
     /// @name Utility
     /// @{
+
+    /// Return the first declaration of this interface, optionally filtered
+    ///    by the given target name.
+    /// @param target An optional target name, which will be used to filter
+    ///    the declarations that are considered.
+    /// @return A shared pointer to nodedef, or an empty shared pointer if
+    ///    no declaration was found.
+    NodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const;
 
     /// Return true if the given interface element is type compatible with
     /// this one.  This may be used to test, for example, whether a NodeDef

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -66,6 +66,19 @@ TEST_CASE("Node", "[node]")
     REQUIRE(constant->getDownstreamPorts()[0] == output1);
     REQUIRE(image->getDownstreamPorts()[0] == output2);
 
+    // Create a custom nodedef.
+    mx::NodeDefPtr nodeDef = doc->addNodeDef("nodeDef1", "float", "turbulence3d");
+    nodeDef->setParameterValue("octaves", 3);
+    nodeDef->setParameterValue("lacunarity", 2.0f);
+    nodeDef->setParameterValue("gain", 0.5f);
+
+    // Reference the custom nodedef.
+    mx::NodePtr custom = nodeGraph->addNode("turbulence3d", "turbulence1", "float");
+    REQUIRE(custom->getParameterValue("octaves")->isA<int>());
+    REQUIRE(custom->getParameterValue("octaves")->asA<int>() == 3);
+    custom->setParameterValue("octaves", 5);
+    REQUIRE(custom->getParameterValue("octaves")->asA<int>() == 5);
+
     // Define a custom type.
     mx::TypeDefPtr typeDef = doc->addTypeDef("spectrum");
     const int scalarCount = 10;
@@ -84,6 +97,9 @@ TEST_CASE("Node", "[node]")
     REQUIRE(constant->getParameterValue("value")->isA<std::string>());
     REQUIRE(constant->getParameterValue("value")->asA<std::string>() == d65);
 
+    // Validate the document.
+    REQUIRE(doc->validate());
+
     // Disconnect outputs from sources.
     output1->setConnectedNode(nullptr);
     output2->setConnectedNode(nullptr);
@@ -95,6 +111,7 @@ TEST_CASE("Node", "[node]")
     // Remove nodes and outputs.
     nodeGraph->removeNode(image->getName());
     nodeGraph->removeNode(constant->getName());
+    nodeGraph->removeNode(custom->getName());
     nodeGraph->removeOutput(output1->getName());
     nodeGraph->removeOutput(output2->getName());
     REQUIRE(nodeGraph->getChildren().empty());

--- a/source/PyMaterialX/PyInterface.cpp
+++ b/source/PyMaterialX/PyInterface.cpp
@@ -57,6 +57,8 @@ void bindPyInterface(py::module& mod)
         .def("getOutputCount", &mx::InterfaceElement::getOutputCount)
         .def("_getParameterValue", &mx::InterfaceElement::getParameterValue)
         .def("_getInputValue", &mx::InterfaceElement::getInputValue)
+        .def("getDeclaration", &mx::InterfaceElement::getDeclaration,
+            py::arg("target") = mx::EMPTY_STRING)
         .def("isTypeCompatible", &mx::InterfaceElement::isTypeCompatible)
         BIND_INTERFACE_TYPE_INSTANCE(integer, int)
         BIND_INTERFACE_TYPE_INSTANCE(boolean, bool)


### PR DESCRIPTION
With this changelist, the InterfaceElement methods getParameterValue and getInputValue now respect values stored in the interface declaration of the calling element.