### PR TITLE
Improvements to vector and matrix classes

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -82,6 +82,8 @@ class TestMaterialX(unittest.TestCase):
         v3 = mx.Vector4(4)
         self.assertTrue(v3.getMagnitude() == 8)
         self.assertTrue(v3.getNormalized().getMagnitude() == 1)
+        self.assertTrue(v1.dot(v2) == 28)
+        self.assertTrue(v1.cross(v2) == mx.Vector3())
 
         # Vector copy
         v4 = v2.copy()

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -53,6 +53,7 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
     explicit VectorN(S s) { _arr.fill(s); }
     explicit VectorN(const std::array<S, N>& arr) : _arr(arr) { }
     explicit VectorN(const vector<float>& vec) { std::copy_n(vec.begin(), N, _arr.begin()); }
+    explicit VectorN(const S* buf) { std::copy_n(buf, N, _arr.begin()); }
 
     /// @}
     /// @name Equality Operators
@@ -187,6 +188,15 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
         return *this / getMagnitude();
     }
 
+    /// Return the dot product of two vectors.
+    S dot(const V& rhs) const
+    {
+        S res{};
+        for (size_t i = 0; i < N; i++)
+            res += _arr[i] * rhs[i];
+        return res;
+    }
+
     /// @}
     /// @name Iterators
     /// @{
@@ -221,6 +231,12 @@ class Vector2 : public VectorN<Vector2, float, 2>
     {
         _arr = {x, y};
     }
+
+    /// Return the cross product of two vectors.
+    float cross(const Vector2& rhs) const
+    {
+        return _arr[0] * rhs[1] - _arr[1] * rhs[0];
+    }
 };
 
 /// @class Vector3
@@ -233,6 +249,14 @@ class Vector3 : public VectorN<Vector3, float, 3>
     Vector3(float x, float y, float z) : VectorN(Uninit{})
     {
         _arr = {x, y, z};
+    }
+
+    /// Return the cross product of two vectors.
+    Vector3 cross(const Vector3& rhs) const
+    {
+        return Vector3(_arr[1] * rhs[2] - _arr[2] * rhs[1],
+                       _arr[2] * rhs[0] - _arr[0] * rhs[2],
+                       _arr[0] * rhs[1] - _arr[1] * rhs[0]);
     }
 };
 
@@ -294,7 +318,8 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
   public:
     MatrixN() : _arr{} { }
     explicit MatrixN(Uninit) { }
-    explicit MatrixN(S s) { for (RowArray& row : _arr) row.fill(s); }
+    explicit MatrixN(S s) { std::fill_n(&_arr[0][0], N * N, s); }
+    explicit MatrixN(const S* buf) { std::copy_n(buf, N * N, &_arr[0][0]); }
 
     /// @}
     /// @name Equality Operators

--- a/source/MaterialXTest/Types.cpp
+++ b/source/MaterialXTest/Types.cpp
@@ -42,6 +42,8 @@ TEST_CASE("Vectors", "[types]")
     mx::Vector4 v3(4);
     REQUIRE(v3.getMagnitude() == 8);
     REQUIRE(v3.getNormalized().getMagnitude() == 1);
+    REQUIRE(v1.dot(v2) == 28);
+    REQUIRE(v1.cross(v2) == mx::Vector3());
 }
 
 TEST_CASE("Matrices", "[types]")

--- a/source/PyMaterialX/PyTypes.cpp
+++ b/source/PyMaterialX/PyTypes.cpp
@@ -31,6 +31,7 @@ using IndexPair = std::pair<size_t, size_t>;
 .def(py::self / float())                                \
 .def("getMagnitude", &V::getMagnitude)                  \
 .def("getNormalized", &V::getNormalized)                \
+.def("dot", &V::dot)                                    \
 .def("__getitem__", [](V& v, size_t i)                  \
     { return v[i]; } )                                  \
 .def("__setitem__", [](V& v, size_t i, float f)         \
@@ -77,11 +78,13 @@ void bindPyTypes(py::module& mod)
     py::class_<mx::Vector2, mx::VectorBase>(mod, "Vector2")
         BIND_VECTOR_SUBCLASS(mx::Vector2, 2)
         .def(py::init<float, float>())
+        .def("cross", &mx::Vector2::cross)
         .def("asTuple", [](const mx::Vector2& v) { return std::make_tuple(v[0], v[1]); });
 
     py::class_<mx::Vector3, mx::VectorBase>(mod, "Vector3")
         BIND_VECTOR_SUBCLASS(mx::Vector3, 3)
         .def(py::init<float, float, float>())
+        .def("cross", &mx::Vector3::cross)
         .def("asTuple", [](const mx::Vector3& v) { return std::make_tuple(v[0], v[1], v[2]); });
 
     py::class_<mx::Vector4, mx::VectorBase>(mod, "Vector4")


### PR DESCRIPTION
- Add vector and matrix constructors taking scalar buffers, allowing for more straightforward conversions between vector/matrix libraries.
- Add vector dot and cross products.
- Simplify the implementation of the matrix constructor taking a single scalar.