### PR TITLE
Fix fallback for missing attributes in getTypedAttribute

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -402,7 +402,9 @@ class Element : public std::enable_shared_from_this<Element>
     /// type, then the zero value for the given data type is returned.
     template<class T> const T getTypedAttribute(const string& attrib) const
     {
-        return fromValueString<T>(getAttribute(attrib));
+        if (hasAttribute(attrib))
+            return fromValueString<T>(getAttribute(attrib));
+        return {};
     }
 
     /// Remove the given attribute, if present.

--- a/source/MaterialXTest/Look.cpp
+++ b/source/MaterialXTest/Look.cpp
@@ -55,7 +55,9 @@ TEST_CASE("Look", "[look]")
 
     // Create a visibility element.
     mx::VisibilityPtr visibility = look->addVisibility();
-    REQUIRE(look->getVisibilities().size() == 1);
+    REQUIRE(visibility->getVisible() == false);
+    visibility->setVisible(true);
+    REQUIRE(visibility->getVisible() == true);
     visibility->setGeom("/robot2");
     REQUIRE(visibility->getGeom() == "/robot2");
     visibility->setCollection(collection);


### PR DESCRIPTION
This changelist fixes the fallback logic for missing attributes in getTypedAttribute, aligning its behavior with its documentation.