### PR TITLE
Add support for search path specified in environment variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ if(MSVC)
     if(MATERIALX_WARNINGS_AS_ERRORS)
         add_compile_options(/WX)
     endif()
+    # Temporarily disable secure warnings for setenv in windows, until cross-platform 
+    # getEnvironmentVar/setEnvironmentVar functions are added.
+    add_compile_options(/D_CRT_SECURE_NO_WARNINGS)
 else()
     add_compile_options(-Wall -Wno-missing-braces)
     if(MATERIALX_WARNINGS_AS_ERRORS)

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -27,7 +27,6 @@ _fileDir = os.path.dirname(os.path.abspath(__file__))
 _libraryDir = os.path.join(_fileDir, '../../documents/Libraries/stdlib/')
 _exampleDir = os.path.join(_fileDir, '../../documents/Examples/')
 _searchPath = _libraryDir + mx.PATH_LIST_SEPARATOR + _exampleDir
-_searchPathEnv = mx.MATERIALX_SEARCH_PATH_ENV_VAR
 
 _libraryFilenames = ('stdlib_defs.mtlx',
                      'stdlib_ng.mtlx',
@@ -515,15 +514,6 @@ class TestMaterialX(unittest.TestCase):
         mx.readFromXmlFile(doc, filename, _searchPath, readOptions)
         mx.readFromXmlFile(doc, filename, _searchPath, readOptions)
         self.assertTrue(doc.validate()[0])
-
-        # Read document using environment search path.
-        os.environ[_searchPathEnv] = _searchPath
-        envDoc = mx.createDocument()
-        readOptions = mx.XmlReadOptions()
-        filename = 'MaterialBasic.mtlx'
-        mx.readFromXmlFile(envDoc, filename, '', readOptions)
-        self.assertTrue(envDoc.validate()[0])
-        os.environ.pop(_searchPathEnv)
 
 #--------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -26,7 +26,8 @@ _testValues = (1,
 _fileDir = os.path.dirname(os.path.abspath(__file__))
 _libraryDir = os.path.join(_fileDir, '../../documents/Libraries/stdlib/')
 _exampleDir = os.path.join(_fileDir, '../../documents/Examples/')
-_searchPath = _libraryDir + ';' + _exampleDir
+_searchPath = _libraryDir + mx.PATH_LIST_SEPARATOR + _exampleDir
+_searchPathEnv = mx.MATERIALX_SEARCH_PATH_ENV_VAR
 
 _libraryFilenames = ('stdlib_defs.mtlx',
                      'stdlib_ng.mtlx',
@@ -515,6 +516,14 @@ class TestMaterialX(unittest.TestCase):
         mx.readFromXmlFile(doc, filename, _searchPath, readOptions)
         self.assertTrue(doc.validate()[0])
 
+        # Read document using environment search path.
+        os.environ[_searchPathEnv] = _searchPath
+        envDoc = mx.createDocument()
+        readOptions = mx.XmlReadOptions()
+        filename = 'MaterialBasic.mtlx'
+        mx.readFromXmlFile(envDoc, filename, '', readOptions)
+        self.assertTrue(envDoc.validate()[0])
+        os.environ.pop(_searchPathEnv)
 
 #--------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -27,6 +27,13 @@ const string VALID_SEPARATORS_POSIX = "/";
 const char PREFERRED_SEPARATOR_WINDOWS = '\\';
 const char PREFERRED_SEPARATOR_POSIX = '/';
 
+#if defined(_WIN32)
+const string PATH_LIST_SEPARATOR = ";";
+#else
+const string PATH_LIST_SEPARATOR = ":";
+#endif
+const string MATERIALX_SEARCH_PATH_ENV_VAR = "MATERIALX_SEARCH_PATH";
+
 //
 // FilePath methods
 //
@@ -138,6 +145,18 @@ FilePath FilePath::getCurrentPath()
     }
     return FilePath(buf);
 #endif
+}
+
+FileSearchPath getEnvironmentPath(const string& sep)
+{
+    const char* searchPathEnv = std::getenv(MATERIALX_SEARCH_PATH_ENV_VAR.c_str());
+
+    if (!searchPathEnv)
+    {
+        searchPathEnv = "";
+    }
+
+    return FileSearchPath(searchPathEnv, sep);
 }
 
 } // namespace MaterialX

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -117,10 +117,10 @@ void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions
 
 void xmlDocumentFromFile(xml_document& xmlDoc, string filename, const string& searchPath)
 {
-    if (!searchPath.empty())
-    {
-        filename = FileSearchPath(searchPath).find(filename);
-    }
+    FileSearchPath fileSearchPath = FileSearchPath(searchPath);
+    fileSearchPath.append(getEnvironmentPath());
+
+    filename = fileSearchPath.find(filename);
 
     xml_parse_result result = xmlDoc.load_file(filename.c_str());
     if (!result)

--- a/source/MaterialXTest/File.cpp
+++ b/source/MaterialXTest/File.cpp
@@ -46,3 +46,23 @@ TEST_CASE("File system operations", "[file]")
         REQUIRE(mx::FileSearchPath().find(path).exists());
     }
 }
+
+TEST_CASE("File search path operations", "[file]")
+{
+    std::string searchPath = "documents/Libraries/stdlib" + 
+                             mx::PATH_LIST_SEPARATOR + 
+                             "documents/Examples";
+
+    std::vector<std::string> filenames =
+    {
+        "stdlib_defs.mtlx",
+        "MaterialBasic.mtlx",
+        "PaintMaterials.mtlx",
+    };
+
+    for (const std::string& filename : filenames)
+    {
+        mx::FilePath path(filename);
+        REQUIRE(mx::FileSearchPath(searchPath, mx::PATH_LIST_SEPARATOR).find(path).exists());
+    }
+}

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -8,6 +8,7 @@
 #include <MaterialXCore/Definition.h>
 #include <MaterialXCore/Document.h>
 
+#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/XmlIo.h>
 
 namespace mx = MaterialX;
@@ -136,9 +137,11 @@ TEST_CASE("Node", "[node]")
 
 TEST_CASE("Flatten", "[nodegraph]")
 {
+    std::string searchPath = "documents/Examples" + mx::PATH_LIST_SEPARATOR + "documents/Libraries/stdlib";
+
     // Read the example file.
     mx::DocumentPtr doc = mx::createDocument();
-    mx::readFromXmlFile(doc, "SubGraphs.mtlx", "documents/Examples;documents/Libraries/stdlib");
+    mx::readFromXmlFile(doc, "SubGraphs.mtlx", searchPath);
 
     // Find the example graph.
     mx::NodeGraphPtr graph = doc->getNodeGraph("subgraph_ex1");

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -32,7 +32,12 @@ TEST_CASE("Load content", "[xmlio]")
         "BxDF/Disney_BRDF_2012.mtlx",
         "BxDF/Disney_BSDF_2015.mtlx",
     };
-    std::string searchPath = "documents/Libraries/stdlib;documents/Libraries/stdlib/osl;documents/Examples";
+
+    std::string searchPath = "documents/Libraries/stdlib" + 
+                             mx::PATH_LIST_SEPARATOR + 
+                             "documents/Libraries/stdlib/osl" + 
+                             mx::PATH_LIST_SEPARATOR + 
+                             "documents/Examples";
 
     // Read the standard library.
     std::vector<mx::DocumentPtr> libs;
@@ -40,7 +45,13 @@ TEST_CASE("Load content", "[xmlio]")
     {
         mx::DocumentPtr lib = mx::createDocument();
         mx::readFromXmlFile(lib, filename, searchPath);
-        REQUIRE(lib->validate());
+        std::string message;
+        bool docValid = lib->validate(&message);
+        if (!docValid)
+        {
+            WARN("[" + filename + "] " + message);
+        }
+        REQUIRE(docValid);
         libs.push_back(lib);
     }
 

--- a/source/PyMaterialX/PyUtil.cpp
+++ b/source/PyMaterialX/PyUtil.cpp
@@ -5,9 +5,10 @@
 
 #include <PyMaterialX/PyMaterialX.h>
 
+#include <MaterialXCore/Node.h>
 #include <MaterialXCore/Util.h>
 
-#include <MaterialXCore/Node.h>
+#include <MaterialXFormat/File.h>
 
 namespace py = pybind11;
 namespace mx = MaterialX;
@@ -22,4 +23,7 @@ void bindPyUtil(py::module& mod)
     mod.def("splitString", &mx::splitString);
     mod.def("replaceSubstrings", &mx::replaceSubstrings);
     mod.def("prettyPrint", &mx::prettyPrint);
+
+    mod.attr("PATH_LIST_SEPARATOR") = mx::PATH_LIST_SEPARATOR;
+    mod.attr("MATERIALX_SEARCH_PATH_ENV_VAR") = mx::MATERIALX_SEARCH_PATH_ENV_VAR;
 }


### PR DESCRIPTION
This changelist adds the ability to specify a search path in an environment variable (MATERIALX_SEARCH_PATH). This search path is appended when loading a MaterialX document in xmlDocumentFromFile().