### PR TITLE
Fix upgrade path for legacy documents

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -388,15 +388,12 @@ void Document::upgradeVersion()
     {
         for (ElementPtr elem : traverseTree())
         {
-            if (elem->isA<Node>("constant"))
+            if (elem->getCategory() == "constant")
             {
-                NodePtr constant = elem->asA<Node>();
-                ParameterPtr colorParam = constant->getChildOfType<Parameter>("color");
-                if (colorParam)
+                ElementPtr param = elem->getChild("color");
+                if (param)
                 {
-                    ParameterPtr valueParam = constant->addParameter("value");
-                    valueParam->copyContentFrom(colorParam);
-                    constant->removeParameter(colorParam->getName());
+                    param->setName("value");
                 }
             }
         }


### PR DESCRIPTION
This changelist fixes a bug in the upgrade path for constant nodes in v1.25 documents.