### PR TITLE
Value class float formatting

### DIFF
--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -15,7 +15,7 @@ namespace MaterialX
 {
 
 Value::CreatorMap Value::_creatorMap;
-int Value::_floatFormat = 0;
+Value::FloatFormat Value::_floatFormat = Value::FloatFormatDefault;
 int Value::_floatPrecision = 6;
 
 namespace {
@@ -96,8 +96,14 @@ template <class T> void stringToData(const string& str, enable_if_std_vector_t<T
 template <class T> void dataToString(const T& data, string& str)
 {
     std::stringstream ss;
+
+    // Set float format and precision for the stream
+    const Value::FloatFormat fmt = Value::getFloatFormat();
+    ss.setf(fmt == Value::FloatFormatFixed ? std::ios_base::fixed :
+        (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0),
+        std::ios_base::floatfield);
     ss.precision(Value::getFloatPrecision());
-    ss.setf((std::ios_base::fmtflags)Value::getFloatFormat(), std::ios_base::floatfield);
+
     ss << data;
     str = ss.str();
 }
@@ -237,7 +243,7 @@ template<class T> T Value::asA() const
     return typedVal->getData();
 }
 
-Value::ScopedFloatFormatting::ScopedFloatFormatting(int format, int precision)
+Value::ScopedFloatFormatting::ScopedFloatFormatting(FloatFormat format, int precision)
     : _format(Value::getFloatFormat())
     , _precision(Value::getFloatPrecision())
 {

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -97,7 +97,7 @@ template <class T> void dataToString(const T& data, string& str)
 {
     std::stringstream ss;
     ss.precision(Value::getFloatPrecision());
-    ss.setf(Value::getFloatFormat(), std::ios_base::floatfield);
+    ss.setf((std::ios_base::fmtflags)Value::getFloatFormat(), std::ios_base::floatfield);
     ss << data;
     str = ss.str();
 }

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -8,12 +8,15 @@
 #include <MaterialXCore/Util.h>
 
 #include <sstream>
+#include <iomanip>
 #include <type_traits>
 
 namespace MaterialX
 {
 
 Value::CreatorMap Value::_creatorMap;
+int Value::_floatFormat = 0;
+int Value::_floatPrecision = 6;
 
 namespace {
 
@@ -93,6 +96,8 @@ template <class T> void stringToData(const string& str, enable_if_std_vector_t<T
 template <class T> void dataToString(const T& data, string& str)
 {
     std::stringstream ss;
+    ss.precision(Value::getFloatPrecision());
+    ss.setf(Value::getFloatFormat(), std::ios_base::floatfield);
     ss << data;
     str = ss.str();
 }
@@ -230,6 +235,20 @@ template<class T> T Value::asA() const
         throw ExceptionTypeError("Incorrect type specified for value");
     }
     return typedVal->getData();
+}
+
+Value::ScopedFloatFormatting::ScopedFloatFormatting(int format, int precision)
+    : _format(Value::getFloatFormat())
+    , _precision(Value::getFloatPrecision())
+{
+    Value::setFloatFormat(format);
+    Value::setFloatPrecision(precision);
+}
+
+Value::ScopedFloatFormatting::~ScopedFloatFormatting()
+{
+    Value::setFloatFormat(_format);
+    Value::setFloatPrecision(_precision);
 }
 
 //

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -7,8 +7,8 @@
 
 #include <MaterialXCore/Util.h>
 
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 #include <type_traits>
 
 namespace MaterialX
@@ -244,9 +244,9 @@ template<class T> T Value::asA() const
     return typedVal->getData();
 }
 
-Value::ScopedFloatFormatting::ScopedFloatFormatting(FloatFormat format, int precision)
-    : _format(Value::getFloatFormat())
-    , _precision(Value::getFloatPrecision())
+Value::ScopedFloatFormatting::ScopedFloatFormatting(FloatFormat format, int precision) :
+    _format(Value::getFloatFormat()),
+    _precision(Value::getFloatPrecision())
 {
     Value::setFloatFormat(format);
     Value::setFloatPrecision(precision);

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -99,8 +99,9 @@ template <class T> void dataToString(const T& data, string& str)
 
     // Set float format and precision for the stream
     const Value::FloatFormat fmt = Value::getFloatFormat();
-    ss.setf(fmt == Value::FloatFormatFixed ? std::ios_base::fixed :
-        (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0),
+    ss.setf(std::ios_base::fmtflags(
+            (fmt == Value::FloatFormatFixed ? std::ios_base::fixed :
+            (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0))),
         std::ios_base::floatfield);
     ss.precision(Value::getFloatPrecision());
 

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -27,6 +27,15 @@ template <class T> class TypedValue;
 class Value
 {
   public:
+    /// Float formats to use when converting values to strings.
+    enum FloatFormat
+    {
+        FloatFormatDefault = 0,
+        FloatFormatFixed = 1,
+        FloatFormatScientific = 2
+    };
+
+  public:
     Value()
     {
     }
@@ -65,9 +74,9 @@ class Value
     virtual string getValueString() const = 0;
 
     /// Set float formatting for converting values to strings.
-    /// Formats to use are 'std::ios_base::fixed', 'std::ios_base::scientific' 
-    /// or '0' to set default format.
-    static void setFloatFormat(int format)
+    /// Formats to use are FloatFormatFixed, FloatFormatScientific 
+    /// or FloatFormatDefault to set default format.
+    static void setFloatFormat(FloatFormat format)
     {
         _floatFormat = format;
     }
@@ -79,7 +88,7 @@ class Value
     }
 
     /// Return the current float format.
-    static int getFloatFormat()
+    static FloatFormat getFloatFormat()
     {
         return _floatFormat;
     }
@@ -95,10 +104,10 @@ class Value
     class ScopedFloatFormatting
     {
       public:
-        ScopedFloatFormatting(int format, int precision = 6);
+        ScopedFloatFormatting(FloatFormat format, int precision = 6);
         ~ScopedFloatFormatting();
       private:
-          int _format;
+          FloatFormat _format;
           int _precision;
     };
 
@@ -110,7 +119,7 @@ class Value
 
   private:
     static CreatorMap _creatorMap;
-    static int _floatFormat;
+    static FloatFormat _floatFormat;
     static int _floatPrecision;
 };
 

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -64,6 +64,44 @@ class Value
     /// Return the value string for this value.
     virtual string getValueString() const = 0;
 
+    /// Set float formatting for converting values to strings.
+    /// Formats to use are 'std::ios_base::fixed', 'std::ios_base::scientific' 
+    /// or '0' to set default format.
+    static void setFloatFormat(int format)
+    {
+        _floatFormat = format;
+    }
+
+    /// Set float precision for converting values to strings.
+    static void setFloatPrecision(int precision)
+    {
+        _floatPrecision = precision;
+    }
+
+    /// Return the current float format.
+    static int getFloatFormat()
+    {
+        return _floatFormat;
+    }
+
+    /// Return the current float precision.
+    static int getFloatPrecision()
+    {
+        return _floatPrecision;
+    }
+
+    /// RAII class for scoped setting of float formatting.
+    /// Flags are reset when the object goes out of scope.
+    class ScopedFloatFormatting
+    {
+      public:
+        ScopedFloatFormatting(int format, int precision = 6);
+        ~ScopedFloatFormatting();
+      private:
+          int _format;
+          int _precision;
+    };
+
   protected:
     template <class T> friend class ValueRegistry;
 
@@ -72,6 +110,8 @@ class Value
 
   private:
     static CreatorMap _creatorMap;
+    static int _floatFormat;
+    static int _floatPrecision;
 };
 
 /// The class template for typed subclasses of Value

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -106,9 +106,10 @@ class Value
       public:
         ScopedFloatFormatting(FloatFormat format, int precision = 6);
         ~ScopedFloatFormatting();
+
       private:
-          FloatFormat _format;
-          int _precision;
+        FloatFormat _format;
+        int _precision;
     };
 
   protected:

--- a/source/MaterialXTest/Value.cpp
+++ b/source/MaterialXTest/Value.cpp
@@ -50,6 +50,22 @@ TEST_CASE("Value strings", "[value]")
     REQUIRE(mx::toValueString(mx::Color3(1.0f)) == "1, 1, 1");
     REQUIRE(mx::toValueString(std::string("text")) == "text");
 
+    // Convert from data values to value strings
+    // using the various float formattings.
+    {
+        mx::Value::ScopedFloatFormatting fmt(mx::Value::FloatFormatFixed, 3);
+        REQUIRE(mx::toValueString(0.1234f) == "0.123");
+        REQUIRE(mx::toValueString(mx::Color3(1.0f)) == "1.000, 1.000, 1.000");
+    }
+    {
+        mx::Value::ScopedFloatFormatting fmt(mx::Value::FloatFormatScientific, 2);
+        REQUIRE(mx::toValueString(0.1234f) == "1.23e-01");
+    }
+    {
+        mx::Value::ScopedFloatFormatting fmt(mx::Value::FloatFormatDefault, 2);
+        REQUIRE(mx::toValueString(0.1234f) == "0.12");
+    }
+
     // Convert from value strings to data values.
     REQUIRE(mx::fromValueString<int>("1") == 1);
     REQUIRE(mx::fromValueString<float>("1") == 1.0f);


### PR DESCRIPTION
This change list adds methods to the Value class to control how float values are formatted when converted to strings. It enables support for selecting the format as "fixed", "scientific" or "default" as well as setting the precision. 
Our use-case for this is when doing code generation targeting a shading language compiler that doesn't support scientific notation.
