### PR TITLE
Extend type aliases to cover all const element pointers

### DIFF
--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -42,6 +42,8 @@ using ConstTypeDefPtr = shared_ptr<const class TypeDef>;
 
 /// A shared pointer to a Member
 using MemberPtr = shared_ptr<class Member>;
+/// A shared pointer to a const Member
+using ConstMemberPtr = shared_ptr<const class Member>;
 
 /// @class NodeDef
 /// A node definition element within a Document.

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -555,7 +555,7 @@ class Document : public Element
     std::unique_ptr<Cache> _cache;
 };
 
-/// @class @ScopedUpdate
+/// @class ScopedUpdate
 /// An RAII class for Document updates.
 ///
 /// A ScopedUpdate instance calls Document::onBeginUpdate when created, and
@@ -577,7 +577,7 @@ class ScopedUpdate
     DocumentPtr _doc;
 };
 
-/// @class @ScopedDisableCallbacks
+/// @class ScopedDisableCallbacks
 /// An RAII class for disabling Document callbacks.
 ///
 /// A ScopedDisableCallbacks instance calls Document::disableCallbacks() when

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1079,7 +1079,7 @@ class CopyOptions
     bool copySourceUris;
 };
 
-/// @class @ExceptionOrphanedElement
+/// @class ExceptionOrphanedElement
 /// An exception that is thrown when an ElementPtr is used after its owning
 /// Document has gone out of scope.
 class ExceptionOrphanedElement : public Exception

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -22,17 +22,33 @@ extern const string UV_TILE_TOKEN;
 
 /// A shared pointer to a GeomElement
 using GeomElementPtr = shared_ptr<class GeomElement>;
+/// A shared pointer to a const GeomElement
+using ConstGeomElementPtr = shared_ptr<const class GeomElement>;
+
 /// A shared pointer to a GeomAttr
 using GeomAttrPtr = shared_ptr<class GeomAttr>;
+/// A shared pointer to a const GeomAttr
+using ConstGeomAttrPtr = shared_ptr<const class GeomAttr>;
+
 /// A shared pointer to a GeomInfo
 using GeomInfoPtr = shared_ptr<class GeomInfo>;
+/// A shared pointer to a const GeomInfo
+using ConstGeomInfoPtr = shared_ptr<const class GeomInfo>;
 
 /// A shared pointer to a Collection
 using CollectionPtr = shared_ptr<class Collection>;
+/// A shared pointer to a const Collection
+using ConstCollectionPtr = shared_ptr<const class Collection>;
+
 /// A shared pointer to a CollectionAdd
 using CollectionAddPtr = shared_ptr<class CollectionAdd>;
+/// A shared pointer to a const CollectionAdd
+using ConstCollectionAddPtr = shared_ptr<const class CollectionAdd>;
+
 /// A shared pointer to a CollectionRemove
 using CollectionRemovePtr = shared_ptr<class CollectionRemove>;
+/// A shared pointer to a const CollectionRemove
+using ConstCollectionRemovePtr = shared_ptr<const class CollectionRemove>;
 
 /// @class GeomElement
 /// The base class for geometric elements, which support bindings to geometries

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -18,16 +18,28 @@ namespace MaterialX
 
 /// A shared pointer to a Parameter
 using ParameterPtr = shared_ptr<class Parameter>;
+/// A shared pointer to a const Parameter
+using ConstParameterPtr = shared_ptr<const class Parameter>;
+
 /// A shared pointer to a PortElement
 using PortElementPtr = shared_ptr<class PortElement>;
+/// A shared pointer to a const PortElement
+using ConstPortElementPtr = shared_ptr<const class PortElement>;
+
 /// A shared pointer to an Input
 using InputPtr = shared_ptr<class Input>;
-/// A shared pointer to an Input
+/// A shared pointer to a const Input
 using ConstInputPtr = shared_ptr<const class Input>;
+
 /// A shared pointer to an Output
 using OutputPtr = shared_ptr<class Output>;
+/// A shared pointer to a const Output
+using ConstOutputPtr = shared_ptr<const class Output>;
+
 /// A shared pointer to an InterfaceElement
 using InterfaceElementPtr = shared_ptr<class InterfaceElement>;
+/// A shared pointer to a const InterfaceElement
+using ConstInterfaceElementPtr = shared_ptr<const class InterfaceElement>;
 
 /// @class Parameter
 /// A parameter element within a Node or NodeDef.
@@ -426,6 +438,7 @@ class InterfaceElement : public TypedElement
 
     /// Return the typed value of an input by its name, taking both the calling
     /// element and its declaration into account.
+    /// @param name The name of the input to be evaluated.
     /// @param target An optional target name, which will be used to filter
     ///    the declarations that are considered.
     /// @return If the given parameter is found in this interface or its

--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -34,7 +34,7 @@ using StringMap = std::unordered_map<string, string>;
 /// A set of strings.
 using StringSet = std::set<string>;
 
-/// @class @Exception
+/// @class Exception
 /// The base class for exceptions that are propagated from the MaterialX library
 /// to the client application.
 class Exception : public std::exception

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -19,12 +19,23 @@ namespace MaterialX
 
 /// A shared pointer to a Look
 using LookPtr = shared_ptr<class Look>;
+/// A shared pointer to a const Look
+using ConstLookPtr = shared_ptr<const class Look>;
+
 /// A shared pointer to a LookInherit
 using LookInheritPtr = shared_ptr<class LookInherit>;
+/// A shared pointer to a const LookInherit
+using ConstLookInheritPtr = shared_ptr<const class LookInherit>;
+
 /// A shared pointer to a MaterialAssign
 using MaterialAssignPtr = shared_ptr<class MaterialAssign>;
+/// A shared pointer to a const MaterialAssign
+using ConstMaterialAssignPtr = shared_ptr<const class MaterialAssign>;
+
 /// A shared pointer to a Visibility
 using VisibilityPtr = shared_ptr<class Visibility>;
+/// A shared pointer to a const Visibility
+using ConstVisibilityPtr = shared_ptr<const class Visibility>;
 
 /// @class Look
 /// A look element within a Document.

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -24,14 +24,28 @@ using ConstMaterialPtr = shared_ptr<const class Material>;
 
 /// A shared pointer to a ShaderRef
 using ShaderRefPtr = shared_ptr<class ShaderRef>;
+/// A shared pointer to a const ShaderRef
+using ConstShaderRefPtr = shared_ptr<const class ShaderRef>;
+
 /// A shared pointer to a BindParam
 using BindParamPtr = shared_ptr<class BindParam>;
+/// A shared pointer to a const BindParam
+using ConstBindParamPtr = shared_ptr<const class BindParam>;
+
 /// A shared pointer to a BindInput
 using BindInputPtr = shared_ptr<class BindInput>;
+/// A shared pointer to a const BindInput
+using ConstBindInputPtr = shared_ptr<const class BindInput>;
+
 /// A shared pointer to an Override
 using OverridePtr = shared_ptr<class Override>;
+/// A shared pointer to a const Override
+using ConstOverridePtr = shared_ptr<const class Override>;
+
 /// A shared pointer to a MaterialInherit
 using MaterialInheritPtr = shared_ptr<class MaterialInherit>;
+/// A shared pointer to a const MaterialInherit
+using ConstMaterialInheritPtr = shared_ptr<const class MaterialInherit>;
 
 /// @class Material
 /// A material element within a Document.

--- a/source/MaterialXCore/Observer.h
+++ b/source/MaterialXCore/Observer.h
@@ -16,8 +16,13 @@ namespace MaterialX
 
 /// A shared pointer to an Observer
 using ObserverPtr = shared_ptr<class Observer>;
+/// A shared pointer to a const Observer
+using ConstObserverPtr = shared_ptr<const class Observer>;
+
 /// A shared pointer to an ObservedDocument
 using ObservedDocumentPtr = shared_ptr<class ObservedDocument>;
+/// A shared pointer to a const ObservedDocument
+using ConstObservedDocumentPtr = shared_ptr<const class ObservedDocument>;
 
 /// An observer of a MaterialX Document
 class Observer

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -18,12 +18,23 @@ namespace MaterialX
 
 /// A shared pointer to a Property
 using PropertyPtr = shared_ptr<class Property>;
+/// A shared pointer to a const Property
+using ConstPropertyPtr = shared_ptr<const class Property>;
+
 /// A shared pointer to a PropertyAssign
 using PropertyAssignPtr = shared_ptr<class PropertyAssign>;
+/// A shared pointer to a const PropertyAssign
+using ConstPropertyAssignPtr = shared_ptr<const class PropertyAssign>;
+
 /// A shared pointer to a PropertySet
 using PropertySetPtr = shared_ptr<class PropertySet>;
+/// A shared pointer to a const PropertySet
+using ConstPropertySetPtr = shared_ptr<const class PropertySet>;
+
 /// A shared pointer to a PropertySetAssign
 using PropertySetAssignPtr = shared_ptr<class PropertySetAssign>;
+/// A shared pointer to a const PropertySetAssign
+using ConstPropertySetAssignPtr = shared_ptr<const class PropertySetAssign>;
 
 /// @class Property
 /// A property element within a PropertySet.

--- a/source/MaterialXCore/Traversal.h
+++ b/source/MaterialXCore/Traversal.h
@@ -184,7 +184,7 @@ class TreeIterator
     size_t _holdCount;
 };
 
-/// @class @GraphIterator
+/// @class GraphIterator
 /// An iterator object representing the state of an upstream graph traversal.
 ///
 /// @sa Element::traverseGraph
@@ -329,7 +329,7 @@ class GraphIterator
     size_t _holdCount;
 };
 
-/// @class @InheritanceIterator
+/// @class InheritanceIterator
 /// An iterator object representing the current state of an inheritance traversal.
 ///
 /// @sa Element::traverseInheritance
@@ -385,7 +385,7 @@ class InheritanceIterator
     size_t _holdCount;
 };
 
-/// @class @AncestorIterator
+/// @class AncestorIterator
 /// An iterator object representing the current state of an ancestor traversal.
 ///
 /// @sa Element::traverseAncestors
@@ -434,7 +434,7 @@ class AncestorIterator
     size_t _holdCount;
 };
 
-/// @class @ExceptionFoundCycle
+/// @class ExceptionFoundCycle
 /// An exception that is thrown when a traversal call encounters a cycle.
 class ExceptionFoundCycle : public Exception
 {

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -134,7 +134,7 @@ template <class T> class TypedValue : public Value
     T _data;
 };
 
-/// @class @ExceptionTypeError
+/// @class ExceptionTypeError
 /// An exception that is thrown when a type mismatch is encountered.
 class ExceptionTypeError : public Exception
 {

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -37,7 +37,7 @@ class XmlReadOptions
     bool readXIncludes;
 };
 
-/// @class @ExceptionParseError
+/// @class ExceptionParseError
 /// An exception that is thrown when a requested document cannot be parsed.
 class ExceptionParseError : public Exception
 {
@@ -45,7 +45,7 @@ class ExceptionParseError : public Exception
     using Exception::Exception;
 };
 
-/// @class @ExceptionFileMissing
+/// @class ExceptionFileMissing
 /// An exception that is thrown when a requested file cannot be opened.
 class ExceptionFileMissing : public Exception
 {


### PR DESCRIPTION
This changelist extends the set of provided type aliases to cover all const element pointers, as an additional tool for compile-time error checking, and fixes a handful of Doxygen comments.