### PR TITLE
Improvements to XInclude processing

### DIFF
--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -36,9 +36,9 @@ class XmlReadOptions : public CopyOptions
     /// needs to be read into a document.  Defaults to readFromXmlFile.
     XmlReadFunction readXIncludeFunction;
 
-    /// The set of parent filenames at the scope of the current document.
-    /// Defaults to an empty set.
-    StringSet parentFilenames;
+    /// The vector of parent XIncludes at the scope of the current document.
+    /// Defaults to an empty vector.
+    StringVec parentXIncludes;
 };
 
 /// @class XmlWriteOptions

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -21,7 +21,6 @@ void loadLibrary(const mx::FilePath& file, mx::DocumentPtr doc)
 {
     mx::DocumentPtr libDoc = mx::createDocument();
     mx::readFromXmlFile(libDoc, file);
-    libDoc->setSourceUri(file);
     mx::CopyOptions copyOptions;
     copyOptions.skipDuplicateElements = true;
     doc->importLibrary(libDoc, &copyOptions);

--- a/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
@@ -16,7 +16,7 @@ void bindPyXmlIo(py::module& mod)
     py::class_<mx::XmlReadOptions, mx::CopyOptions>(mod, "XmlReadOptions")
         .def(py::init())
         .def_readwrite("readXIncludeFunction", &mx::XmlReadOptions::readXIncludeFunction)
-        .def_readwrite("parentFilenames", &mx::XmlReadOptions::parentFilenames);
+        .def_readwrite("parentXIncludes", &mx::XmlReadOptions::parentXIncludes);
 
     py::class_<mx::XmlWriteOptions>(mod, "XmlWriteOptions")
         .def(py::init())


### PR DESCRIPTION
- Skip intermediate XInclude files when serializing multi-level document hierarchies.
- Rename XmlReadOptions::parentFilenames to XmlReadOptions::parentXIncludes for clarity.
- Remove a duplicate call to setSourceUri.