### PR TITLE
Add PropertySet methods setPropertyValue and getPropertyValue

### DIFF
--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -101,9 +101,9 @@ def _setParameterValue(self, name, value, typeString = ''):
     return method(self, name, value, typeString)
 
 def _getParameterValue(self, name, target = ''):
-    """Return the typed value of a parameter by its name.  If the given
-       parameter is not found in either the interface or its declaration,
-       then None is returned."""
+    """Return the typed value of a parameter by its name, taking both the
+       calling element and its declaration into account.  If the given
+       parameter is not found, then None is returned."""
     value = self._getParameterValue(name, target)
     return value.getData() if value else None
 
@@ -121,9 +121,9 @@ def _setInputValue(self, name, value, typeString = ''):
     return method(self, name, value, typeString)
 
 def _getInputValue(self, name, target = ''):
-    """Return the typed value of an input by its name.  If the given
-       input is not found in either the interface or its declaration,
-       then None is returned."""
+    """Return the typed value of an input by its name, taking both the
+       calling element and its declaration into account.  If the given
+       input is not found, then None is returned."""
     value = self._getInputValue(name, target)
     return value.getData() if value else None
 
@@ -196,6 +196,26 @@ def _getReferencedShaderDef(self):
     return self.getNodeDef()
 
 ShaderRef.getReferencedShaderDef = _getReferencedShaderDef
+
+
+#
+# PropertySet
+#
+
+def _setPropertyValue(self, name, value, typeString = ''):
+    """Set the typed value of a property by its name, creating a child element
+       to hold the property if needed."""
+    method = getattr(self.__class__, "_setPropertyValue" + typeToName(value.__class__))
+    return method(self, name, value, typeString)
+
+def _getPropertyValue(self, name, target = ''):
+    """Return the typed value of a property by its name.  If the given property
+       is not found, then None is returned."""
+    value = self._getPropertyValue(name)
+    return value.getData() if value else None
+
+PropertySet.setPropertyValue = _setPropertyValue
+PropertySet.getPropertyValue = _getPropertyValue
 
 
 #

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -101,15 +101,15 @@ class TestMaterialX(unittest.TestCase):
         self.assertTrue(image.getParameterValue('file') == file)
 
         # Create a custom nodedef.
-        nodeDef = doc.addNodeDef('nodeDef1', 'float', 'turbulence3d');
-        nodeDef.setParameterValue('octaves', 3);
-        nodeDef.setParameterValue('lacunarity', 2.0);
-        nodeDef.setParameterValue('gain', 0.5);
+        nodeDef = doc.addNodeDef('nodeDef1', 'float', 'turbulence3d')
+        nodeDef.setParameterValue('octaves', 3)
+        nodeDef.setParameterValue('lacunarity', 2.0)
+        nodeDef.setParameterValue('gain', 0.5)
 
         # Reference the custom nodedef.
-        custom = nodeGraph.addNode('turbulence3d', 'turbulence1', 'float');
+        custom = nodeGraph.addNode('turbulence3d', 'turbulence1', 'float')
         self.assertTrue(custom.getParameterValue('octaves') == 3)
-        custom.setParameterValue('octaves', 5);
+        custom.setParameterValue('octaves', 5)
         self.assertTrue(custom.getParameterValue('octaves') == 5)
 
         # Validate the document.
@@ -187,6 +187,14 @@ class TestMaterialX(unittest.TestCase):
         propertyAssign.setValue(True)
         self.assertTrue(propertyAssign.getGeom() == "/robot1")
         self.assertTrue(propertyAssign.getValue() == True)
+
+        # Create a property set assignment.
+        propertySet = doc.addPropertySet()
+        propertySet.setPropertyValue('matte', False)
+        self.assertTrue(propertySet.getPropertyValue('matte') == False)
+        propertySetAssign = look.addPropertySetAssign(propertySet.getName())
+        propertySetAssign.setGeom('/robot1')
+        self.assertTrue(propertySetAssign.getGeom() == '/robot1')
 
         # Generate and verify require string.
         doc.generateRequireString()

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -408,8 +408,8 @@ class InterfaceElement : public TypedElement
                                                      const T& value,
                                                      const string& type = EMPTY_STRING);
 
-    /// Return the typed value of a parameter by its name, with interface
-    /// declarations optionally filtered by the given target string.
+    /// Return the typed value of a parameter by its name, taking both the
+    /// calling element and its declaration into account.
     /// @param name The name of the parameter to be evaluated.
     /// @param target An optional target name, which will be used to filter
     ///    the declarations that are considered.
@@ -424,8 +424,8 @@ class InterfaceElement : public TypedElement
                                              const T& value,
                                              const string& type = EMPTY_STRING);
 
-    /// Return the typed value of an input by its name, with interface
-    /// declarations optionally filtered by the given target string.
+    /// Return the typed value of an input by its name, taking both the calling
+    /// element and its declaration into account.
     /// @param target An optional target name, which will be used to filter
     ///    the declarations that are considered.
     /// @return If the given parameter is found in this interface or its

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -119,6 +119,9 @@ class PropertySet : public Element
     }
     virtual ~PropertySet() { }
 
+    /// @name Properties
+    /// @{
+
     /// Add a Property to the set.
     /// @param name The name of the new Property.
     ///     If no name is specified, then a unique name will automatically be
@@ -126,9 +129,6 @@ class PropertySet : public Element
     /// @return A shared pointer to the new Property.
     PropertyPtr addProperty(const string& name)
     {
-        PropertyPtr assignPtr = getChildOfType<Property>(name);
-        if (assignPtr)
-            return assignPtr;
         return addChild<Property>(name);
     }
 
@@ -150,7 +150,36 @@ class PropertySet : public Element
         removeChildOfType<Property>(name);
     }
 
-  public:
+    /// @}
+    /// @name Values
+    /// @{
+
+    /// Set the typed value of a property by its name, creating a child element
+    /// to hold the property if needed.
+    template<class T> PropertyPtr setPropertyValue(const string& name,
+                                                   const T& value,
+                                                   const string& type = EMPTY_STRING)
+    {
+        PropertyPtr property = getChildOfType<Property>(name);
+        if (!property)
+            property = addProperty(name);
+        property->setValue(value, type);
+        return property;
+    }
+
+    /// Return the typed value of a property by its name.
+    /// @param name The name of the property to be evaluated.
+    /// @return If the given property is found, then a shared pointer to its
+    ///    value is returned; otherwise, an empty shared pointer is returned.
+    ValuePtr getPropertyValue(const string& name) const
+    {
+        PropertyPtr property = getProperty(name);
+        return property ? property->getValue() : ValuePtr();
+    }
+
+    /// @}
+
+public:
     static const string CATEGORY;
 };
 

--- a/source/MaterialXTest/Look.cpp
+++ b/source/MaterialXTest/Look.cpp
@@ -46,13 +46,12 @@ TEST_CASE("Look", "[look]")
 
     // Create a property set assignment.
     mx::PropertySetPtr propertySet = doc->addPropertySet();
-    REQUIRE(doc->getPropertySets().size() == 1);
-    mx::PropertyPtr property = propertySet->addProperty("matte");
-    property->setValue(false);
-    REQUIRE(property->getValue()->isA<bool>());
-    REQUIRE(property->getValue()->asA<bool>() == false);
+    propertySet->setPropertyValue("matte", false);
+    REQUIRE(propertySet->getPropertyValue("matte")->isA<bool>());
+    REQUIRE(propertySet->getPropertyValue("matte")->asA<bool>() == false);
     mx::PropertySetAssignPtr propertySetAssign = look->addPropertySetAssign(propertySet->getName());
-    REQUIRE(look->getPropertySetAssigns().size() == 1);
+    propertySetAssign->setGeom("/robot1");
+    REQUIRE(propertySetAssign->getGeom() == "/robot1");
 
     // Create a visibility element.
     mx::VisibilityPtr visibility = look->addVisibility();

--- a/source/PyMaterialX/PyProperty.cpp
+++ b/source/PyMaterialX/PyProperty.cpp
@@ -10,6 +10,9 @@
 namespace py = pybind11;
 namespace mx = MaterialX;
 
+#define BIND_PROPERTYSET_TYPE_INSTANCE(NAME, T) \
+.def("_setPropertyValue" #NAME, &mx::PropertySet::setPropertyValue<T>, py::arg("name"), py::arg("value"), py::arg("type") = mx::EMPTY_STRING)
+
 void bindPyProperty(py::module& mod)
 {
     py::class_<mx::Property, mx::PropertyPtr, mx::ValueElement>(mod, "Property")
@@ -30,6 +33,19 @@ void bindPyProperty(py::module& mod)
         .def("addProperty", &mx::PropertySet::addProperty)
         .def("getProperties", &mx::PropertySet::getProperties)
         .def("removeProperty", &mx::PropertySet::removeProperty)
+        .def("_getPropertyValue", &mx::PropertySet::getPropertyValue)
+        BIND_PROPERTYSET_TYPE_INSTANCE(integer, int)
+        BIND_PROPERTYSET_TYPE_INSTANCE(boolean, bool)
+        BIND_PROPERTYSET_TYPE_INSTANCE(float, float)
+        BIND_PROPERTYSET_TYPE_INSTANCE(color2, mx::Color2)
+        BIND_PROPERTYSET_TYPE_INSTANCE(color3, mx::Color3)
+        BIND_PROPERTYSET_TYPE_INSTANCE(color4, mx::Color4)
+        BIND_PROPERTYSET_TYPE_INSTANCE(vector2, mx::Vector2)
+        BIND_PROPERTYSET_TYPE_INSTANCE(vector3, mx::Vector3)
+        BIND_PROPERTYSET_TYPE_INSTANCE(vector4, mx::Vector4)
+        BIND_PROPERTYSET_TYPE_INSTANCE(matrix33, mx::Matrix3x3)
+        BIND_PROPERTYSET_TYPE_INSTANCE(matrix44, mx::Matrix4x4)
+        BIND_PROPERTYSET_TYPE_INSTANCE(string, std::string)
         .def_readonly_static("CATEGORY", &mx::Property::CATEGORY);
 
     py::class_<mx::PropertySetAssign, mx::PropertySetAssignPtr, mx::GeomElement>(mod, "PropertySetAssign")


### PR DESCRIPTION
This changelist adds two helper methods to the PropertySet class, setPropertyValue and getPropertyValue, allowing property values to be accessed in a single call.  Also:

- Align behavior of PropertySet::addProperty with other element add methods.
- Clarify documentation for value accessor methods in InterfaceElement.
- Minor improvements to unit tests.