### PR TITLE
Refactor build options for MaterialX Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,16 @@ matrix:
     # Custom builds
     - os: linux
       compiler: gcc
-      env: MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+      env: MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+    - os: linux
+      compiler: gcc
+      env: MATRIX_EVAL="CC=gcc-8 && CXX=g++-8 && CMAKE_EXTRA_ARGS='-DMATERIALX_PYTHON_LTO=OFF'"
       addons:
         apt:
           sources:
@@ -39,7 +48,7 @@ before_install:
 script:
   - mkdir build
   - cd build
-  - cmake -DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_PYTHON_VERSION=2 -DMATERIALX_INSTALL_PYTHON=OFF -DMATERIALX_WARNINGS_AS_ERRORS=ON ..
+  - cmake -DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_PYTHON_VERSION=2 -DMATERIALX_INSTALL_PYTHON=OFF -DMATERIALX_WARNINGS_AS_ERRORS=ON ${CMAKE_EXTRA_ARGS} ..
   - cmake --build . --target install -- -j4
   - ctest --output-on-failure
   - export PYTHONPATH=$PYTHONPATH:$PWD/installed/python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ enable_testing()
 
 option(MATERIALX_BUILD_PYTHON "Build the MaterialX Python package from C++ bindings. Requires Python 2.6 or greater." OFF)
 option(MATERIALX_BUILD_DOCS "Create HTML documentation using Doxygen. Requires that Doxygen be installed." OFF)
+option(MATERIALX_PYTHON_LTO "Enable link-time optimizations for MaterialX Python." ON)
 option(MATERIALX_INSTALL_PYTHON "Install the MaterialX Python package as a third-party library when the install target is built." ON)
 option(MATERIALX_WARNINGS_AS_ERRORS "Interpret all compiler warnings as errors." OFF)
 
@@ -26,15 +27,13 @@ set(MATERIALX_PYTHON_PYBIND11_DIR "${CMAKE_CURRENT_SOURCE_DIR}/source/PyMaterial
     "Path to a folder containing the PyBind11 source. Defaults to the included PyBind11 source, which has been extended to support Python 2.6.")
 
 mark_as_advanced(MATERIALX_BUILD_DOCS)
+mark_as_advanced(MATERIALX_PYTHON_LTO)
+mark_as_advanced(MATERIALX_INSTALL_PYTHON)
+mark_as_advanced(MATERIALX_WARNINGS_AS_ERRORS)
 mark_as_advanced(MATERIALX_PYTHON_VERSION)
 mark_as_advanced(MATERIALX_PYTHON_EXECUTABLE)
 mark_as_advanced(MATERIALX_PYTHON_OCIO_DIR)
 mark_as_advanced(MATERIALX_PYTHON_PYBIND11_DIR)
-mark_as_advanced(MATERIALX_INSTALL_PYTHON)
-mark_as_advanced(MATERIALX_WARNINGS_AS_ERRORS)
-
-set(PYBIND11_PYTHON_VERSION ${MATERIALX_PYTHON_VERSION})
-set(PYTHON_EXECUTABLE ${MATERIALX_PYTHON_EXECUTABLE})
 
 # Adjust the default installation path
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/source/PyMaterialX/CMakeLists.txt
+++ b/source/PyMaterialX/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(PYBIND11_INCLUDE_DIR "${MATERIALX_PYTHON_PYBIND11_DIR}/include")
 set(PYBIND11_COMMON_H "${PYBIND11_INCLUDE_DIR}/pybind11/detail/common.h")
+set(PYBIND11_PYTHON_VERSION ${MATERIALX_PYTHON_VERSION})
+set(PYTHON_EXECUTABLE ${MATERIALX_PYTHON_EXECUTABLE})
 
 if(NOT EXISTS "${PYBIND11_COMMON_H}")
 message(FATAL_ERROR "PyBind11 source file not found: ${PYBIND11_COMMON_H}")
@@ -27,11 +29,15 @@ file(GLOB pymaterialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 list(APPEND CMAKE_MODULE_PATH "${MATERIALX_PYTHON_PYBIND11_DIR}/tools")
 include(pybind11Tools)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
-    set(PYBIND11_PLATFORM_FLAGS "NO_EXTRAS")
+if(NOT MATERIALX_PYTHON_LTO)
+    set(PYBIND11_MODULE_FLAGS "NO_EXTRAS")
 endif()
 
-pybind11_add_module(PyMaterialX SHARED ${PYBIND11_PLATFORM_FLAGS} ${pymaterialx_source} ${pymaterialx_headers})
+pybind11_add_module(PyMaterialX SHARED ${PYBIND11_MODULE_FLAGS} ${pymaterialx_source} ${pymaterialx_headers})
+
+if(APPLE)
+    set_target_properties(PyMaterialX PROPERTIES CXX_VISIBILITY_PRESET "default")
+endif()
 
 set_target_properties(
     PyMaterialX

--- a/source/PyMaterialX/PyBind11/tools/pybind11Tools.cmake
+++ b/source/PyMaterialX/PyBind11/tools/pybind11Tools.cmake
@@ -145,7 +145,7 @@ function(pybind11_add_module target_name)
   # py::module_local).  We force it on everything inside the `pybind11`
   # namespace; also turning it on for a pybind module compilation here avoids
   # potential warnings or issues from having mixed hidden/non-hidden types.
-  #set_target_properties(${target_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
+  set_target_properties(${target_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
 
   if(WIN32 OR CYGWIN)
     # Link against the Python shared library on Windows


### PR DESCRIPTION
- Add a MATERIALX_PYTHON_LTO flag, which enables and disables link-time optimizations for MaterialX Python.
- Move platform-specific visibility settings from PyBind11 to PyMaterialX.
- Build both GCC 6 and 8 in Travis, disabling LTO only for GCC 8.