### PR TITLE
Adding cross platform get/set env var functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,6 @@ if(MSVC)
     if(MATERIALX_WARNINGS_AS_ERRORS)
         add_compile_options(/WX)
     endif()
-    # Temporarily disable secure warnings for setenv in windows, until cross-platform 
-    # getEnvironmentVar/setEnvironmentVar functions are added.
-    add_compile_options(/D_CRT_SECURE_NO_WARNINGS)
 else()
     add_compile_options(-Wall -Wno-missing-braces)
     if(MATERIALX_WARNINGS_AS_ERRORS)

--- a/source/MaterialXFormat/Environ.cpp
+++ b/source/MaterialXFormat/Environ.cpp
@@ -1,0 +1,59 @@
+//
+// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXFormat/Environ.h>
+
+#include <MaterialXCore/Library.h>
+#include <MaterialXCore/Util.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+namespace MaterialX
+{
+
+string getEnviron(const string& name)
+{
+#if defined(_WIN32)
+    DWORD size = GetEnvironmentVariable(name.c_str(), nullptr, 0);
+
+    if (size != 0 && size != ERROR_ENVVAR_NOT_FOUND) 
+    {
+        std::unique_ptr<char[]> buffer(new char[size]);
+        GetEnvironmentVariable(name.c_str(), buffer.get(), size);
+        return string(buffer.get());
+    }
+
+    return EMPTY_STRING;
+#else
+    if (const char* const result = getenv(name.c_str()))
+    {
+        return string(result);
+    }
+
+    return EMPTY_STRING;
+#endif
+}
+
+bool setEnviron(const string& name, const string& value)
+{
+#if defined(_WIN32)
+    return SetEnvironmentVariable(name.c_str(), value.c_str()) != 0;
+#else
+    return setenv(name.c_str(), value.c_str(), true);
+#endif
+}
+
+bool removeEnviron(const string& name)
+{
+#if defined(_WIN32)
+    return SetEnvironmentVariable(name.c_str(), nullptr) != 0;
+#else
+    return unsetenv(name.c_str()) == 0;
+#endif
+}
+
+}  // namespace MaterialX

--- a/source/MaterialXFormat/Environ.cpp
+++ b/source/MaterialXFormat/Environ.cpp
@@ -26,16 +26,13 @@ string getEnviron(const string& name)
         GetEnvironmentVariable(name.c_str(), buffer.get(), size);
         return string(buffer.get());
     }
-
-    return EMPTY_STRING;
 #else
     if (const char* const result = getenv(name.c_str()))
     {
         return string(result);
     }
-
-    return EMPTY_STRING;
 #endif
+    return EMPTY_STRING;
 }
 
 bool setEnviron(const string& name, const string& value)

--- a/source/MaterialXFormat/Environ.h
+++ b/source/MaterialXFormat/Environ.h
@@ -1,0 +1,28 @@
+//
+// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_ENVIRON_H
+#define MATERIALX_ENVIRON_H
+
+/// @file
+/// Cross-platform environment variable functionality
+
+#include <MaterialXCore/Library.h>
+
+namespace MaterialX
+{
+
+/// Return the value of an environment variable by name
+string getEnviron(const string& name);
+
+/// Set an environment variable to a specified value
+bool setEnviron(const string& name, const string& value);
+
+/// Remove an environment variable by name
+bool removeEnviron(const string& name);
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -5,6 +5,8 @@
 
 #include <MaterialXFormat/File.h>
 
+#include <MaterialXFormat/Environ.h>
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -149,13 +151,7 @@ FilePath FilePath::getCurrentPath()
 
 FileSearchPath getEnvironmentPath(const string& sep)
 {
-    const char* searchPathEnv = std::getenv(MATERIALX_SEARCH_PATH_ENV_VAR.c_str());
-
-    if (!searchPathEnv)
-    {
-        searchPathEnv = "";
-    }
-
+    string searchPathEnv = getEnviron(MATERIALX_SEARCH_PATH_ENV_VAR);
     return FileSearchPath(searchPathEnv, sep);
 }
 

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -5,6 +5,7 @@
 
 #include <MaterialXTest/Catch/catch.hpp>
 
+#include <MaterialXFormat/Environ.h>
 #include <MaterialXFormat/File.h>
 #include <MaterialXFormat/XmlIo.h>
 
@@ -188,6 +189,13 @@ TEST_CASE("Load content", "[xmlio]")
     readOptions.readXIncludeFunction = nullptr;
     mx::readFromXmlFile(flatDoc, filename, searchPath, &readOptions);
     REQUIRE(*flatDoc != *doc);
+
+    // Read document using environment search path.
+    mx::setEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR, searchPath);
+    mx::DocumentPtr envDoc = mx::createDocument();
+    mx::readFromXmlFile(envDoc, filename);
+    REQUIRE(envDoc->validate());
+    mx::removeEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR);
 
     // Serialize to XML with a custom predicate that skips images.
     auto skipImages = [](mx::ElementPtr elem)


### PR DESCRIPTION
This change adds cross platform functions for getting and setting environment variables. It also re-adds the unit test for reading a MaterialX document using the environment variable search path.