### PR TITLE
Add cstdlib to Library.h

### DIFF
--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -11,6 +11,7 @@
 /// any public header in the MaterialX library.
 
 #include <algorithm>
+#include <cstdlib>
 #include <exception>
 #include <functional>
 #include <memory>

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -14,8 +14,6 @@
 #include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
 
-#include <algorithm>
-
 namespace MaterialX
 {
 

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -9,9 +9,8 @@
 #include <MaterialXGenShader/HwShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
 
-#include <iostream>
-#include <algorithm>
 #include <cmath>
+#include <iostream>
 
 namespace MaterialX
 {

--- a/source/MaterialXRenderGlsl/GlslValidator.cpp
+++ b/source/MaterialXRenderGlsl/GlslValidator.cpp
@@ -9,7 +9,6 @@
 #include <MaterialXRender/TinyObjLoader.h>
 
 #include <iostream>
-#include <algorithm>
 
 namespace MaterialX
 {


### PR DESCRIPTION
For some OSX targets, cstdlib is not brought in by other standard headers in Library.h, so this change explicitly adds that header.  Also, remove a few duplicate includes of the algorithm header.