### PR TITLE
Add validation checks for matching types in data bindings

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -537,9 +537,11 @@ ValuePtr ValueElement::getDefaultValue() const
     }
 
     // Return the value, if any, stored in our declaration.
-    if (getParent()->isA<InterfaceElement>())
+    ConstElementPtr parent = getParent();
+    ConstInterfaceElementPtr interface = parent ? parent->asA<InterfaceElement>() : nullptr;
+    if (interface)
     {
-        ConstNodeDefPtr decl = getParent()->asA<InterfaceElement>()->getDeclaration();
+        ConstNodeDefPtr decl = interface->getDeclaration();
         if (decl)
         {
             ValueElementPtr value = decl->getActiveValueElement(getName());
@@ -570,7 +572,8 @@ Edge Token::getUpstreamEdge(ConstMaterialPtr material, size_t index) const
 {
     if (material && index < getUpstreamEdgeCount())
     {
-        ConstInterfaceElementPtr interface = getParent()->asA<InterfaceElement>();
+        ConstElementPtr parent = getParent();
+        ConstInterfaceElementPtr interface = parent ? parent->asA<InterfaceElement>() : nullptr;
         ConstNodeDefPtr nodeDef = interface ? interface->getDeclaration() : nullptr;
         if (nodeDef)
         {

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -84,7 +84,8 @@ Edge Parameter::getUpstreamEdge(ConstMaterialPtr material, size_t index) const
 {
     if (material && index < getUpstreamEdgeCount())
     {
-        ConstInterfaceElementPtr interface = getParent()->asA<InterfaceElement>();
+        ConstElementPtr parent = getParent();
+        ConstInterfaceElementPtr interface = parent ? parent->asA<InterfaceElement>() : nullptr;
         ConstNodeDefPtr nodeDef = interface ? interface->getDeclaration() : nullptr;
         if (nodeDef)
         {
@@ -116,7 +117,8 @@ Edge Input::getUpstreamEdge(ConstMaterialPtr material, size_t index) const
 {
     if (material && index < getUpstreamEdgeCount())
     {
-        ConstInterfaceElementPtr interface = getParent()->asA<InterfaceElement>();
+        ConstElementPtr parent = getParent();
+        ConstInterfaceElementPtr interface = parent ? parent->asA<InterfaceElement>() : nullptr;
         ConstNodeDefPtr nodeDef = interface ? interface->getDeclaration() : nullptr;
         if (nodeDef)
         {

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -145,6 +145,28 @@ bool Material::validate(string* message) const
 }
 
 //
+// BindParam methods
+//
+
+bool BindParam::validate(string* message) const
+{
+    bool res = true;
+    ConstElementPtr parent = getParent();
+    ConstShaderRefPtr shaderRef = parent ? parent->asA<ShaderRef>() : nullptr;
+    NodeDefPtr nodeDef = shaderRef ? shaderRef->getNodeDef() : nullptr;
+    if (nodeDef)
+    {
+        ParameterPtr param = nodeDef->getActiveParameter(getName());
+        validateRequire(param != nullptr, res, message, "BindParam does not match an Parameter in the referenced NodeDef");
+        if (param)
+        {
+            validateRequire(getType() == param->getType(), res, message, "Type mismatch between BindParam and Parameter");
+        }
+    }
+    return ValueElement::validate(message) && res;
+}
+
+//
 // BindInput methods
 //
 
@@ -178,6 +200,24 @@ OutputPtr BindInput::getConnectedOutput() const
         return nodeGraph ? nodeGraph->getOutput(getOutputString()) : OutputPtr();
     }
     return getDocument()->getOutput(getOutputString());
+}
+
+bool BindInput::validate(string* message) const
+{
+    bool res = true;
+    ConstElementPtr parent = getParent();
+    ConstShaderRefPtr shaderRef = parent ? parent->asA<ShaderRef>() : nullptr;
+    NodeDefPtr nodeDef = shaderRef ? shaderRef->getNodeDef() : nullptr;
+    if (nodeDef)
+    {
+        InputPtr input = nodeDef->getActiveInput(getName());
+        validateRequire(input != nullptr, res, message, "BindInput does not match an Input in the referenced NodeDef");
+        if (input)
+        {
+            validateRequire(getType() == input->getType(), res, message, "Type mismatch between BindInput and Input");
+        }
+    }
+    return ValueElement::validate(message) && res;
 }
 
 //

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -227,6 +227,15 @@ class BindParam : public ValueElement
     }
     virtual ~BindParam() { }
 
+    /// @name Validation
+    /// @{
+
+    /// Validate that the given element tree, including all descendants, is
+    /// consistent with the MaterialX specification.
+    bool validate(string* message = nullptr) const override;
+
+    /// @}
+
   public:
     static const string CATEGORY;
 };
@@ -298,6 +307,14 @@ class BindInput : public ValueElement
 
     /// Return the output, if any, to which the BindInput is connected.
     OutputPtr getConnectedOutput() const;
+
+    /// @}
+    /// @name Validation
+    /// @{
+
+    /// Validate that the given element tree, including all descendants, is
+    /// consistent with the MaterialX specification.
+    bool validate(string* message = nullptr) const override;
 
     /// @}
 

--- a/source/MaterialXTest/Document.cpp
+++ b/source/MaterialXTest/Document.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Document", "[document]")
     output->setConnectedNode(constant);
     REQUIRE(doc->validate());
 
-    // Create and test a type mismatch.
+    // Create and test a type mismatch in a connection.
     output->setType("float");
     REQUIRE(!doc->validate());
     output->setType("color3");
@@ -56,6 +56,17 @@ TEST_CASE("Document", "[document]")
     mx::BindInputPtr bindInput = shaderRef->addBindInput("diffColor");
     bindInput->setConnectedOutput(output);
     REQUIRE(diffColor->getUpstreamElement(material) == output);
+
+    // Bind the roughness parameter to a value.
+    mx::BindParamPtr bindParam = shaderRef->addBindParam("roughness");
+    bindParam->setValue(0.5f);
+    REQUIRE(roughness->getBoundValue(material)->asA<float>() == 0.5f);
+
+    // Create and test a type mismatch in a data binding.
+    bindParam->setValue(5);
+    REQUIRE(!doc->validate());
+    bindParam->setValue(0.5f);
+    REQUIRE(doc->validate());
 
     // Create a collection 
     mx::CollectionPtr collection = doc->addCollection();


### PR DESCRIPTION
This changelist adds validation checks for the data types of BindParam and BindInput elements, making sure that they match the types of their corresponding Parameter and Input elements.  Documents with mismatching types will now return false with error messages when Document.validate is called.