### PR TITLE
Remove version constants from public headers

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -12,9 +12,6 @@
 namespace MaterialX
 {
 
-const string DOCUMENT_VERSION_STRING = std::to_string(MAJOR_VERSION) + "." +
-                                       std::to_string(MINOR_VERSION);
-
 const string Document::VERSION_ATTRIBUTE = "version";
 const string Document::REQUIRE_ATTRIBUTE = "require";
 const string Document::CMS_ATTRIBUTE = "cms";
@@ -24,6 +21,9 @@ const string Document::REQUIRE_STRING_MATNODEGRAPH = "matnodegraph";
 const string Document::REQUIRE_STRING_OVERRIDE = "override";
 
 namespace {
+
+const string DOCUMENT_VERSION_STRING = std::to_string(MATERIALX_MAJOR_VERSION) + "." +
+                                       std::to_string(MATERIALX_MINOR_VERSION);
 
 template<class T> shared_ptr<T> updateChildSubclass(ElementPtr parent, ElementPtr origChild)
 {
@@ -182,7 +182,8 @@ std::pair<int, int> Document::getVersionIntegers()
     string versionString = getVersionString();
     if (versionString.empty())
     {
-        return std::pair<int, int>(MAJOR_VERSION, MINOR_VERSION);
+        return std::pair<int, int>(MATERIALX_MAJOR_VERSION,
+                                   MATERIALX_MINOR_VERSION);
     }
 
     vector<string> splitVersion = splitString(versionString, ".");
@@ -323,8 +324,11 @@ void Document::upgradeVersion()
     std::pair<int, int> versions = getVersionIntegers();
     int majorVersion = versions.first;
     int minorVersion = versions.second;
-    if (majorVersion == MAJOR_VERSION && minorVersion == MINOR_VERSION)
+    if (majorVersion == MATERIALX_MAJOR_VERSION &&
+        minorVersion == MATERIALX_MINOR_VERSION)
+    {
         return;
+    }
 
     // Upgrade from v1.22 to v1.23
     if (majorVersion == 1 && minorVersion == 22)
@@ -531,7 +535,8 @@ void Document::upgradeVersion()
         minorVersion = 35;
     }
 
-    if (majorVersion == MAJOR_VERSION && minorVersion == MINOR_VERSION)
+    if (majorVersion == MATERIALX_MAJOR_VERSION &&
+        minorVersion == MATERIALX_MINOR_VERSION)
     {
         setVersionString(DOCUMENT_VERSION_STRING);
     }

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -18,8 +18,6 @@
 namespace MaterialX
 {
 
-extern const string DOCUMENT_VERSION_STRING;
-
 /// A shared pointer to a Document
 using DocumentPtr = shared_ptr<class Document>;
 /// A shared pointer to a const Document

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -6,21 +6,21 @@
 #include <MaterialXCore/Util.h>
 
 #include <MaterialXCore/Element.h>
-#include <MaterialXCore/Node.h>
 
 namespace MaterialX
 {
 
-const int MAJOR_VERSION = MATERIALX_MAJOR_VERSION;
-const int MINOR_VERSION = MATERIALX_MINOR_VERSION;
-const int BUILD_VERSION = MATERIALX_BUILD_VERSION;
-
-const string LIBRARY_VERSION_STRING = std::to_string(MAJOR_VERSION) + "." +
-                                      std::to_string(MINOR_VERSION) + "." +
-                                      std::to_string(BUILD_VERSION);
 const string EMPTY_STRING;
 
 namespace {
+
+const string LIBRARY_VERSION_STRING = std::to_string(MATERIALX_MAJOR_VERSION) + "." +
+                                      std::to_string(MATERIALX_MINOR_VERSION) + "." +
+                                      std::to_string(MATERIALX_BUILD_VERSION);
+
+const std::tuple<int, int, int> LIBRARY_VERSION_TUPLE(MATERIALX_MAJOR_VERSION,
+                                                      MATERIALX_MINOR_VERSION,
+                                                      MATERIALX_BUILD_VERSION);
 
 bool invalidNameChar(char c)
 {
@@ -40,9 +40,7 @@ string getVersionString()
 
 std::tuple<int, int, int> getVersionIntegers()
 {
-    return std::make_tuple(MATERIALX_MAJOR_VERSION,
-                           MATERIALX_MINOR_VERSION,
-                           MATERIALX_BUILD_VERSION);
+    return LIBRARY_VERSION_TUPLE;
 }
 
 string createValidName(string name, char replaceChar)

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -14,11 +14,6 @@
 namespace MaterialX
 {
 
-extern const int MAJOR_VERSION;
-extern const int MINOR_VERSION;
-extern const int BUILD_VERSION;
-
-extern const string LIBRARY_VERSION_STRING;
 extern const string EMPTY_STRING;
 
 using ElementPtr = shared_ptr<class Element>;


### PR DESCRIPTION
This changelist removes version constants such as MAJOR_VERSION, MINOR_VERSION, and BUILD_VERSION from public headers, in order to avoid potential collisions with client macros.