### PR TITLE
Geometry name updates for MaterialX v1.36

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -692,10 +692,10 @@ class Element : public std::enable_shared_from_this<Element>
     /// Construct a StringResolver at the scope of this element.  The returned
     /// object may be used to apply substring modifiers to data values in the
     /// context of a specific element and geometry.
-    /// @param geom An optional geometry name, which will be used to the
-    ///    applicable set of GeomAttr-based string substitutions.  This name
-    ///    may be the univeral geometry name "*", which requests that all
-    ///    GeomAttr string substitutions be used.
+    /// @param geom An optional geometry name, which will be used to select the
+    ///    applicable set of geometric string substitutions.  By default, no
+    ///    geometric string substitutions are applied.  If the universal geometry
+    ///    name "/" is given, then all geometric string substitutions are applied,
     /// @return A shared pointer to a StringResolver.
     /// @todo The StringResolver returned by this method doesn't yet take
     ///    interface tokens into account.

--- a/source/MaterialXCore/Geom.cpp
+++ b/source/MaterialXCore/Geom.cpp
@@ -10,7 +10,8 @@
 namespace MaterialX
 {
 
-const string UNIVERSAL_GEOM_NAME = "*";
+const string GEOM_PATH_SEPARATOR = "/";
+const string UNIVERSAL_GEOM_NAME = GEOM_PATH_SEPARATOR;
 const string UDIM_TOKEN = "%UDIM";
 const string UV_TILE_TOKEN = "%UVTILE";
 
@@ -19,24 +20,26 @@ const string GeomElement::COLLECTION_ATTRIBUTE = "collection";
 const string Collection::INCLUDE_GEOM_ATTRIBUTE = "includegeom";
 const string Collection::INCLUDE_COLLECTION_ATTRIBUTE = "includecollection";
 const string Collection::EXCLUDE_GEOM_ATTRIBUTE = "excludegeom";
-const string Collection::EXCLUDE_COLLECTION_ATTRIBUTE = "excludecollection";
 
 bool geomStringsMatch(const string& geom1, const string& geom2)
 {
-    vector<string> vec1 = splitString(geom1, ARRAY_VALID_SEPARATORS);
-    vector<string> vec2 = splitString(geom2, ARRAY_VALID_SEPARATORS);
-    std::set<string> set1(vec1.begin(), vec1.end());
-    std::set<string> set2(vec2.begin(), vec2.end());
-
-    if (set1.empty() || set2.empty())
-        return false;
-    if (set1.count(UNIVERSAL_GEOM_NAME) || set2.count(UNIVERSAL_GEOM_NAME))
-        return true;
-
-    std::set<string> matches;
-    std::set_intersection(set1.begin(), set1.end(), set2.begin(), set2.end(), 
-                          std::inserter(matches, matches.end()));
-    return !matches.empty();
+    vector<GeomPath> paths1;
+    for (const string& name1 : splitString(geom1, ARRAY_VALID_SEPARATORS))
+    {
+        paths1.push_back(GeomPath(name1));
+    }
+    for (const string& name2 : splitString(geom2, ARRAY_VALID_SEPARATORS))
+    {
+        GeomPath path2(name2);
+        for (const GeomPath& path1 : paths1)
+        {
+            if (path2.isMatching(path1))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 void GeomElement::setCollection(ConstCollectionPtr collection)

--- a/source/MaterialXTest/Geom.cpp
+++ b/source/MaterialXTest/Geom.cpp
@@ -9,12 +9,21 @@
 
 namespace mx = MaterialX;
 
-TEST_CASE("Geom", "[geom]")
+TEST_CASE("Geom strings", "[geom]")
+{
+    REQUIRE(mx::geomStringsMatch("/", "/robot1"));
+    REQUIRE(mx::geomStringsMatch("/robot1", "/robot1/left_arm"));
+    REQUIRE(mx::geomStringsMatch("/robot1, /robot2", "/robot2/left_arm"));
+    REQUIRE(!mx::geomStringsMatch("/robot1", "/robot2"));
+    REQUIRE(!mx::geomStringsMatch("/robot1, /robot2", "/robot3"));
+}
+
+TEST_CASE("Geom elements", "[geom]")
 {
     mx::DocumentPtr doc = mx::createDocument();
 
     // Add geominfos and tokens
-    mx::GeomInfoPtr geominfo1 = doc->addGeomInfo("geominfo1", "/robot1,/robot2");
+    mx::GeomInfoPtr geominfo1 = doc->addGeomInfo("geominfo1", "/robot1, /robot2");
     geominfo1->setTokenValue("asset", std::string("robot"));
     mx::GeomInfoPtr geominfo2 = doc->addGeomInfo("geominfo2", "/robot1");
     geominfo2->setTokenValue("id", std::string("01"));

--- a/source/PyMaterialX/PyGeom.cpp
+++ b/source/PyMaterialX/PyGeom.cpp
@@ -63,9 +63,6 @@ void bindPyGeom(py::module& mod)
         .def("setExcludeGeom", &mx::Collection::setExcludeGeom)
         .def("hasExcludeGeom", &mx::Collection::hasExcludeGeom)
         .def("getExcludeGeom", &mx::Collection::getExcludeGeom)
-        .def("setExcludeCollection", &mx::Collection::setExcludeCollection)
-        .def("hasExcludeCollection", &mx::Collection::hasExcludeCollection)
-        .def("getExcludeCollection", &mx::Collection::getExcludeCollection)
         .def_readonly_static("CATEGORY", &mx::Collection::CATEGORY);
 
     mod.def("geomStringsMatch", &mx::geomStringsMatch);


### PR DESCRIPTION
- Update geometry name matching rules to match v1.36.
- Remove an unsupported attribute from Collection.
- Add helper class GeomPath.