### PR TITLE
Improvements to element validation

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -421,10 +421,6 @@ bool Element::validate(string* message) const
 {
     bool res = true;
     validateRequire(isValidName(getName()), res, message, "Invalid element name");
-    if (hasColorSpace())
-    {
-        validateRequire(getDocument()->hasColorManagementSystem(), res, message, "Colorspace set without color management system");
-    }
     if (hasInheritString())
     {
         bool validInherit = getInheritsFrom() && getInheritsFrom()->getCategory() == getCategory();
@@ -581,6 +577,16 @@ bool ValueElement::validate(string* message) const
     if (hasType() && hasValueString())
     {
         validateRequire(getValue() != nullptr, res, message, "Invalid value");
+    }
+    if (hasInterfaceName())
+    {
+        ConstNodeGraphPtr nodeGraph = getAncestorOfType<NodeGraph>();
+        NodeDefPtr nodeDef = nodeGraph ? nodeGraph->getNodeDef() : nullptr;
+        if (nodeDef)
+        {
+            ValueElementPtr valueElem = nodeDef->getActiveValueElement(getInterfaceName());
+            validateRequire(valueElem != nullptr, res, message, "Interface name not found in referenced nodedef");
+        }
     }
     return TypedElement::validate(message) && res;
 }

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -466,9 +466,9 @@ class Element : public std::enable_shared_from_this<Element>
         return _childOrder;
     }
 
-    /// Return a vector of all child elements that are instances of the given type,
-    /// optionally filtered by the given category string.  The returned vector
-    /// maintains the order in which children were added.
+    /// Return a vector of all child elements that are instances of the given
+    /// subclass, optionally filtered by the given category string.  The returned
+    /// vector maintains the order in which children were added.
     template<class T> vector< shared_ptr<T> > getChildrenOfType(const string& category = EMPTY_STRING) const
     {
         vector< shared_ptr<T> > children;
@@ -604,6 +604,21 @@ class Element : public std::enable_shared_from_this<Element>
     ConstDocumentPtr getDocument() const
     {
         return getRoot()->asA<Document>();
+    }
+
+    /// Return the first ancestor of the given subclass, or an empty shared
+    /// pointer if no ancestor of this subclass is found.
+    template<class T> shared_ptr<const T> getAncestorOfType() const
+    {
+        for (ConstElementPtr elem = getSelf(); elem; elem = elem->getParent())
+        {
+            shared_ptr<const T> typedElem = elem->asA<T>();
+            if (typedElem)
+            {
+                return typedElem;
+            }
+        }
+        return nullptr;
     }
 
     /// @}

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -61,13 +61,10 @@ void PortElement::setConnectedNode(NodePtr node)
 
 NodePtr PortElement::getConnectedNode() const
 {
-    for (ConstElementPtr elem = getSelf(); elem; elem = elem->getParent())
+    ConstGraphElementPtr graph = getAncestorOfType<GraphElement>();
+    if (graph)
     {
-        ConstGraphElementPtr graph = elem->asA<GraphElement>();
-        if (graph)
-        {
-            return graph->getNode(getNodeName());
-        }
+        return graph->getNode(getNodeName());
     }
     return NodePtr();
 }


### PR DESCRIPTION
- Add a validation check for interface names within nodegraph implementations.
- Remove a validation check for colorspaces without CMS strings, as this usage is valid in non-color-managed documents that reference color-managed libraries.
- Add helper method Element::getAncestorOfType.