### PR TITLE
Initial support for arithmetic operators on vector, color, and matrix classes

### DIFF
--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -21,4 +21,13 @@ const string NAME_PATH_SEPARATOR = "/";
 const string ARRAY_VALID_SEPARATORS = ", ";
 const string ARRAY_PREFERRED_SEPARATOR = ", ";
 
+Matrix3x3 Matrix3x3::IDENTITY{1, 0, 0,
+                              0, 1, 0,
+                              0, 0, 1};
+
+Matrix4x4 Matrix4x4::IDENTITY{1, 0, 0, 0,
+                              0, 1, 0, 0,
+                              0, 0, 1, 0,
+                              0, 0, 0, 1};
+
 } // namespace MaterialX

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -41,11 +41,108 @@ template <size_t N> class VectorN : public VectorBase
     explicit VectorN(const std::array<float, N>& arr) : data(arr) { }
     explicit VectorN(const vector<float>& vec) { std::copy_n(vec.begin(), N, data.begin()); }
 
+    //
+    // Equality operators
+    //
+
     bool operator==(const VectorN& rhs) const { return data == rhs.data; }
     bool operator!=(const VectorN& rhs) const { return data != rhs.data; }
 
+    //
+    // Indexing operators
+    //
+
     float operator[](size_t i) const { return data.at(i); }
     float& operator[](size_t i) { return data.at(i); }
+
+    //
+    // Component-wise addition
+    //
+
+    VectorN operator+(const VectorN& rhs) const
+    {
+        VectorN res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = data[i] + rhs[i];
+        return res;
+    }
+    VectorN& operator+=(const VectorN& rhs)
+    {
+        for (size_t i = 0; i < N; i++)
+            data[i] += rhs[i];
+        return *this;
+    }
+
+    //
+    // Component-wise subtraction
+    //
+
+    VectorN operator-(const VectorN& rhs) const
+    {
+        VectorN res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = data[i] - rhs[i];
+        return res;
+    }
+    VectorN& operator-=(const VectorN& rhs)
+    {
+        for (size_t i = 0; i < N; i++)
+            data[i] -= rhs[i];
+        return *this;
+    }
+
+    //
+    // Component-wise multiplication
+    //
+
+    VectorN operator*(const VectorN& rhs) const
+    {
+        VectorN res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = data[i] * rhs[i];
+        return res;
+    }
+    VectorN& operator*=(const VectorN& rhs)
+    {
+        for (size_t i = 0; i < N; i++)
+            data[i] *= rhs[i];
+        return *this;
+    }
+
+    //
+    // Component-wise division
+    //
+
+    VectorN operator/(const VectorN& rhs) const
+    {
+        VectorN res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = data[i] / rhs[i];
+        return res;
+    }
+    VectorN& operator/=(const VectorN& rhs)
+    {
+        for (size_t i = 0; i < N; i++)
+            data[i] /= rhs[i];
+        return *this;
+    }
+
+    //
+    // Iterators
+    //
+
+    using iterator = typename std::array<float, N>::iterator;
+    using const_iterator = typename std::array<float, N>::const_iterator;
+
+    iterator begin() { return data.begin(); }
+    const_iterator begin() const { return data.begin(); }
+
+    iterator end() { return data.end(); }
+    const_iterator end() const { return data.end(); }
+
+    //
+    // Static methods
+    //
 
     static size_t length() { return N; }
 
@@ -59,6 +156,7 @@ class Vector2 : public VectorN<2>
   public:
     using VectorN<2>::VectorN;
     Vector2() { }
+    Vector2(const VectorN<2>& v) { data = v.data; }
     Vector2(float x, float y) { data = {x, y}; }
 };
 
@@ -68,6 +166,7 @@ class Vector3 : public VectorN<3>
   public:
     using VectorN<3>::VectorN;
     Vector3() { }
+    Vector3(const VectorN<3>& v) { data = v.data; }
     Vector3(float x, float y, float z) { data = {x, y, z}; }
 };
 
@@ -77,21 +176,8 @@ class Vector4 : public VectorN<4>
   public:
     using VectorN<4>::VectorN;
     Vector4() { }
+    Vector4(const VectorN<4>& v) { data = v.data; }
     Vector4(float x, float y, float z, float w) { data = {x, y, z, w}; }
-};
-
-/// A 3x3 matrix of floating-point values
-class Matrix3x3 : public VectorN<9>
-{
-  public:
-    using VectorN<9>::VectorN;
-};
-
-/// A 4x4 matrix of floating-point values
-class Matrix4x4 : public VectorN<16>
-{
-  public:
-    using VectorN<16>::VectorN;
 };
 
 /// A two-component color value
@@ -115,10 +201,86 @@ class Color4 : public Vector4
     using Vector4::Vector4;
 };
 
-// Standard vector aliases
-using IntVec = vector<int>;
-using BoolVec = vector<bool>;
-using FloatVec = vector<float>;
+/// The class template for square matrix subclasses of VectorBase
+template <size_t N> class MatrixNxN : public VectorN<N*N>
+{
+  public:
+    using VectorN<N*N>::VectorN;
+
+    //
+    // Matrix indexing
+    //
+
+    float& at(size_t row, size_t col)
+    {
+        return VectorN<N*N>::data[row * N + col];
+    }
+    const float& at(size_t row, size_t col) const
+    {
+        return VectorN<N*N>::data[row * N + col];
+    }
+
+    //
+    // Matrix multiplication
+    //
+
+    MatrixNxN operator*(const MatrixNxN& rhs) const
+    {
+        MatrixNxN res;
+        for (size_t i = 0; i < N; i++)
+            for (size_t j = 0; j < N; j++)
+                for (size_t k = 0; k < N; k++)
+                    res.at(i, j) += at(i, k) * rhs.at(k, j);
+        return res;
+    }
+    MatrixNxN& operator*=(const MatrixNxN& rhs)
+    {
+        *this = *this * rhs;
+        return *this;
+    }
+};
+
+/// A 3x3 matrix of floating-point values
+class Matrix3x3 : public MatrixNxN<3>
+{
+  public:
+    using MatrixNxN<3>::MatrixNxN;
+    Matrix3x3() { }
+    Matrix3x3(const VectorN<9>& m) { data = m.data; }
+    Matrix3x3(float m00, float m01, float m02,
+              float m10, float m11, float m12,
+              float m20, float m21, float m22)
+    {
+        data = {m00, m01, m02,
+                m10, m11, m12,
+                m20, m21, m22};
+    }
+
+  public:
+    static Matrix3x3 IDENTITY;
+};
+
+/// A 4x4 matrix of floating-point values
+class Matrix4x4 : public MatrixNxN<4>
+{
+  public:
+    using MatrixNxN<4>::MatrixNxN;
+    Matrix4x4() { }
+    Matrix4x4(const VectorN<16>& m) { data = m.data; }
+    Matrix4x4(float m00, float m01, float m02, float m03,
+              float m10, float m11, float m12, float m13,
+              float m20, float m21, float m22, float m23,
+              float m30, float m31, float m32, float m33)
+    {
+        data = {m00, m01, m02, m03,
+                m10, m11, m12, m13,
+                m20, m21, m22, m23,
+                m30, m31, m32, m33};
+    }
+
+  public:
+    static Matrix4x4 IDENTITY;
+};
 
 } // namespace MaterialX
 

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -217,6 +217,10 @@ template <class T> class ValueRegistry
 // Template instantiations
 //
 
+using IntVec = vector<int>;
+using BoolVec = vector<bool>;
+using FloatVec = vector<float>;
+
 #define INSTANTIATE_TYPE(T, name)                       \
 template <> const string TypedValue<T>::TYPE = name;    \
 template bool Value::isA<T>() const;                    \

--- a/source/MaterialXTest/Types.cpp
+++ b/source/MaterialXTest/Types.cpp
@@ -1,0 +1,62 @@
+//
+// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXTest/Catch/catch.hpp>
+
+#include <MaterialXCore/Types.h>
+
+namespace mx = MaterialX;
+
+TEST_CASE("Vector operators", "[types]")
+{
+    mx::Vector3 v1(1, 2, 3);
+    mx::Vector3 v2(2, 4, 6);
+
+    // Indexing operators
+    REQUIRE(v1[2] == 3);
+    v1[2] = 4;
+    REQUIRE(v1[2] == 4);
+    v1[2] = 3;
+
+    // Component-wise operators
+    REQUIRE(v2 + v1 == mx::Vector3(3, 6, 9));
+    REQUIRE(v2 - v1 == mx::Vector3(1, 2, 3));
+    REQUIRE(v2 * v1 == mx::Vector3(2, 8, 18));
+    REQUIRE(v2 / v1 == mx::Vector3(2, 2, 2));
+    REQUIRE((v2 += v1) == mx::Vector3(3, 6, 9));
+    REQUIRE((v2 -= v1) == mx::Vector3(2, 4, 6));
+    REQUIRE((v2 *= v1) == mx::Vector3(2, 8, 18));
+    REQUIRE((v2 /= v1) == mx::Vector3(2, 4, 6));
+}
+
+TEST_CASE("Matrix operators", "[types]")
+{
+    mx::Matrix4x4 scale(2, 0, 0, 0,
+                        0, 2, 0, 0,
+                        0, 0, 2, 0,
+                        0, 0, 0, 1);
+    mx::Matrix4x4 trans(1, 0, 0, 0,
+                        0, 1, 0, 0,
+                        0, 0, 1, 0,
+                        3, 0, 0, 1);
+
+    mx::Matrix4x4 prod1 = scale * trans;
+    REQUIRE(prod1 == mx::Matrix4x4(2, 0, 0, 0,
+                                   0, 2, 0, 0,
+                                   0, 0, 2, 0,
+                                   3, 0, 0, 1));
+
+    mx::Matrix4x4 prod2 = trans * scale;
+    REQUIRE(prod2 == mx::Matrix4x4(2, 0, 0, 0,
+                                   0, 2, 0, 0,
+                                   0, 0, 2, 0,
+                                   6, 0, 0, 1));
+
+    prod2 *= trans;
+    REQUIRE(prod2 == mx::Matrix4x4(2, 0, 0, 0,
+                                   0, 2, 0, 0,
+                                   0, 0, 2, 0,
+                                   9, 0, 0, 1));
+}

--- a/source/MaterialXTest/Value.cpp
+++ b/source/MaterialXTest/Value.cpp
@@ -91,14 +91,14 @@ TEST_CASE("Typed values", "[value]")
                    std::string("second_value"));
 
     // Array types
-    testTypedValue(mx::IntVec{1, 2, 3},
-                   mx::IntVec{4, 5, 6});
-    testTypedValue(mx::BoolVec{false, false, false},
-                   mx::BoolVec{true, true, true});
-    testTypedValue(mx::FloatVec{1.0f, 2.0f, 3.0f},
-                   mx::FloatVec{4.0f, 5.0f, 6.0f});
-    testTypedValue(mx::StringVec{"one", "two", "three"},
-                   mx::StringVec{"four", "five", "six"});
+    testTypedValue(std::vector<int>{1, 2, 3},
+                   std::vector<int>{4, 5, 6});
+    testTypedValue(std::vector<bool>{false, false, false},
+                   std::vector<bool>{true, true, true});
+    testTypedValue(std::vector<float>{1.0f, 2.0f, 3.0f},
+                   std::vector<float>{4.0f, 5.0f, 6.0f});
+    testTypedValue(std::vector<std::string>{"one", "two", "three"},
+                   std::vector<std::string>{"four", "five", "six"});
 
     // Alias types
     testTypedValue<long>(1l, 2l);

--- a/source/PyMaterialX/PyTypes.cpp
+++ b/source/PyMaterialX/PyTypes.cpp
@@ -14,123 +14,72 @@
 namespace py = pybind11;
 namespace mx = MaterialX;
 
+#define BIND_VECTOR_SUBCLASS(T, N)                          \
+.def(py::init<>())                                          \
+.def(py::init<float>())                                     \
+.def(py::init<const std::array<float, N>&>())               \
+.def(py::init<const std::vector<float>&>())                 \
+.def(py::self == py::self)                                  \
+.def(py::self != py::self)                                  \
+.def("__add__", [](const T& v1, const T& v2)                \
+    { return T(v1 + v2); } )                                \
+.def("__sub__", [](const T& v1, const T& v2)                \
+    { return T(v1 - v2); } )                                \
+.def("__mul__", [](const T& v1, const T& v2)                \
+    { return T(v1 * v2); } )                                \
+.def("__div__", [](const T& v1, const T& v2)                \
+    { return T(v1 / v2); } )                                \
+.def("__getitem__", [](T& vec, size_t i)                    \
+    { return vec[i]; } )                                    \
+.def("__setitem__", [](T& vec, size_t i, float value)       \
+    { vec[i] = value; } )                                   \
+.def("__str__", [](const T& vec)                            \
+    { return mx::toValueString(vec); })                     \
+.def("copy", [](const T& vec) { return T(vec); })           \
+.def("asTuple", [](const mx::Vector2& vec)                  \
+    { return std::make_tuple(vec[0], vec[1]); })            \
+.def_static("__len__", &T::length)
+
 void bindPyTypes(py::module& mod)
 {
     py::class_<mx::VectorBase>(mod, "VectorBase");
 
     py::class_<mx::Vector2, mx::VectorBase>(mod, "Vector2")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<float, float>())
-        .def(py::init<const mx::Vector2&>())
-        .def(py::init<const std::array<float, 2>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def("copy", [](const mx::Vector2 &vec) { return mx::Vector2(vec); })
-        .def("asTuple", [](const mx::Vector2 &vec) { return std::make_tuple(vec[0], vec[1]); })
-        .def("__getitem__", [](mx::Vector2& vec, size_t i) { return vec[i]; } )
-        .def("__setitem__", [](mx::Vector2& vec, size_t i, float value) { vec[i] = value; } )
-        .def("__iter__", [](const mx::Vector2& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
-            py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Vector2& vec) { return mx::toValueString(vec); })
-        .def_static("__len__", &mx::Vector2::length);
+        BIND_VECTOR_SUBCLASS(mx::Vector2, 2)
+        .def(py::init<float, float>());
 
     py::class_<mx::Vector3, mx::VectorBase>(mod, "Vector3")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<float, float, float>())
-        .def(py::init<const mx::Vector3&>())
-        .def(py::init<const std::array<float, 3>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def("copy", [](const mx::Vector3 &vec) { return mx::Vector3(vec); })
-        .def("asTuple", [](const mx::Vector3 &vec) { return std::make_tuple(vec[0], vec[1], vec[2]); })
-        .def("__getitem__", [](mx::Vector3& vec, size_t i) { return vec[i]; } )
-        .def("__setitem__", [](mx::Vector3& vec, size_t i, float value) { vec[i] = value; } )
-        .def("__iter__", [](const mx::Vector3& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
-            py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Vector3& vec) { return mx::toValueString(vec); })
-        .def_static("__len__", &mx::Vector3::length);
+        BIND_VECTOR_SUBCLASS(mx::Vector3, 3)
+        .def(py::init<float, float, float>());
 
     py::class_<mx::Vector4, mx::VectorBase>(mod, "Vector4")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<float, float, float, float>())
-        .def(py::init<const mx::Vector4&>())
-        .def(py::init<const std::array<float, 4>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def("copy", [](const mx::Vector4 &vec) { return mx::Vector4(vec); })
-        .def("asTuple", [](const mx::Vector4 &vec) { return std::make_tuple(vec[0], vec[1], vec[2], vec[3]); })
-        .def("__getitem__", [](mx::Vector4& vec, size_t i) { return vec[i]; } )
-        .def("__setitem__", [](mx::Vector4& vec, size_t i, float value) { vec[i] = value; } )
-        .def("__iter__", [](const mx::Vector4& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
-            py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Vector4& vec) { return mx::toValueString(vec); })
-        .def_static("__len__", &mx::Vector4::length);
-
-    py::class_<mx::Matrix3x3, mx::VectorBase>(mod, "Matrix3x3")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<const mx::Matrix3x3&>())
-        .def(py::init<const std::array<float, 9>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def("copy", [](const mx::Matrix3x3 &vec) { return mx::Matrix3x3(vec); })
-        .def("__getitem__", [](mx::Matrix3x3& vec, size_t i) { return vec[i]; } )
-        .def("__setitem__", [](mx::Matrix3x3& vec, size_t i, float value) { vec[i] = value; } )
-        .def("__iter__", [](const mx::Matrix3x3& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
-            py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Matrix3x3& vec) { return mx::toValueString(vec); })
-        .def_static("__len__", &mx::Matrix3x3::length);
-
-    py::class_<mx::Matrix4x4, mx::VectorBase>(mod, "Matrix4x4")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<const mx::Matrix4x4&>())
-        .def(py::init<const std::array<float, 16>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def("copy", [](const mx::Matrix4x4 &vec) { return mx::Matrix4x4(vec); })
-        .def("__getitem__", [](mx::Matrix4x4& vec, size_t i) { return vec[i]; } )
-        .def("__setitem__", [](mx::Matrix4x4& vec, size_t i, float value) { vec[i] = value; } )
-        .def("__iter__", [](const mx::Matrix4x4& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
-            py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Matrix4x4& vec) { return mx::toValueString(vec); })
-        .def_static("__len__", &mx::Matrix4x4::length);
+        BIND_VECTOR_SUBCLASS(mx::Vector4, 4)
+        .def(py::init<float, float, float, float>());
 
     py::class_<mx::Color2, mx::Vector2>(mod, "Color2")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<float, float>())
-        .def(py::init<const mx::Color2&>())
-        .def(py::init<const std::array<float, 2>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self);
+        BIND_VECTOR_SUBCLASS(mx::Color2, 2)
+        .def(py::init<float, float>());
 
     py::class_<mx::Color3, mx::Vector3>(mod, "Color3")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<float, float, float>())
-        .def(py::init<const mx::Color3&>())
-        .def(py::init<const std::array<float, 3>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self);
+        BIND_VECTOR_SUBCLASS(mx::Color3, 3)
+        .def(py::init<float, float, float>());
 
     py::class_<mx::Color4, mx::Vector4>(mod, "Color4")
-        .def(py::init<>())
-        .def(py::init<float>())
-        .def(py::init<float, float, float, float>())
-        .def(py::init<const mx::Color4&>())
-        .def(py::init<const std::array<float, 4>&>())
-        .def(py::init<const std::vector<float>&>())
-        .def(py::self == py::self)
-        .def(py::self != py::self);
+        BIND_VECTOR_SUBCLASS(mx::Color4, 4)
+        .def(py::init<float, float, float, float>());
+
+    py::class_<mx::Matrix3x3, mx::VectorBase>(mod, "Matrix3x3")
+        BIND_VECTOR_SUBCLASS(mx::Matrix3x3, 9)
+        .def(py::init<float, float, float,
+                      float, float, float,
+                      float, float, float>())
+        .def_readonly_static("IDENTITY", &mx::Matrix3x3::IDENTITY);
+
+    py::class_<mx::Matrix4x4, mx::VectorBase>(mod, "Matrix4x4")
+        BIND_VECTOR_SUBCLASS(mx::Matrix4x4, 16)
+        .def(py::init<float, float, float, float,
+                      float, float, float, float,
+                      float, float, float, float,
+                      float, float, float, float>())
+        .def_readonly_static("IDENTITY", &mx::Matrix4x4::IDENTITY);
 }


### PR DESCRIPTION
This changelist adds initial support for arithmetic operators on the vector, color, and matrix classes, including:

- Component-wise addition, subtraction, multiplication, and division for vectors.
- Matrix multiplication (though not yet matrix division).
- Identity constants for 3x3 and 4x4 matrices.