### PR TITLE
Allow angle brackets in MTLX serialization

### DIFF
--- a/source/MaterialXFormat/PugiXML/pugixml.cpp
+++ b/source/MaterialXFormat/PugiXML/pugixml.cpp
@@ -3922,11 +3922,13 @@ PUGI__NS_BEGIN
 					++s;
 					break;
 				case '<':
-					writer.write('&', 'l', 't', ';');
+					// MaterialX: Allow angle brackets in MTLX serialization.
+					writer.write(*s);
 					++s;
 					break;
 				case '>':
-					writer.write('&', 'g', 't', ';');
+					// MaterialX: Allow angle brackets in MTLX serialization.
+					writer.write(*s);
 					++s;
 					break;
 				case '"':


### PR DESCRIPTION
This changelist modifies PugiXML to allow angle brackets in MTLX serialization, so that geometry tokens (e.g. <UDIM>) are written out unmodified.