### PR TITLE
Move file path methods to the FilePath class

### DIFF
--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -10,9 +10,11 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <direct.h>
 #else
 #include <unistd.h>
 #include <sys/stat.h>
+#include <dirent.h>
 #endif
 
 #include <cctype>
@@ -123,10 +125,120 @@ FilePath FilePath::operator/(const FilePath& rhs) const
 bool FilePath::exists() const
 {
 #if defined(_WIN32)
-    return GetFileAttributes(asString().c_str()) != INVALID_FILE_ATTRIBUTES;
+    uint32_t result = GetFileAttributes(asString().c_str());
+    return result != INVALID_FILE_ATTRIBUTES;
 #else
     struct stat sb;
     return stat(asString().c_str(), &sb) == 0;
+#endif
+}
+
+bool FilePath::isDirectory() const
+{
+#if defined(_WIN32)
+    uint32_t result = GetFileAttributes(asString().c_str());
+    if (result == INVALID_FILE_ATTRIBUTES)
+        return false;
+    return (result & FILE_ATTRIBUTE_DIRECTORY) != 0;
+#else
+    struct stat sb;
+    if (stat(asString().c_str(), &sb))
+        return false;
+    return S_ISDIR(sb.st_mode);
+#endif
+}
+
+FilePathVec FilePath::getFilesInDirectory(const string& extension) const
+{
+    FilePathVec files;
+
+#if defined(_WIN32)
+    WIN32_FIND_DATA fd;
+    string wildcard = "*." + extension;
+    HANDLE hFind = FindFirstFile((*this / wildcard).asString().c_str(), &fd);
+    if (hFind != INVALID_HANDLE_VALUE)
+    {
+        do
+        {
+            if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+            {
+                files.push_back(FilePath(fd.cFileName));
+            }
+        } while (FindNextFile(hFind, &fd));
+        FindClose(hFind);
+    }
+#else
+    DIR* dir = opendir(asString().c_str());
+    if (dir)
+    {
+        while (struct dirent* entry = readdir(dir))
+        {
+            if (entry->d_type != DT_DIR && FilePath(entry->d_name).getExtension() == extension)
+            {
+                files.push_back(FilePath(entry->d_name));
+            }
+        }
+        closedir(dir);
+    }
+#endif
+
+    return files;
+}
+
+FilePathVec FilePath::getSubDirectories() const
+{
+    if (!isDirectory())
+    {
+        return FilePathVec();
+    }
+
+    FilePathVec dirs { *this };
+
+#if defined(_WIN32)
+    WIN32_FIND_DATA fd;
+    string wildcard = "*";
+    HANDLE hFind = FindFirstFile((*this / wildcard).asString().c_str(), &fd);
+    if (hFind != INVALID_HANDLE_VALUE)
+    {
+        do
+        {
+            string path = fd.cFileName;
+            if ((fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && (path != "." && path != ".."))
+            {
+                FilePath newDir = *this / path;
+                FilePathVec newDirs = newDir.getSubDirectories();
+                dirs.insert(dirs.end(), newDirs.begin(), newDirs.end());
+            }
+        } while (FindNextFile(hFind, &fd));
+        FindClose(hFind);
+    }
+#else
+    DIR* dir = opendir(asString().c_str());
+    if (dir)
+    {
+        while (struct dirent* entry = readdir(dir))
+        {
+            string path = entry->d_name;
+            if (entry->d_type == DT_DIR && (path != "." && path != ".."))
+            {
+                FilePath newDir = *this / path;
+                FilePathVec newDirs = newDir.getSubDirectories();
+                dirs.insert(dirs.end(), newDirs.begin(), newDirs.end());
+            }
+        }
+        closedir(dir);
+    }
+#endif
+
+    return dirs;
+}
+
+void FilePath::createDirectory()
+{
+#if defined(_WIN32)
+    _mkdir(asString().c_str());
+#else
+    mkdir(asString().c_str(), 0777);
 #endif
 }
 

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -14,6 +14,9 @@
 namespace MaterialX
 {
 
+class FilePath;
+using FilePathVec = vector<FilePath>;
+
 extern const string PATH_LIST_SEPARATOR;
 extern const string MATERIALX_SEARCH_PATH_ENV_VAR;
 
@@ -103,6 +106,14 @@ class FilePath
         return _vec[_vec.size() - 1];
     }
 
+    /// Return the file extension of the given path.
+    string getExtension()
+    {
+        string baseName = getBaseName();
+        size_t i = baseName.rfind('.');
+        return i != string::npos ? baseName.substr(i + 1) : EMPTY_STRING;
+    }
+
     /// Concatenate two paths with a directory separator, returning the
     /// combined path.
     FilePath operator/(const FilePath& rhs) const;
@@ -113,6 +124,18 @@ class FilePath
 
     /// Return true if the given path exists on the file system.
     bool exists() const;
+
+    /// Return true if the given path is a directory on the file system.
+    bool isDirectory() const;
+
+    /// Return a vector of all files in the given directory with the given extension.
+    FilePathVec getFilesInDirectory(const string& extension) const;
+
+    /// Return a vector of all directories at or beneath the given path.
+    FilePathVec getSubDirectories() const;
+
+    /// Create a directory on the file system at the given path.
+    void createDirectory();
 
     /// @}
 
@@ -181,7 +204,7 @@ class FileSearchPath
     }
 
     /// Get list of paths in the search path.
-    const vector<FilePath>& paths() const
+    const FilePathVec& paths() const
     {
         return _paths;
     }
@@ -235,7 +258,7 @@ class FileSearchPath
     }
 
   private:
-    vector<FilePath> _paths;
+    FilePathVec _paths;
 };
 
 /// Return a FileSearchPath object from search path environment variable.

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -21,6 +21,8 @@ using namespace pugi;
 namespace MaterialX
 {
 
+const string MTLX_EXTENSION = "mtlx";
+
 namespace {
 
 const string SOURCE_URI_ATTRIBUTE = "__sourceUri";

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -18,6 +18,8 @@ namespace MaterialX
 
 class XmlReadOptions;
 
+extern const string MTLX_EXTENSION;
+
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.
 using XmlReadFunction = std::function<void(DocumentPtr, string, string, const XmlReadOptions*)>;

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -29,14 +29,14 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
 
     const Implementation& impl = static_cast<const Implementation&>(element);
 
-    const string& file = impl.getAttribute("file");
-    if (file.empty())
+    FilePath file = impl.getAttribute("file");
+    if (file.isEmpty())
     {
         throw ExceptionShaderGenError("No source file specified for implementation '" + impl.getName() + "'");
     }
 
     _functionSource = "";
-    _inlined = (getFileExtension(file) == "inline");
+    _inlined = (file.getExtension() == "inline");
 
     // Find the function name to use
     _functionName = impl.getAttribute("function");
@@ -49,7 +49,8 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
 
     if (!readFile(context.resolveSourceFile(file), _functionSource))
     {
-        throw ExceptionShaderGenError("Can't find source file '" + file + "' used by implementation '" + impl.getName() + "'");
+        throw ExceptionShaderGenError("Can't find source file '" + file.asString() +
+                                      "' used by implementation '" + impl.getName() + "'");
     }
 
     if (_inlined)

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -22,24 +22,11 @@ namespace MaterialX
 
 class ShaderGenerator;
 
-/// Make the directory with the given path if it doesn't already exist
-void makeDirectory(const string& directoryPath);
-
 /// Removes the extension from the provided filename
 string removeExtension(const string& filename);
 
-/// Directory scanner utility. Finds all subdirectories in the given directory
-void getSubDirectories(const string& baseDirectory, StringVec& relativePaths);
-
-/// Directory file scanner utility. Finds all files with a given extension
-/// in the given directory.
-void getFilesInDirectory(const string& directory, StringVec& files, const string& extension);
-
 /// Reads the contents of a file into the given string
 bool readFile(const string& filename, string& content);
-
-/// Returns the extension of the given filename
-string getFileExtension(const string& filename);
 
 /// Scans for all documents under a root path and returns documents which can be loaded
 /// Optionally can test and log errors if the document is not considered to be valid.

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -10,6 +10,8 @@
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/Util.h>
 
+#include <MaterialXFormat/File.h>
+
 namespace mx = MaterialX;
 
 namespace GenShaderUtil
@@ -30,25 +32,17 @@ void loadLibraries(const mx::StringVec& libraryNames,
                    mx::DocumentPtr doc,
                    const mx::StringSet* excludeFiles)
 {
-    const std::string MTLX_EXTENSION("mtlx");
     for (const std::string& library : libraryNames)
     {
-        mx::StringVec librarySubPaths;
         mx::FilePath libraryPath = searchPath / library;
-        mx::getSubDirectories(libraryPath, librarySubPaths);
-
-        for (auto path : librarySubPaths)
+        for (const mx::FilePath& path : libraryPath.getSubDirectories())
         {
-            mx::StringVec filenames;
-            mx::getFilesInDirectory(path, filenames, MTLX_EXTENSION);
-
-            for (const std::string& filename : filenames)
+            for (const mx::FilePath& filename : path.getFilesInDirectory(mx::MTLX_EXTENSION))
             {
-                if (excludeFiles && excludeFiles->count(filename))
+                if (!excludeFiles || !excludeFiles->count(filename))
                 {
-                    continue;
+                    loadLibrary(path / filename, doc);
                 }
-                loadLibrary(mx::FilePath(path)/ filename, doc);
             }
         }
     }


### PR DESCRIPTION
- Move file path methods (getExtension, getFilesInDirectory, getSubDirectories, and createDirectory) from MaterialXGenShader to the FilePath class in MaterialXFormat.
- Add method FilePath::isDirectory.
- Add constant MTLX_EXTENSION to MaterialXFormat.