### PR TITLE
Improvements to XInclude handling in MTLX files

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -489,7 +489,9 @@ class TestMaterialX(unittest.TestCase):
                 self.assertTrue(edgeCount > 0)
 
             # Serialize to XML.
-            xmlString = mx.writeToXmlString(doc, False)
+            writeOptions = mx.XmlWriteOptions()
+            writeOptions.writeXIncludeEnable = False
+            xmlString = mx.writeToXmlString(doc, writeOptions)
 
             # Verify that the serialized document is identical.
             writtenDoc = mx.createDocument()

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -63,7 +63,7 @@ class Document : public GraphElement
     /// @param copyOptions An optional pointer to a CopyOptions object.
     ///    If provided, then the given options will affect the behavior of the
     ///    import function.  Defaults to a null pointer.
-    void importLibrary(ConstDocumentPtr library, const class CopyOptions* copyOptions = nullptr);
+    void importLibrary(ConstDocumentPtr library, const CopyOptions* copyOptions = nullptr);
 
     /// @}
     /// @name NodeGraph Elements

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -25,6 +25,7 @@ class Token;
 class StringResolver;
 class Document;
 class Material;
+class CopyOptions;
 
 /// A shared pointer to an Element
 using ElementPtr = shared_ptr<Element>;
@@ -755,7 +756,7 @@ class Element : public std::enable_shared_from_this<Element>
     /// @param copyOptions An optional pointer to a CopyOptions object.
     ///    If provided, then the given options will affect the behavior of the
     ///    copy function.  Defaults to a null pointer.
-    void copyContentFrom(ConstElementPtr source, const class CopyOptions* copyOptions = nullptr);
+    void copyContentFrom(ConstElementPtr source, const CopyOptions* copyOptions = nullptr);
 
     /// Clear all attributes and descendants from this element.
     void clearContent();

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -16,20 +16,44 @@
 namespace MaterialX
 {
 
+class XmlReadOptions;
+
+/// A standard function that reads from an XML file into a Document, with
+/// optional search path and read options.
+using XmlReadFunction = std::function<void(DocumentPtr, string, string, const XmlReadOptions*)>;
+
 /// @class XmlReadOptions
 /// A set of options for controlling the behavior of XML read functions.
 class XmlReadOptions : public CopyOptions
 {
   public:
-    XmlReadOptions() :
-        readXIncludes(true)
-    {
-    }
+    XmlReadOptions();
     ~XmlReadOptions() { }
     
-    /// If true, XInclude references will be read from disk and included in the
-    /// document.  Defaults to true.
-    bool readXIncludes;
+    /// If provided, this function will be invoked when an XInclude reference
+    /// needs to be read into a document.  Defaults to readFromXmlFile.
+    XmlReadFunction readXIncludeFunction;
+
+    /// The set of parent filenames at the scope of the current document.
+    /// Defaults to an empty set.
+    std::set<string> parentFilenames;
+};
+
+/// @class XmlWriteOptions
+/// A set of options for controlling the behavior of XML write functions.
+class XmlWriteOptions
+{
+  public:
+    XmlWriteOptions();
+    ~XmlWriteOptions() { }
+
+    /// If true, elements with source file markings will be written as
+    /// XIncludes rather than explicit data.  Defaults to true.
+    bool writeXIncludeEnable;
+    
+    /// If provided, this function will be used to exclude specific elements
+    /// (those returning false) from the write operation.  Defaults to nullptr.
+    ElementPredicate elementPredicate;
 };
 
 /// @class ExceptionParseError
@@ -101,32 +125,26 @@ void readFromXmlString(DocumentPtr doc, const string& str, const XmlReadOptions*
 /// Write a Document as XML to the given output stream.
 /// @param doc The Document to be written.
 /// @param stream The output stream to which data is written
-/// @param writeXIncludes If true, elements with source file markings will be written
-///    as XIncludes rather than explicit data.  Defaults to true.
-/// @param predicate If provided, this function will be used to exclude specific elements
-///    (those returning false) from the write operation.
-void writeToXmlStream(DocumentPtr doc, std::ostream& stream, bool writeXIncludes = true,
-                      const ElementPredicate& predicate = ElementPredicate());
+/// @param writeOptions An optional pointer to an XmlWriteOptions object.
+///    If provided, then the given options will affect the behavior of the
+///    write function.  Defaults to a null pointer.
+void writeToXmlStream(DocumentPtr doc, std::ostream& stream, const XmlWriteOptions* writeOptions = nullptr);
 
 /// Write a Document as XML to the given filename.
 /// @param doc The Document to be written.
 /// @param filename The filename to which data is written
-/// @param writeXIncludes If true, elements with source file markings will be written
-///    as XIncludes rather than explicit data.  Defaults to true.
-/// @param predicate If provided, this function will be used to exclude specific elements
-///    (those returning false) from the write operation.
-void writeToXmlFile(DocumentPtr doc, const string& filename, bool writeXIncludes = true,
-                    const ElementPredicate& predicate = ElementPredicate());
+/// @param writeOptions An optional pointer to an XmlWriteOptions object.
+///    If provided, then the given options will affect the behavior of the
+///    write function.  Defaults to a null pointer.
+void writeToXmlFile(DocumentPtr doc, const string& filename, const XmlWriteOptions* writeOptions = nullptr);
 
 /// Write a Document as XML to a new string, returned by value.
 /// @param doc The Document to be written.
-/// @param writeXIncludes If true, elements with source file markings will be written
-///    as XIncludes rather than explicit data.  Defaults to true.
-/// @param predicate If provided, this function will be used to exclude specific elements
-///    (those returning false) from the write operation.
+/// @param writeOptions An optional pointer to an XmlWriteOptions object.
+///    If provided, then the given options will affect the behavior of the
+///    write function.  Defaults to a null pointer.
 /// @return The output string, returned by value
-string writeToXmlString(DocumentPtr doc, bool writeXIncludes = true,
-                        const ElementPredicate& predicate = ElementPredicate());
+string writeToXmlString(DocumentPtr doc, const XmlWriteOptions* writeOptions = nullptr);
 
 /// @}
 /// @name Edit Functions

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -94,7 +94,9 @@ TEST_CASE("Load content", "[xmlio]")
         }
 
         // Serialize to XML.
-        std::string xmlString = mx::writeToXmlString(doc, false);
+        mx::XmlWriteOptions writeOptions;
+        writeOptions.writeXIncludeEnable = false;
+        std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
 
         // Verify that the serialized document is identical.
         mx::DocumentPtr writtenDoc = mx::createDocument();
@@ -170,7 +172,7 @@ TEST_CASE("Load content", "[xmlio]")
     // Read document without XIncludes.
     mx::DocumentPtr flatDoc = mx::createDocument();
     readOptions = mx::XmlReadOptions();
-    readOptions.readXIncludes = false;
+    readOptions.readXIncludeFunction = nullptr;
     mx::readFromXmlFile(flatDoc, filename, searchPath, &readOptions);
     REQUIRE(*flatDoc != *doc);
 
@@ -179,7 +181,10 @@ TEST_CASE("Load content", "[xmlio]")
     {
         return !elem->isA<mx::Node>("image");
     };
-    std::string xmlString = mx::writeToXmlString(doc, false, skipImages);
+    mx::XmlWriteOptions writeOptions;
+    writeOptions.writeXIncludeEnable = false;
+    writeOptions.elementPredicate = skipImages;
+    std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
         
     // Reconstruct and verify that the document contains no images.
     mx::DocumentPtr writtenDoc = mx::createDocument();

--- a/source/PyMaterialX/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyXmlIo.cpp
@@ -15,16 +15,22 @@ void bindPyXmlIo(py::module& mod)
 {
     py::class_<mx::XmlReadOptions, mx::CopyOptions>(mod, "XmlReadOptions")
         .def(py::init())
-        .def_readwrite("readXIncludes", &mx::XmlReadOptions::readXIncludes);
+        .def_readwrite("readXIncludeFunction", &mx::XmlReadOptions::readXIncludeFunction)
+        .def_readwrite("parentFilenames", &mx::XmlReadOptions::parentFilenames);
+
+    py::class_<mx::XmlWriteOptions>(mod, "XmlWriteOptions")
+        .def(py::init())
+        .def_readwrite("writeXIncludeEnable", &mx::XmlWriteOptions::writeXIncludeEnable)
+        .def_readwrite("elementPredicate", &mx::XmlWriteOptions::elementPredicate);
 
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("readFromXmlString", &mx::readFromXmlString,
         py::arg("doc"), py::arg("str"), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("writeToXmlFile", mx::writeToXmlFile,
-        py::arg("doc"), py::arg("filename"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());
+        py::arg("doc"), py::arg("filename"), py::arg("writeOptions") = (mx::XmlWriteOptions*) nullptr);
     mod.def("writeToXmlString", mx::writeToXmlString,
-        py::arg("doc"), py::arg("writeXIncludes") = true, py::arg("predicate") = mx::ElementPredicate());
+        py::arg("doc"), py::arg("writeOptions") = nullptr);
     mod.def("prependXInclude", mx::prependXInclude);
 
     py::register_exception<mx::ExceptionParseError>(mod, "ExceptionParseError");


### PR DESCRIPTION
- Allow the client to override the callback function used to resolve XInclude references.  This is designed to allow multi-file MaterialX documents to be included in memory-mapped packages such as USDZ.
- Detect and disallow XInclude cycles.
- For consistency with XML reading, wrap XML write options within an XmlWriteOptions structure.