### PR TITLE
Improvements to type handling for v1.36

### DIFF
--- a/documents/Examples/BxDF/Disney_BSDF_2015.mtlx
+++ b/documents/Examples/BxDF/Disney_BSDF_2015.mtlx
@@ -15,7 +15,7 @@
     <input name="scatterDistance" type="vector3" value="0, 0, 0"/>
     <input name="flatness" type="float" value="0"/>
     <input name="diffTrans" type="float" value="0"/>
-    <parameter name="thin" type="bool" value="false"/>
+    <parameter name="thin" type="boolean" value="false"/>
   </nodedef>
   <implementation name="im_d2015" nodedef="nd_d2015" target="pbrt" language="c++" file="https://github.com/mmp/pbrt-v3/blob/master/src/materials/disney.cpp" function="DisneyMaterial::DisneyMaterial">
     <input name="baseColor" type="color3" implname="color"/>

--- a/documents/Examples/BxDF/alSurface.mtlx
+++ b/documents/Examples/BxDF/alSurface.mtlx
@@ -49,7 +49,7 @@
            helptext="Controls how much the specular highlight is stretched along its axis. The default value of 0.5 produces a round highlight. Higher values will stretch the highlight along the V axis, lower values stretch along the U axis. The axis of the highlight is controlled by the UVs of the object. For best results, give your object a single UV shell with as few seams as possible."  />
     <input name="specular1Rotation" type="float" value="0.0" publicname="Specular 1/Rotation" uimax="1"
            helptext="Rotates the axis of specular anisotropy around the surface normal. 0 gives no rotation, 0.5 gives 90 degree rotation, 1 gives 180 degree rotation."  />
-    <parameter name="specular1FresnelMode" type="int" value="0" publicname="Specular 1/Fresnel/Mode"
+    <parameter name="specular1FresnelMode" type="integer" value="0" publicname="Specular 1/Fresnel/Mode"
            helptext="Selects which mode to use for the fresnel. Dielectric is appropriate for non-conductive materials such as most organics, plastic, glass and water etc. and gives dark reflections at normal incidence and bright reflections at glancing angles. Metallic is appropriate for metals and gives colored reflections that vary less strongly with angle."  />
     <input name="specular1Ior" type="float" value="1.4" publicname="Specular 1/Fresnel/IOR"
            helptext="The index of refraction for the dielectric fresnel mode."  />
@@ -71,7 +71,7 @@
            helptext="Controls how much the specular highlight is stretched along its axis. The default value of 0.5 produces a round highlight. Higher values will stretch the highlight along the V axis, lower values stretch along the U axis. The axis of the highlight is controlled by the UVs of the object. For best results, give your object a single UV shell with as few seams as possible."  />
     <input name="specular2Rotation" type="float" value="0.0" publicname="Specular 2/Rotation" uimax="1"
            helptext="Rotates the axis of specular anisotropy around the surface normal. 0 gives no rotation, 0.5 gives 90 degree rotation, 1 gives 180 degree rotation."  />
-    <parameter name="specular2FresnelMode" type="int" value="0" publicname="Specular 2/Fresnel/Mode"
+    <parameter name="specular2FresnelMode" type="integer" value="0" publicname="Specular 2/Fresnel/Mode"
            helptext="Selects which mode to use for the fresnel. Dielectric is appropriate for non-conductive materials such as most organics, plastic, glass and water etc. and gives dark reflections at normal incidence and bright reflections at glancing angles. Metallic is appropriate for metals and gives colored reflections that vary less strongly with angle."  />
     <input name="specular2Ior" type="float" value="1.4" publicname="Specular 2/Fresnel/IOR"
            helptext="The index of refraction for the dielectric fresnel mode."  />

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -80,7 +80,7 @@ bool NodeDef::validate(string* message) const
 {
     bool res = true;
     validateRequire(hasType(), res, message, "Missing type");
-    if (getType() == MULTI_OUTPUT_TYPE_STRING)
+    if (isMultiOutputType())
     {
         validateRequire(getOutputCount() >= 2, res, message, "Multioutput nodedefs must have two or more output ports");
     }

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -13,13 +13,13 @@ namespace MaterialX
 {
 
 const string Element::NAME_ATTRIBUTE = "name";
-const string Element::TYPE_ATTRIBUTE = "type";
 const string Element::FILE_PREFIX_ATTRIBUTE = "fileprefix";
 const string Element::GEOM_PREFIX_ATTRIBUTE = "geomprefix";
 const string Element::COLOR_SPACE_ATTRIBUTE = "colorspace";
 const string Element::TARGET_ATTRIBUTE = "target";
 const string Element::INHERIT_ATTRIBUTE = "inherit";
 const string Element::NAMESPACE_ATTRIBUTE = "namespace";
+const string TypedElement::TYPE_ATTRIBUTE = "type";
 const string ValueElement::VALUE_ATTRIBUTE = "value";
 const string ValueElement::INTERFACE_NAME_ATTRIBUTE = "interfacename";
 const string ValueElement::IMPLEMENTATION_NAME_ATTRIBUTE = "implname";
@@ -105,18 +105,19 @@ string Element::getNamePath(ConstElementPtr relativeTo) const
     return res;
 }
 
-ElementPtr Element::getDescendant(const string& path)
+ElementPtr Element::getDescendant(const string& namePath)
 {
-    const StringVec elementNames = splitString(path, NAME_PATH_SEPARATOR);
-    ElementPtr currentElement = getSelf();
-    for (const string& elementName : elementNames)
+    const StringVec nameVec = splitString(namePath, NAME_PATH_SEPARATOR);
+    ElementPtr elem = getSelf();
+    for (const string& name : nameVec)
     {
-        if (!(currentElement = currentElement->getChild(elementName)))
+        elem = elem->getChild(name);
+        if (!elem)
         {
             return ElementPtr();
         }
     }
-    return currentElement;
+    return elem;
 }
 
 void Element::registerChildElement(ElementPtr child)
@@ -456,6 +457,15 @@ void Element::validateRequire(bool expression, bool& res, string* message, strin
             *message += errorDesc + ": " + asString() + "\n";
         }
     }
+}
+
+//
+// TypedElement methods
+//
+
+TypeDefPtr TypedElement::getTypeDef() const
+{
+    return resolveRootNameReference<TypeDef>(getType());
 }
 
 //

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -121,13 +121,12 @@ class Element : public std::enable_shared_from_this<Element>
     ///    the returned path will be relative to this ancestor.
     string getNamePath(ConstElementPtr relativeTo = nullptr) const;
 
-    /// Return the descendant referred to by the hierarchical path relative
-    /// to the current element. If an empty string is provided as the path
-    /// then a shared pointer to the current element is returned. If the
-    /// path cannot be found then an empty shared pointer is returned.
-    /// @param path The hierarchical path to use to find a descendant
-    ///    relative to the current element.
-    ElementPtr getDescendant(const string& path);
+    /// Return the element specified by the given hierarchical name path,
+    /// relative to the current element.  If the name path is empty then the
+    /// current element is returned.  If no element is found at the given path,
+    /// then an empty shared pointer is returned.
+    /// @param namePath The relative name path of the specified element.
+    ElementPtr getDescendant(const string& namePath);
 
     /// @}
     /// @name File Prefix
@@ -758,7 +757,6 @@ class Element : public std::enable_shared_from_this<Element>
 
   public:
     static const string NAME_ATTRIBUTE;
-    static const string TYPE_ATTRIBUTE;
     static const string FILE_PREFIX_ATTRIBUTE;
     static const string GEOM_PREFIX_ATTRIBUTE;
     static const string COLOR_SPACE_ATTRIBUTE;
@@ -819,6 +817,13 @@ class TypedElement : public Element
   public:
     virtual ~TypedElement() { }
 
+  protected:
+    using TypeDefPtr = shared_ptr<class TypeDef>;
+
+  public:
+    /// @}
+    /// @name Type String
+
     /// Set the element's type string.
     void setType(const string& type)
     {
@@ -836,6 +841,23 @@ class TypedElement : public Element
     {
         return getAttribute(TYPE_ATTRIBUTE);
     }
+
+    /// Return true if the element is of multi-output type.
+    bool isMultiOutputType() const
+    {
+        return getType() == MULTI_OUTPUT_TYPE_STRING;
+    }
+
+    /// @}
+    /// @name TypeDef References
+    /// @{
+
+    /// Return the TypeDef declaring the type string of this element.  If no
+    /// matching TypeDef is found, then an empty shared pointer is returned.
+    TypeDefPtr getTypeDef() const;
+
+  public:
+    static const string TYPE_ATTRIBUTE;
 };
 
 /// @class ValueElement

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -125,10 +125,16 @@ TEST_CASE("Load content", "[xmlio]")
         }
         REQUIRE(doc2->validate());
 
-        // Verify that all referenced nodes are declared and implemented.
+        // Verify that all referenced types and nodes are declared, and that
+        // referenced node declarations are implemented.
         for (mx::ElementPtr elem : doc2->traverseTree())
         {
+            mx::TypedElementPtr typedElem = elem->asA<mx::TypedElement>();
             mx::NodePtr node = elem->asA<mx::Node>();
+            if (typedElem && typedElem->hasType() && !typedElem->isMultiOutputType())
+            {
+                REQUIRE(typedElem->getTypeDef());
+            }
             if (node)
             {
                 REQUIRE(node->getNodeDef());

--- a/source/PyMaterialX/PyElement.cpp
+++ b/source/PyMaterialX/PyElement.cpp
@@ -133,7 +133,9 @@ void bindPyElement(py::module& mod)
     py::class_<mx::TypedElement, mx::TypedElementPtr, mx::Element>(mod, "TypedElement")
         .def("setType", &mx::TypedElement::setType)
         .def("hasType", &mx::TypedElement::hasType)
-        .def("getType", &mx::TypedElement::getType);
+        .def("getType", &mx::TypedElement::getType)
+        .def("isMultiOutputType", &mx::TypedElement::isMultiOutputType)
+        .def("getTypeDef", &mx::TypedElement::getTypeDef);
 
     py::class_<mx::ValueElement, mx::ValueElementPtr, mx::TypedElement>(mod, "ValueElement")
         .def("setValueString", &mx::ValueElement::setValueString)


### PR DESCRIPTION
- Validate type attributes of example documents in unit tests, and fix related typos in shader examples.
- Add helper methods TypedElement::getTypeDef and TypedElement::isMultiOutputType.

Also:

- Minor clarifications to Element::getDescendant.