### PR TITLE
Add support for nodedef attributes on Node elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## [1.36.2] - Development
 
 ### Added
+- Added support for 'nodedef' attributes on MaterialX\:\:Node, integrating this usage into GraphElement\:\:addNodeInstance.
 - Added support for GCC 8 and Clang 7.
+
+### Changed
+- Added callbacks Observer\:\:onCopyContent and Observer\:\:onClearContent, and removed callback Observer::onInitialize.
 
 ## [1.36.1] - 2018-12-18
 

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -97,7 +97,7 @@ class Document::Cache
                 if (!nodeDefString.empty())
                 {
                     InterfaceElementPtr interface = elem->asA<InterfaceElement>();
-                    if (interface)
+                    if (interface && (interface->isA<Implementation>() || interface->isA<NodeGraph>()))
                     {
                         implementationMap.insert(std::pair<string, InterfaceElementPtr>(
                             interface->getQualifiedName(nodeDefString),

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -287,9 +287,9 @@ vector<TokenPtr> InterfaceElement::getActiveTokens() const
 
 ValueElementPtr InterfaceElement::getActiveValueElement(const string& name) const
 {
-    for (ConstElementPtr elem : traverseInheritance())
+    for (ConstElementPtr interface : traverseInheritance())
     {
-       ValueElementPtr valueElem = elem->asA<InterfaceElement>()->getChildOfType<ValueElement>(name);
+        ValueElementPtr valueElem = interface->getChildOfType<ValueElement>(name);
         if (valueElem)
         {
             return valueElem;
@@ -301,9 +301,9 @@ ValueElementPtr InterfaceElement::getActiveValueElement(const string& name) cons
 vector<ValueElementPtr> InterfaceElement::getActiveValueElements() const
 {
     vector<ValueElementPtr> activeValueElems;
-    for (ConstElementPtr elem : traverseInheritance())
+    for (ConstElementPtr interface : traverseInheritance())
     {
-        vector<ValueElementPtr> valueElems = elem->asA<InterfaceElement>()->getChildrenOfType<ValueElement>();
+        vector<ValueElementPtr> valueElems = interface->getChildrenOfType<ValueElement>();
         activeValueElems.insert(activeValueElems.end(), valueElems.begin(), valueElems.end());
     }
     return activeValueElems;

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -68,6 +68,10 @@ string Node::getConnectedNodeName(const string& inputName) const
 
 NodeDefPtr Node::getNodeDef(const string& target) const
 {
+    if (hasNodeDefString())
+    {
+        return resolveRootNameReference<NodeDef>(getNodeDefString());
+    }
     vector<NodeDefPtr> nodeDefs = getDocument()->getMatchingNodeDefs(getQualifiedName(getCategory()));
     vector<NodeDefPtr> secondary = getDocument()->getMatchingNodeDefs(getCategory());
     nodeDefs.insert(nodeDefs.end(), secondary.begin(), secondary.end());

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -179,7 +179,9 @@ class GraphElement : public InterfaceElement
     /// Add a Node that is an instance of the given NodeDef.
     NodePtr addNodeInstance(ConstNodeDefPtr nodeDef, const string& name = EMPTY_STRING)
     {
-        return addNode(nodeDef->getNodeString(), name, nodeDef->getType());
+        NodePtr node = addNode(nodeDef->getNodeString(), name, nodeDef->getType());
+        node->setNodeDefString(nodeDef->getName());
+        return node;
     }
 
     /// Return the Node, if any, with the given name.

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -73,11 +73,17 @@ TEST_CASE("Node", "[node]")
 
     // Reference the custom nodedef.
     mx::NodePtr custom = doc->addNodeInstance(customNodeDef);
+    REQUIRE(custom->getNodeDefString() == customNodeDef->getName());
     REQUIRE(custom->getNodeDef()->getNodeGroup() == mx::PROCEDURAL_NODE_GROUP);
     REQUIRE(custom->getParameterValue("octaves")->isA<int>());
     REQUIRE(custom->getParameterValue("octaves")->asA<int>() == 3);
     custom->setParameterValue("octaves", 5);
     REQUIRE(custom->getParameterValue("octaves")->asA<int>() == 5);
+
+    // Remove the nodedef attribute from the node, requiring that it fall back
+    // to type and version matching.
+    custom->removeAttribute(mx::NodeDef::NODE_DEF_ATTRIBUTE);
+    REQUIRE(custom->getNodeDef() == customNodeDef);
 
     // Set nodedef and node version strings.
     customNodeDef->setVersionString("2.0");


### PR DESCRIPTION
This changelist adds support for 'nodedef' attributes on Node elements, integrating this usage into the existing method GraphElement::addNodeInstance.