### PR TITLE
Refine the behavior of InterfaceElement::isTypeCompatible

### DIFF
--- a/documents/Examples/NodeGraphs.mtlx
+++ b/documents/Examples/NodeGraphs.mtlx
@@ -84,8 +84,8 @@
     </mix>
     <texcoord name="t1" type="vector2"/>
     <multiply name="m1" type="vector2">
-      <input name="in" type="vector2" nodename="t1"/>
-      <parameter name="amount" type="float" value="0.003"/>
+      <input name="in1" type="vector2" nodename="t1"/>
+      <input name="in2" type="float" value="0.003"/>
     </multiply>
     <noise2d name="n9" type="color3">
       <input name="texcoord" type="vector2" nodename="m1"/>

--- a/documents/Libraries/stdlib_ng.mtlx
+++ b/documents/Libraries/stdlib_ng.mtlx
@@ -2060,7 +2060,7 @@
   <nodegraph name="NG_saturate_color3" nodedef="ND_saturate_color3">
     <luminance name="N_gray_color3" type="color3">
       <input name="in" type="color3" interfacename="in"/>
-      <input name="lumacoeffs" type="color3" interfacename="lumacoeffs"/>
+      <parameter name="lumacoeffs" type="color3" interfacename="lumacoeffs"/>
     </luminance>
     <mix name="N_mix_color3" type="color3">
       <input name="bg" type="color3" nodename="N_gray_color3"/>
@@ -2073,7 +2073,7 @@
   <nodegraph name="NG_saturate_color4" nodedef="ND_saturate_color4">
     <luminance name="N_gray_color4" type="color4">
       <input name="in" type="color4" interfacename="in"/>
-      <input name="lumacoeffs" type="color3" interfacename="lumacoeffs"/>
+      <parameter name="lumacoeffs" type="color3" interfacename="lumacoeffs"/>
     </luminance>
     <mix name="N_mix_color4" type="color4">
       <input name="bg" type="color4" nodename="N_gray_color4"/>

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -392,24 +392,18 @@ ConstNodeDefPtr InterfaceElement::getDeclaration(const string&) const
     return NodeDefPtr();
 }
 
-bool InterfaceElement::isTypeCompatible(ConstInterfaceElementPtr rhs) const
+bool InterfaceElement::isTypeCompatible(ConstInterfaceElementPtr declaration) const
 {
-    if (getType() != rhs->getType())
+    if (getType() != declaration->getType())
     {
         return false;
     }
-    for (ParameterPtr param : getActiveParameters())
+    for (ValueElementPtr value : getActiveValueElements())
     {
-        ParameterPtr matchingParam = rhs->getActiveParameter(param->getName());
-        if (matchingParam && matchingParam->getType() != param->getType())
-        {
-            return false;
-        }
-    }
-    for (InputPtr input : getActiveInputs())
-    {
-        InputPtr matchingInput = rhs->getActiveInput(input->getName());
-        if (matchingInput && matchingInput->getType() != input->getType())
+        ValueElementPtr declarationValue = declaration->getActiveValueElement(value->getName());
+        if (!declarationValue ||
+            declarationValue->getCategory() != value->getCategory() ||
+            declarationValue->getType() != value->getType())
         {
             return false;
         }

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -540,7 +540,7 @@ class InterfaceElement : public TypedElement
         TokenPtr token = getToken(name);
         if (!token)
             token = addToken(name);
-        token->setValue<std::string>(value);
+        token->setValue<string>(value);
         return token;
     }
 
@@ -564,18 +564,15 @@ class InterfaceElement : public TypedElement
     ///    no declaration was found.
     virtual ConstNodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const;
 
-    /// Return true if the given interface element is type compatible with
-    /// this one.  This may be used to test, for example, whether a NodeDef
-    /// and Node may be used together.
+    /// Return true if this interface instance is type compatible with the given
+    /// interface declaration.  This may be used to test, for example, whether a
+    /// Node is an instantiation of a given NodeDef.
     ///
-    /// If the type string of the given interface element differs from this
-    /// one, then false is returned.
-    ///
-    /// If the two interface elements have child Parameter or Input elements
-    /// with identical names but different types, then false is returned.  Note
-    /// that a Parameter or Input that is present in only one of the two
-    /// interfaces does not affect their type compatibility.
-    bool isTypeCompatible(ConstInterfaceElementPtr rhs) const;
+    /// If the type string of the instance differs from that of the declaration,
+    /// then false is returned.  If the instance possesses a Parameter or Input
+    /// with no Parameter or Input of matching type in the declaration, then
+    /// false is returned.
+    bool isTypeCompatible(ConstInterfaceElementPtr declaration) const;
 
     /// @}
 


### PR DESCRIPTION
This changelist refines the behavior of InterfaceElement::isTypeCompatible, clarifying that the calling element is the interface instance, and the argument element is the interface declaration.  An interface declaration is allowed to have extra Parameter or Input elements without affecting type compatibility, but an interface instance is not.