### PR TITLE
Finalize changelog for MaterialX 1.35.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [1.35.5] - Development
+## [1.35.5] - 2018-05-07
 
 ### Added
 - Added material inheritance support to graph traversal and the high-level Material API.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ The MaterialX repository consists of the following folders:
                 and graph traversal, while the MaterialXFormat module supports
                 XML serialization.
     python    - Support modules for MaterialX Python.
+
+### Additional Resources
+
+- The [Developer Guide](http://www.materialx.org/docs/api/index.html) contains more detailed documentation and code examples in C++ and Python.


### PR DESCRIPTION
This changelist finalizes the changelog for MaterialX 1.35.5, and adds a link to the developer guide in the top-level readme.