### PR TITLE
Additional updates for v1.36

### DIFF
--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -13,14 +13,14 @@ namespace MaterialX
 const string COLOR_SEMANTIC = "color";
 const string SHADER_SEMANTIC = "shader";
 
-const string TEXTURE_NODE_CATEGORY = "texture";
-const string PROCEDURAL_NODE_CATEGORY = "procedural";
-const string GEOMETRIC_NODE_CATEGORY = "geometric";
-const string ADJUSTMENT_NODE_CATEGORY = "adjustment";
-const string CONDITIONAL_NODE_CATEGORY = "conditional";
+const string TEXTURE_NODE_GROUP = "texture";
+const string PROCEDURAL_NODE_GROUP = "procedural";
+const string GEOMETRIC_NODE_GROUP = "geometric";
+const string ADJUSTMENT_NODE_GROUP = "adjustment";
+const string CONDITIONAL_NODE_GROUP = "conditional";
 
 const string NodeDef::NODE_ATTRIBUTE = "node";
-const string NodeDef::NODE_CATEGORY_ATTRIBUTE = "nodecategory";
+const string NodeDef::NODE_GROUP_ATTRIBUTE = "nodegroup";
 const string TypeDef::SEMANTIC_ATTRIBUTE = "semantic";
 const string TypeDef::CONTEXT_ATTRIBUTE = "context";
 const string Implementation::NODE_DEF_ATTRIBUTE = "nodedef";

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -19,11 +19,11 @@ namespace MaterialX
 extern const string COLOR_SEMANTIC;
 extern const string SHADER_SEMANTIC;
 
-extern const string TEXTURE_NODE_CATEGORY;
-extern const string PROCEDURAL_NODE_CATEGORY;
-extern const string GEOMETRIC_NODE_CATEGORY;
-extern const string ADJUSTMENT_NODE_CATEGORY;
-extern const string CONDITIONAL_NODE_CATEGORY;
+extern const string TEXTURE_NODE_GROUP;
+extern const string PROCEDURAL_NODE_GROUP;
+extern const string GEOMETRIC_NODE_GROUP;
+extern const string ADJUSTMENT_NODE_GROUP;
+extern const string CONDITIONAL_NODE_GROUP;
 
 class NodeDef;
 class Implementation;
@@ -89,25 +89,25 @@ class NodeDef : public InterfaceElement
     }
 
     /// @}
-    /// @name Node Category
+    /// @name Node Group
     /// @{
 
-    /// Set the node category of the NodeDef.
-    void setNodeCategory(const string& category)
+    /// Set the node group of the NodeDef.
+    void setNodeGroup(const string& category)
     {
-        setAttribute(NODE_CATEGORY_ATTRIBUTE, category);
+        setAttribute(NODE_GROUP_ATTRIBUTE, category);
     }
 
-    /// Return true if the given NodeDef has a node category.
-    bool hasNodeCategory() const
+    /// Return true if the given NodeDef has a node group.
+    bool hasNodeGroup() const
     {
-        return hasAttribute(NODE_CATEGORY_ATTRIBUTE);
+        return hasAttribute(NODE_GROUP_ATTRIBUTE);
     }
 
-    /// Return the node category of the NodeDef.
-    const string& getNodeCategory() const
+    /// Return the node group of the NodeDef.
+    const string& getNodeGroup() const
     {
-        return getAttribute(NODE_CATEGORY_ATTRIBUTE);
+        return getAttribute(NODE_GROUP_ATTRIBUTE);
     }
 
     /// @}
@@ -155,7 +155,7 @@ class NodeDef : public InterfaceElement
   public:
     static const string CATEGORY;
     static const string NODE_ATTRIBUTE;
-    static const string NODE_CATEGORY_ATTRIBUTE;
+    static const string NODE_GROUP_ATTRIBUTE;
 };
 
 /// @class Implementation

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -146,7 +146,6 @@ void Document::initialize()
 void Document::importLibrary(ConstDocumentPtr library, const CopyOptions* copyOptions)
 {
     bool skipDuplicateElements = copyOptions && copyOptions->skipDuplicateElements;
-    bool copySourceUris = copyOptions && copyOptions->copySourceUris;
     for (ElementPtr child : library->getChildren())
     {
         string childName = child->getQualifiedName(child->getName());
@@ -173,7 +172,7 @@ void Document::importLibrary(ConstDocumentPtr library, const CopyOptions* copyOp
         {
             childCopy->setNamespace(library->getNamespace());
         }
-        if (copySourceUris && !childCopy->hasSourceUri())
+        if (!childCopy->hasSourceUri() && library->hasSourceUri())
         {
             childCopy->setSourceUri(library->getSourceUri());
         }

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -52,9 +52,7 @@ class Document : public GraphElement
     virtual DocumentPtr copy()
     {
         DocumentPtr doc = createDocument<Document>();
-        CopyOptions copyOptions;
-        copyOptions.copySourceUris = true;
-        doc->copyContentFrom(getSelf(), &copyOptions);
+        doc->copyContentFrom(getSelf());
         return doc;
     }
 

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -373,10 +373,7 @@ AncestorIterator Element::traverseAncestors() const
 
 void Element::copyContentFrom(ConstElementPtr source, const CopyOptions* copyOptions)
 {
-    if (copyOptions && copyOptions->copySourceUris)
-    {
-        _sourceUri = source->_sourceUri;
-    }
+    _sourceUri = source->_sourceUri;
     for (const string& attr : source->getAttributeNames())
     {
         setAttribute(attr, source->getAttribute(attr));

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -738,6 +738,20 @@ class Element : public std::enable_shared_from_this<Element>
         return _sourceUri;
     }
 
+    /// Return the source URI that is active at the scope of this
+    /// element, taking all ancestor elements into account.
+    const string& getActiveSourceUri() const
+    {
+        for (ConstElementPtr elem : traverseAncestors())
+        {
+            if (elem->hasSourceUri())
+            {
+                return elem->getSourceUri();
+            }
+        }
+        return EMPTY_STRING;
+    }
+
     /// @}
     /// @name Validation
     /// @{
@@ -1219,8 +1233,7 @@ class CopyOptions
 {
   public:
     CopyOptions() :
-        skipDuplicateElements(false),
-        copySourceUris(false)
+        skipDuplicateElements(false)
     {
     }
     ~CopyOptions() { }
@@ -1228,10 +1241,6 @@ class CopyOptions
     /// If true, elements at the same scope with duplicate names will be skipped;
     /// otherwise, they will trigger an exception.  Defaults to false.
     bool skipDuplicateElements;
-
-    /// If true, then source URIs from the given element
-    /// and its descendants are also copied.  Defaults to false.
-    bool copySourceUris;
 };
 
 /// @class ExceptionOrphanedElement

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -160,7 +160,7 @@ void GraphElement::flattenSubgraphs(const string& target)
                 }
 
                 ValueElementPtr refValue = refNode->getChildOfType<ValueElement>(newValue->getInterfaceName());
-                if (refNode)
+                if (refValue)
                 {
                     if (refValue->hasValueString())
                     {
@@ -304,8 +304,8 @@ string GraphElement::asStringDot() const
     {
         dot += "    \"" + node->getName() + "\" ";
         NodeDefPtr nodeDef = node->getNodeDef();
-        const string& nodeCategory = nodeDef ? nodeDef->getNodeCategory() : EMPTY_STRING;
-        if (nodeCategory == CONDITIONAL_NODE_CATEGORY)
+        const string& nodeGroup = nodeDef ? nodeDef->getNodeGroup() : EMPTY_STRING;
+        if (nodeGroup == CONDITIONAL_NODE_GROUP)
         {
             dot += "[shape=diamond];\n";
         }

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -125,7 +125,10 @@ void xmlDocumentFromFile(xml_document& xmlDoc, string filename, const string& se
         }
         else
         {
-            throw ExceptionParseError("XML parse error in file: " + filename + " (" + result.description() + ")");
+            string desc = result.description();
+            string offset = std::to_string(result.offset);
+            throw ExceptionParseError("XML parse error in file: " + filename +
+                                      " (" + desc + " at character " + offset + ")");
         }
     }
 }
@@ -145,9 +148,7 @@ void processXIncludes(DocumentPtr doc, xml_node& xmlNode, const string& searchPa
                 readFromXmlFile(library, fileAttr.value(), searchPath, readOptions);
 
                 // Import the library.
-                CopyOptions copyOptions = readOptions ? (CopyOptions) *readOptions : CopyOptions();
-                copyOptions.copySourceUris = true;
-                doc->importLibrary(library, &copyOptions);
+                doc->importLibrary(library, readOptions);
             }
 
             // Remove include directive.

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -66,14 +66,14 @@ TEST_CASE("Node", "[node]")
 
     // Create a custom nodedef.
     mx::NodeDefPtr customNodeDef = doc->addNodeDef("ND_turbulence3d", "float", "turbulence3d");
-    customNodeDef->setNodeCategory(mx::PROCEDURAL_NODE_CATEGORY);
+    customNodeDef->setNodeGroup(mx::PROCEDURAL_NODE_GROUP);
     customNodeDef->setParameterValue("octaves", 3);
     customNodeDef->setParameterValue("lacunarity", 2.0f);
     customNodeDef->setParameterValue("gain", 0.5f);
 
     // Reference the custom nodedef.
     mx::NodePtr custom = doc->addNodeInstance(customNodeDef);
-    REQUIRE(custom->getNodeDef()->getNodeCategory() == mx::PROCEDURAL_NODE_CATEGORY);
+    REQUIRE(custom->getNodeDef()->getNodeGroup() == mx::PROCEDURAL_NODE_GROUP);
     REQUIRE(custom->getParameterValue("octaves")->isA<int>());
     REQUIRE(custom->getParameterValue("octaves")->asA<int>() == 3);
     custom->setParameterValue("octaves", 5);

--- a/source/PyMaterialX/PyDefinition.cpp
+++ b/source/PyMaterialX/PyDefinition.cpp
@@ -18,9 +18,9 @@ void bindPyDefinition(py::module& mod)
         .def("setNodeString", &mx::NodeDef::setNodeString)
         .def("hasNodeString", &mx::NodeDef::hasNodeString)
         .def("getNodeString", &mx::NodeDef::getNodeString)
-        .def("setNodeCategory", &mx::NodeDef::setNodeCategory)
-        .def("hasNodeCategory", &mx::NodeDef::hasNodeCategory)
-        .def("getNodeCategory", &mx::NodeDef::getNodeCategory)
+        .def("setNodeGroup", &mx::NodeDef::setNodeGroup)
+        .def("hasNodeGroup", &mx::NodeDef::hasNodeGroup)
+        .def("getNodeGroup", &mx::NodeDef::getNodeGroup)
         .def("getImplementation", &mx::NodeDef::getImplementation)
         .def("getImplementation", &mx::NodeDef::getImplementation,
             py::arg("target") = mx::EMPTY_STRING,

--- a/source/PyMaterialX/PyElement.cpp
+++ b/source/PyMaterialX/PyElement.cpp
@@ -28,8 +28,7 @@ void bindPyElement(py::module& mod)
 {
     py::class_<mx::CopyOptions>(mod, "CopyOptions")
         .def(py::init())
-        .def_readwrite("skipDuplicateElements", &mx::CopyOptions::skipDuplicateElements)
-        .def_readwrite("copySourceUris", &mx::CopyOptions::copySourceUris);
+        .def_readwrite("skipDuplicateElements", &mx::CopyOptions::skipDuplicateElements);
 
     py::class_<mx::Element, mx::ElementPtr>(mod, "Element")
         .def(py::self == py::self)
@@ -100,6 +99,7 @@ void bindPyElement(py::module& mod)
         .def("setSourceUri", &mx::Element::setSourceUri)
         .def("hasSourceUri", &mx::Element::hasSourceUri)
         .def("getSourceUri", &mx::Element::getSourceUri)
+        .def("getActiveSourceUri", &mx::Element::getActiveSourceUri)
         .def("validate", [](mx::Element& elem)
             {
                 std::string message;


### PR DESCRIPTION
- Rename 'nodecategory' to 'nodegroup'.
- Add helper method Element::getActiveSourceUri.
- Fix a null check in GraphElement::flattenSubgraphs.
- Remove unneeded flag CopyOptions.copySourceUris.