### PR TITLE
Value class float formatting (#124)

### DIFF
--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -7,6 +7,7 @@
 
 #include <MaterialXCore/Util.h>
 
+#include <iomanip>
 #include <sstream>
 #include <type_traits>
 
@@ -14,6 +15,8 @@ namespace MaterialX
 {
 
 Value::CreatorMap Value::_creatorMap;
+Value::FloatFormat Value::_floatFormat = Value::FloatFormatDefault;
+int Value::_floatPrecision = 6;
 
 namespace {
 
@@ -93,6 +96,15 @@ template <class T> void stringToData(const string& str, enable_if_std_vector_t<T
 template <class T> void dataToString(const T& data, string& str)
 {
     std::stringstream ss;
+
+    // Set float format and precision for the stream
+    const Value::FloatFormat fmt = Value::getFloatFormat();
+    ss.setf(std::ios_base::fmtflags(
+            (fmt == Value::FloatFormatFixed ? std::ios_base::fixed :
+            (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0))),
+        std::ios_base::floatfield);
+    ss.precision(Value::getFloatPrecision());
+
     ss << data;
     str = ss.str();
 }
@@ -230,6 +242,20 @@ template<class T> T Value::asA() const
         throw ExceptionTypeError("Incorrect type specified for value");
     }
     return typedVal->getData();
+}
+
+Value::ScopedFloatFormatting::ScopedFloatFormatting(FloatFormat format, int precision) :
+    _format(Value::getFloatFormat()),
+    _precision(Value::getFloatPrecision())
+{
+    Value::setFloatFormat(format);
+    Value::setFloatPrecision(precision);
+}
+
+Value::ScopedFloatFormatting::~ScopedFloatFormatting()
+{
+    Value::setFloatFormat(_format);
+    Value::setFloatPrecision(_precision);
 }
 
 //

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -27,6 +27,15 @@ template <class T> class TypedValue;
 class Value
 {
   public:
+    /// Float formats to use when converting values to strings.
+    enum FloatFormat
+    {
+        FloatFormatDefault = 0,
+        FloatFormatFixed = 1,
+        FloatFormatScientific = 2
+    };
+
+  public:
     Value()
     {
     }
@@ -64,6 +73,45 @@ class Value
     /// Return the value string for this value.
     virtual string getValueString() const = 0;
 
+    /// Set float formatting for converting values to strings.
+    /// Formats to use are FloatFormatFixed, FloatFormatScientific 
+    /// or FloatFormatDefault to set default format.
+    static void setFloatFormat(FloatFormat format)
+    {
+        _floatFormat = format;
+    }
+
+    /// Set float precision for converting values to strings.
+    static void setFloatPrecision(int precision)
+    {
+        _floatPrecision = precision;
+    }
+
+    /// Return the current float format.
+    static FloatFormat getFloatFormat()
+    {
+        return _floatFormat;
+    }
+
+    /// Return the current float precision.
+    static int getFloatPrecision()
+    {
+        return _floatPrecision;
+    }
+
+    /// RAII class for scoped setting of float formatting.
+    /// Flags are reset when the object goes out of scope.
+    class ScopedFloatFormatting
+    {
+      public:
+        ScopedFloatFormatting(FloatFormat format, int precision = 6);
+        ~ScopedFloatFormatting();
+
+      private:
+        FloatFormat _format;
+        int _precision;
+    };
+
   protected:
     template <class T> friend class ValueRegistry;
 
@@ -72,6 +120,8 @@ class Value
 
   private:
     static CreatorMap _creatorMap;
+    static FloatFormat _floatFormat;
+    static int _floatPrecision;
 };
 
 /// The class template for typed subclasses of Value

--- a/source/MaterialXTest/Value.cpp
+++ b/source/MaterialXTest/Value.cpp
@@ -50,6 +50,22 @@ TEST_CASE("Value strings", "[value]")
     REQUIRE(mx::toValueString(mx::Color3(1.0f)) == "1, 1, 1");
     REQUIRE(mx::toValueString(std::string("text")) == "text");
 
+    // Convert from data values to value strings
+    // using the various float formattings.
+    {
+        mx::Value::ScopedFloatFormatting fmt(mx::Value::FloatFormatFixed, 3);
+        REQUIRE(mx::toValueString(0.1234f) == "0.123");
+        REQUIRE(mx::toValueString(mx::Color3(1.0f)) == "1.000, 1.000, 1.000");
+    }
+    {
+        mx::Value::ScopedFloatFormatting fmt(mx::Value::FloatFormatScientific, 2);
+        REQUIRE(mx::toValueString(0.1234f) == "1.23e-01");
+    }
+    {
+        mx::Value::ScopedFloatFormatting fmt(mx::Value::FloatFormatDefault, 2);
+        REQUIRE(mx::toValueString(0.1234f) == "0.12");
+    }
+
     // Convert from value strings to data values.
     REQUIRE(mx::fromValueString<int>("1") == 1);
     REQUIRE(mx::fromValueString<float>("1") == 1.0f);


### PR DESCRIPTION
* Support for setting float format and precision to Value class, for handling conversion from values to string values.

* Small fix for build problem on linux/mac

* Added enum for the supported float formats.

* Added test for float formatting in value conversion to string.

* Fixed build problem on Linux.

* Fixed coding standard inconsistencies