### PR TITLE
Stdlib defs/NG updates for 1.36.3/1.37

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -44,7 +44,7 @@
   <typedef name="geomnamearray"/>
 
   <!-- ======================================================================== -->
-  <!-- Geomprop definitions                                                     -->
+  <!-- Geometric Properties
   <!-- ======================================================================== -->
 
   <geompropdef name="Pobject" geomprop="position" space="object"/>
@@ -65,7 +65,7 @@
     Samples data from a single image, or from a layer within a multi-layer image.
   -->
   <nodedef name="ND_image_float" node="image" type="float" nodegroup="texture2d" default="0.0">
-    <parameter name="file" type="filename" uiname="Filename"/>
+    <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="float" value="0.0" uiname="Default Color"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates"/>
@@ -74,10 +74,10 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type"/>
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror" uiname="Frame End Action"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
   </nodedef>
   <nodedef name="ND_image_color2" node="image" type="color2" nodegroup="texture2d" default="0.0, 0.0">
-    <parameter name="file" type="filename" uiname="Filename"/>
+    <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="color2" value="0.0, 0.0" uiname="Default Color"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates"/>
@@ -86,10 +86,10 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type"/>
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror" uiname="Frame End Action"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
   </nodedef>
   <nodedef name="ND_image_color3" node="image" type="color3" nodegroup="texture2d" default="0.0, 0.0, 0.0">
-    <parameter name="file" type="filename" uiname="Filename"/>
+    <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default Color"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates"/>
@@ -98,10 +98,10 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type"/>
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror" uiname="Frame End Action"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
   </nodedef>
   <nodedef name="ND_image_color4" node="image" type="color4" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="file" type="filename" uiname="Filename"/>
+    <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates"/>
@@ -110,10 +110,10 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type"/>
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror" uiname="Frame End Action"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
   </nodedef>
   <nodedef name="ND_image_vector2" node="image" type="vector2" nodegroup="texture2d" default="0.0, 0.0">
-    <parameter name="file" type="filename" uiname="Filename"/>
+    <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="vector2" value="0.0, 0.0" uiname="Default Color"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates"/>
@@ -122,31 +122,31 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type"/>
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror" uiname="Frame End Action"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
   </nodedef>
   <nodedef name="ND_image_vector3" node="image" type="vector3" nodegroup="texture2d" default="0.0, 0.0, 0.0">
-    <parameter name="file" type="filename" uiname="Filename"/>
+    <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="vector3" value="0.0, 0.0, 0.0" uiname="Default Color"/>
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates"/>
     <parameter name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U"/>
     <parameter name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type"/>
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror" uiname="Frame End Action"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
   </nodedef>
   <nodedef name="ND_image_vector4" node="image" type="vector4" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="file" type="filename" uiname="Filename"/>
+    <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color"/>
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates"/>
     <parameter name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U"/>
     <parameter name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type"/>
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror" uiname="Frame End Action"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
   </nodedef>
 
   <!--
@@ -155,81 +155,81 @@
     across uv space.
   -->
   <nodedef name="ND_tiledimage_float" node="tiledimage" type="float" nodegroup="texture2d" default="0.0">
-    <parameter name="file" type="filename"/>
+    <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <parameter name="uvtiling" type="vector2" value="1.0, 1.0"/>
-    <parameter name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
+    <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_tiledimage_color2" node="tiledimage" type="color2" nodegroup="texture2d" default="0.0, 0.0">
-    <parameter name="file" type="filename"/>
+    <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <parameter name="uvtiling" type="vector2" value="1.0, 1.0"/>
-    <parameter name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
+    <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_tiledimage_color3" node="tiledimage" type="color3" nodegroup="texture2d" default="0.0, 0.0, 0.0">
-    <parameter name="file" type="filename"/>
+    <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <parameter name="uvtiling" type="vector2" value="1.0, 1.0"/>
-    <parameter name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
+    <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_tiledimage_color4" node="tiledimage" type="color4" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="file" type="filename"/>
+    <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <parameter name="uvtiling" type="vector2" value="1.0, 1.0"/>
-    <parameter name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
+    <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_tiledimage_vector2" node="tiledimage" type="vector2" nodegroup="texture2d" default="0.0, 0.0">
-    <parameter name="file" type="filename"/>
+    <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <parameter name="uvtiling" type="vector2" value="1.0, 1.0"/>
-    <parameter name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
+    <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_tiledimage_vector3" node="tiledimage" type="vector3" nodegroup="texture2d" default="0.0, 0.0, 0.0">
-    <parameter name="file" type="filename"/>
+    <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <parameter name="uvtiling" type="vector2" value="1.0, 1.0"/>
-    <parameter name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
+    <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_tiledimage_vector4" node="tiledimage" type="vector4" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="file" type="filename"/>
+    <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <parameter name="uvtiling" type="vector2" value="1.0, 1.0"/>
-    <parameter name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
+    <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
 
   <!--
@@ -239,9 +239,9 @@
     a weighted blend of the three samples using the geometric normal.
   -->
   <nodedef name="ND_triplanarprojection_float" node="triplanarprojection" type="float" nodegroup="texture3d" default="0.0">
-    <parameter name="filex" type="filename"/>
-    <parameter name="filey" type="filename"/>
-    <parameter name="filez" type="filename"/>
+    <parameter name="filex" type="filename" value=""/>
+    <parameter name="filey" type="filename" value=""/>
+    <parameter name="filez" type="filename" value=""/>
     <parameter name="layerx" type="string" value=""/>
     <parameter name="layery" type="string" value=""/>
     <parameter name="layerz" type="string" value=""/>
@@ -251,12 +251,12 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_triplanarprojection_color2" node="triplanarprojection" type="color2" nodegroup="texture3d" default="0.0, 0.0">
-    <parameter name="filex" type="filename"/>
-    <parameter name="filey" type="filename"/>
-    <parameter name="filez" type="filename"/>
+    <parameter name="filex" type="filename" value=""/>
+    <parameter name="filey" type="filename" value=""/>
+    <parameter name="filez" type="filename" value=""/>
     <parameter name="layerx" type="string" value=""/>
     <parameter name="layery" type="string" value=""/>
     <parameter name="layerz" type="string" value=""/>
@@ -266,12 +266,12 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_triplanarprojection_color3" node="triplanarprojection" type="color3" nodegroup="texture3d" default="0.0, 0.0, 0.0">
-    <parameter name="filex" type="filename"/>
-    <parameter name="filey" type="filename"/>
-    <parameter name="filez" type="filename"/>
+    <parameter name="filex" type="filename" value=""/>
+    <parameter name="filey" type="filename" value=""/>
+    <parameter name="filez" type="filename" value=""/>
     <parameter name="layerx" type="string" value=""/>
     <parameter name="layery" type="string" value=""/>
     <parameter name="layerz" type="string" value=""/>
@@ -281,12 +281,12 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_triplanarprojection_color4" node="triplanarprojection" type="color4" nodegroup="texture3d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="filex" type="filename"/>
-    <parameter name="filey" type="filename"/>
-    <parameter name="filez" type="filename"/>
+    <parameter name="filex" type="filename" value=""/>
+    <parameter name="filey" type="filename" value=""/>
+    <parameter name="filez" type="filename" value=""/>
     <parameter name="layerx" type="string" value=""/>
     <parameter name="layery" type="string" value=""/>
     <parameter name="layerz" type="string" value=""/>
@@ -296,12 +296,12 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_triplanarprojection_vector2" node="triplanarprojection" type="vector2" nodegroup="texture3d" default="0.0, 0.0">
-    <parameter name="filex" type="filename"/>
-    <parameter name="filey" type="filename"/>
-    <parameter name="filez" type="filename"/>
+    <parameter name="filex" type="filename" value=""/>
+    <parameter name="filey" type="filename" value=""/>
+    <parameter name="filez" type="filename" value=""/>
     <parameter name="layerx" type="string" value=""/>
     <parameter name="layery" type="string" value=""/>
     <parameter name="layerz" type="string" value=""/>
@@ -311,12 +311,12 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_triplanarprojection_vector3" node="triplanarprojection" type="vector3" nodegroup="texture3d" default="0.0, 0.0, 0.0">
-    <parameter name="filex" type="filename"/>
-    <parameter name="filey" type="filename"/>
-    <parameter name="filez" type="filename"/>
+    <parameter name="filex" type="filename" value=""/>
+    <parameter name="filey" type="filename" value=""/>
+    <parameter name="filez" type="filename" value=""/>
     <parameter name="layerx" type="string" value=""/>
     <parameter name="layery" type="string" value=""/>
     <parameter name="layerz" type="string" value=""/>
@@ -326,12 +326,12 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
   <nodedef name="ND_triplanarprojection_vector4" node="triplanarprojection" type="vector4" nodegroup="texture3d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="filex" type="filename"/>
-    <parameter name="filey" type="filename"/>
-    <parameter name="filez" type="filename"/>
+    <parameter name="filex" type="filename" value=""/>
+    <parameter name="filey" type="filename" value=""/>
+    <parameter name="filez" type="filename" value=""/>
     <parameter name="layerx" type="string" value=""/>
     <parameter name="layery" type="string" value=""/>
     <parameter name="layerz" type="string" value=""/>
@@ -341,7 +341,7 @@
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
-    <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
+    <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
   </nodedef>
 
 
@@ -355,43 +355,43 @@
     value that can be accessed in multiple places in the opgraph.
   -->
   <nodedef name="ND_constant_float" node="constant" type="float" nodegroup="procedural" default="0.0">
-    <parameter name="value" type="float"/>
+    <parameter name="value" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_constant_color2" node="constant" type="color2" nodegroup="procedural" default="0.0, 0.0">
-    <parameter name="value" type="color2"/>
+    <parameter name="value" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_constant_color3" node="constant" type="color3" nodegroup="procedural" default="0.0, 0.0, 0.0">
-    <parameter name="value" type="color3"/>
+    <parameter name="value" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_constant_color4" node="constant" type="color4" nodegroup="procedural" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="value" type="color4"/>
+    <parameter name="value" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_constant_vector2" node="constant" type="vector2" nodegroup="procedural" default="0.0, 0.0">
-    <parameter name="value" type="vector2"/>
+    <parameter name="value" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_constant_vector3" node="constant" type="vector3" nodegroup="procedural" default="0.0, 0.0, 0.0">
-    <parameter name="value" type="vector3"/>
+    <parameter name="value" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_constant_vector4" node="constant" type="vector4" nodegroup="procedural" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="value" type="vector4"/>
+    <parameter name="value" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_constant_boolean" node="constant" type="boolean" nodegroup="procedural" default="false">
-    <parameter name="value" type="boolean"/>
+    <parameter name="value" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_constant_integer" node="constant" type="integer" nodegroup="procedural" default="0">
-    <parameter name="value" type="integer"/>
+    <parameter name="value" type="integer" value="0"/>
   </nodedef>
-  <nodedef name="ND_constant_matrix33" node="constant" type="matrix33" nodegroup="procedural" default="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0">
-    <parameter name="value" type="matrix33"/>
+  <nodedef name="ND_constant_matrix33" node="constant" type="matrix33" nodegroup="procedural" default="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0">
+    <parameter name="value" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
-  <nodedef name="ND_constant_matrix44" node="constant" type="matrix44" nodegroup="procedural" default="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0">
-    <parameter name="value" type="matrix44"/>
+  <nodedef name="ND_constant_matrix44" node="constant" type="matrix44" nodegroup="procedural" default="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0">
+    <parameter name="value" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_constant_string" node="constant" type="string" nodegroup="procedural" default="">
-    <parameter name="value" type="string"/>
+    <parameter name="value" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_constant_filename" node="constant" type="filename" nodegroup="procedural" default="">
-    <parameter name="value" type="filename"/>
+    <parameter name="value" type="filename" value=""/>
   </nodedef>
 
   <!--
@@ -399,38 +399,38 @@
     A left-to-right bilinear value ramp.
   -->
   <nodedef name="ND_ramplr_float" node="ramplr" type="float" nodegroup="procedural2d" default="0.0">
-    <parameter name="valuel" type="float"/>
-    <parameter name="valuer" type="float"/>
+    <parameter name="valuel" type="float" value="0.0"/>
+    <parameter name="valuer" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramplr_color2" node="ramplr" type="color2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuel" type="color2"/>
-    <parameter name="valuer" type="color2"/>
+    <parameter name="valuel" type="color2" value="0.0, 0.0"/>
+    <parameter name="valuer" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramplr_color3" node="ramplr" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuel" type="color3"/>
-    <parameter name="valuer" type="color3"/>
+    <parameter name="valuel" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuer" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramplr_color4" node="ramplr" type="color4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuel" type="color4"/>
-    <parameter name="valuer" type="color4"/>
+    <parameter name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramplr_vector2" node="ramplr" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuel" type="vector2"/>
-    <parameter name="valuer" type="vector2"/>
+    <parameter name="valuel" type="vector2" value="0.0, 0.0"/>
+    <parameter name="valuer" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramplr_vector3" node="ramplr" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuel" type="vector3"/>
-    <parameter name="valuer" type="vector3"/>
+    <parameter name="valuel" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuer" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramplr_vector4" node="ramplr" type="vector4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuel" type="vector4"/>
-    <parameter name="valuer" type="vector4"/>
+    <parameter name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
 
@@ -439,38 +439,38 @@
     A top-to-bottom bilinear value ramp.
   -->
   <nodedef name="ND_ramptb_float" node="ramptb" type="float" nodegroup="procedural2d" default="0.0">
-    <parameter name="valuet" type="float"/>
-    <parameter name="valueb" type="float"/>
+    <parameter name="valuet" type="float" value="0.0"/>
+    <parameter name="valueb" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramptb_color2" node="ramptb" type="color2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuet" type="color2"/>
-    <parameter name="valueb" type="color2"/>
+    <parameter name="valuet" type="color2" value="0.0, 0.0"/>
+    <parameter name="valueb" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramptb_color3" node="ramptb" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuet" type="color3"/>
-    <parameter name="valueb" type="color3"/>
+    <parameter name="valuet" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valueb" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramptb_color4" node="ramptb" type="color4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuet" type="color4"/>
-    <parameter name="valueb" type="color4"/>
+    <parameter name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramptb_vector2" node="ramptb" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuet" type="vector2"/>
-    <parameter name="valueb" type="vector2"/>
+    <parameter name="valuet" type="vector2" value="0.0, 0.0"/>
+    <parameter name="valueb" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramptb_vector3" node="ramptb" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuet" type="vector3"/>
-    <parameter name="valueb" type="vector3"/>
+    <parameter name="valuet" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valueb" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramptb_vector4" node="ramptb" type="vector4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuet" type="vector4"/>
-    <parameter name="valueb" type="vector4"/>
+    <parameter name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
 
@@ -479,52 +479,52 @@
     A 4-corner bilinear value ramp.
   -->
   <nodedef name="ND_ramp4_float" node="ramp4" type="float" nodegroup="procedural2d" default="0.0">
-    <parameter name="valuetl" type="float"/>
-    <parameter name="valuetr" type="float"/>
-    <parameter name="valuebl" type="float"/>
-    <parameter name="valuebr" type="float"/>
+    <parameter name="valuetl" type="float" value="0.0"/>
+    <parameter name="valuetr" type="float" value="0.0"/>
+    <parameter name="valuebl" type="float" value="0.0"/>
+    <parameter name="valuebr" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramp4_color2" node="ramp4" type="color2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuetl" type="color2"/>
-    <parameter name="valuetr" type="color2"/>
-    <parameter name="valuebl" type="color2"/>
-    <parameter name="valuebr" type="color2"/>
+    <parameter name="valuetl" type="color2" value="0.0, 0.0"/>
+    <parameter name="valuetr" type="color2" value="0.0, 0.0"/>
+    <parameter name="valuebl" type="color2" value="0.0, 0.0"/>
+    <parameter name="valuebr" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramp4_color3" node="ramp4" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuetl" type="color3"/>
-    <parameter name="valuetr" type="color3"/>
-    <parameter name="valuebl" type="color3"/>
-    <parameter name="valuebr" type="color3"/>
+    <parameter name="valuetl" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuetr" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuebl" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuebr" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramp4_color4" node="ramp4" type="color4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuetl" type="color4"/>
-    <parameter name="valuetr" type="color4"/>
-    <parameter name="valuebl" type="color4"/>
-    <parameter name="valuebr" type="color4"/>
+    <parameter name="valuetl" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuetr" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuebl" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuebr" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramp4_vector2" node="ramp4" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuetl" type="vector2"/>
-    <parameter name="valuetr" type="vector2"/>
-    <parameter name="valuebl" type="vector2"/>
-    <parameter name="valuebr" type="vector2"/>
+    <parameter name="valuetl" type="vector2" value="0.0, 0.0"/>
+    <parameter name="valuetr" type="vector2" value="0.0, 0.0"/>
+    <parameter name="valuebl" type="vector2" value="0.0, 0.0"/>
+    <parameter name="valuebr" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramp4_vector3" node="ramp4" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuetl" type="vector3"/>
-    <parameter name="valuetr" type="vector3"/>
-    <parameter name="valuebl" type="vector3"/>
-    <parameter name="valuebr" type="vector3"/>
+    <parameter name="valuetl" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuetr" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuebl" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="valuebr" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_ramp4_vector4" node="ramp4" type="vector4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuetl" type="vector4"/>
-    <parameter name="valuetr" type="vector4"/>
-    <parameter name="valuebl" type="vector4"/>
-    <parameter name="valuebr" type="vector4"/>
+    <parameter name="valuetl" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuetr" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuebl" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="valuebr" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
 
@@ -533,44 +533,44 @@
     A left-right split matte, split at a specified u value.
   -->
   <nodedef name="ND_splitlr_float" node="splitlr" type="float" nodegroup="procedural2d" default="0.0">
-    <parameter name="valuel" type="float" uiname="Left"/>
-    <parameter name="valuer" type="float" uiname="Right"/>
+    <parameter name="valuel" type="float" value="0.0" uiname="Left"/>
+    <parameter name="valuer" type="float" value="0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splitlr_color2" node="splitlr" type="color2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuel" type="color2" uiname="Left"/>
-    <parameter name="valuer" type="color2" uiname="Right"/>
+    <parameter name="valuel" type="color2" value="0.0, 0.0" uiname="Left"/>
+    <parameter name="valuer" type="color2" value="0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splitlr_color3" node="splitlr" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuel" type="color3" uiname="Left"/>
-    <parameter name="valuer" type="color3" uiname="Right"/>
+    <parameter name="valuel" type="color3" value="0.0, 0.0, 0.0" uiname="Left"/>
+    <parameter name="valuer" type="color3" value="0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splitlr_color4" node="splitlr" type="color4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuel" type="color4" uiname="Left"/>
-    <parameter name="valuer" type="color4" uiname="Right"/>
+    <parameter name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Left"/>
+    <parameter name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splitlr_vector2" node="splitlr" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuel" type="vector2" uiname="Left"/>
-    <parameter name="valuer" type="vector2" uiname="Right"/>
+    <parameter name="valuel" type="vector2" value="0.0, 0.0" uiname="Left"/>
+    <parameter name="valuer" type="vector2" value="0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splitlr_vector3" node="splitlr" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuel" type="vector3" uiname="Left"/>
-    <parameter name="valuer" type="vector3" uiname="Right"/>
+    <parameter name="valuel" type="vector3" value="0.0, 0.0, 0.0" uiname="Left"/>
+    <parameter name="valuer" type="vector3" value="0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splitlr_vector4" node="splitlr" type="vector4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuel" type="vector4" uiname="Left"/>
-    <parameter name="valuer" type="vector4" uiname="Right"/>
+    <parameter name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Left"/>
+    <parameter name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
@@ -580,44 +580,44 @@
     A top-bottom split matte, split at a specified v value.
   -->
   <nodedef name="ND_splittb_float" node="splittb" type="float" nodegroup="procedural2d" default="0.0">
-    <parameter name="valuet" type="float" uiname="Top"/>
-    <parameter name="valueb" type="float" uiname="Bottom"/>
+    <parameter name="valuet" type="float" value="0.0" uiname="Top"/>
+    <parameter name="valueb" type="float" value="0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splittb_color2" node="splittb" type="color2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuet" type="color2" uiname="Top"/>
-    <parameter name="valueb" type="color2" uiname="Bottom"/>
+    <parameter name="valuet" type="color2" value="0.0, 0.0" uiname="Top"/>
+    <parameter name="valueb" type="color2" value="0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splittb_color3" node="splittb" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuet" type="color3" uiname="Top"/>
-    <parameter name="valueb" type="color3" uiname="Bottom"/>
+    <parameter name="valuet" type="color3" value="0.0, 0.0, 0.0" uiname="Top"/>
+    <parameter name="valueb" type="color3" value="0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splittb_color4" node="splittb" type="color4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuet" type="color4" uiname="Top"/>
-    <parameter name="valueb" type="color4" uiname="Bottom"/>
+    <parameter name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Top"/>
+    <parameter name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splittb_vector2" node="splittb" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="valuet" type="vector2"  uiname="Top"/>
-    <parameter name="valueb" type="vector2"  uiname="Bottom"/>
+    <parameter name="valuet" type="vector2" value="0.0, 0.0" uiname="Top"/>
+    <parameter name="valueb" type="vector2" value="0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splittb_vector3" node="splittb" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="valuet" type="vector3"  uiname="Top"/>
-    <parameter name="valueb" type="vector3"  uiname="Bottom"/>
+    <parameter name="valuet" type="vector3" value="0.0, 0.0, 0.0" uiname="Top"/>
+    <parameter name="valueb" type="vector3" value="0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
   <nodedef name="ND_splittb_vector4" node="splittb" type="vector4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="valuet" type="vector4" uiname="Top"/>
-    <parameter name="valueb" type="vector4"  uiname="Bottom"/>
+    <parameter name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Top"/>
+    <parameter name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
@@ -636,18 +636,8 @@
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color2FA" node="noise2d" type="color2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-  </nodedef>
   <nodedef name="ND_noise2d_color3" node="noise2d" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-  </nodedef>
-  <nodedef name="ND_noise2d_color3FA" node="noise2d" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
@@ -656,18 +646,8 @@
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color4FA" node="noise2d" type="color4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-  </nodedef>
   <nodedef name="ND_noise2d_vector2" node="noise2d" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-  </nodedef>
-  <nodedef name="ND_noise2d_vector2FA" node="noise2d" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
@@ -676,13 +656,33 @@
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector3FA" node="noise2d" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_vector4" node="noise2d" type="vector4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+  </nodedef>
+  <nodedef name="ND_noise2d_color2FA" node="noise2d" type="color2" nodegroup="procedural2d" default="0.0, 0.0">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector4" node="noise2d" type="vector4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+  <nodedef name="ND_noise2d_color3FA" node="noise2d" type="color3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+  </nodedef>
+  <nodedef name="ND_noise2d_color4FA" node="noise2d" type="color4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+  </nodedef>
+  <nodedef name="ND_noise2d_vector2FA" node="noise2d" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+  </nodedef>
+  <nodedef name="ND_noise2d_vector3FA" node="noise2d" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
@@ -706,18 +706,8 @@
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color2FA" node="noise3d" type="color2" nodegroup="procedural3d" default="0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
   <nodedef name="ND_noise3d_color3" node="noise3d" type="color3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
-  <nodedef name="ND_noise3d_color3FA" node="noise3d" type="color3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
@@ -726,18 +716,8 @@
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color4FA" node="noise3d" type="color4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
   <nodedef name="ND_noise3d_vector2" node="noise3d" type="vector2" nodegroup="procedural3d" default="0.0, 0.0">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
-    <parameter name="pivot" type="float" value="0.0"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
-  <nodedef name="ND_noise3d_vector2FA" node="noise3d" type="vector2" nodegroup="procedural3d" default="0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
@@ -746,13 +726,33 @@
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector3FA" node="noise3d" type="vector3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_vector4" node="noise3d" type="vector4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_noise3d_color2FA" node="noise3d" type="color2" nodegroup="procedural3d" default="0.0, 0.0">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector4" node="noise3d" type="vector4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+  <nodedef name="ND_noise3d_color3FA" node="noise3d" type="color3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_noise3d_color4FA" node="noise3d" type="color4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_noise3d_vector2FA" node="noise3d" type="vector2" nodegroup="procedural3d" default="0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.0"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_noise3d_vector3FA" node="noise3d" type="vector3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
@@ -780,22 +780,8 @@
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color2FA" node="fractal3d" type="color2" nodegroup="procedural3d" default="0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
-    <parameter name="octaves" type="integer" value="3"/>
-    <parameter name="lacunarity" type="float" value="2.0"/>
-    <parameter name="diminish" type="float" value="0.5"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
   <nodedef name="ND_fractal3d_color3" node="fractal3d" type="color3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
-    <parameter name="octaves" type="integer" value="3"/>
-    <parameter name="lacunarity" type="float" value="2.0"/>
-    <parameter name="diminish" type="float" value="0.5"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
-  <nodedef name="ND_fractal3d_color3FA" node="fractal3d" type="color3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
@@ -808,22 +794,8 @@
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color4FA" node="fractal3d" type="color4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
-    <parameter name="octaves" type="integer" value="3"/>
-    <parameter name="lacunarity" type="float" value="2.0"/>
-    <parameter name="diminish" type="float" value="0.5"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
   <nodedef name="ND_fractal3d_vector2" node="fractal3d" type="vector2" nodegroup="procedural3d" default="0.0, 0.0">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
-    <parameter name="octaves" type="integer" value="3"/>
-    <parameter name="lacunarity" type="float" value="2.0"/>
-    <parameter name="diminish" type="float" value="0.5"/>
-    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-  </nodedef>
-  <nodedef name="ND_fractal3d_vector2FA" node="fractal3d" type="vector2" nodegroup="procedural3d" default="0.0, 0.0">
-    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
@@ -836,15 +808,43 @@
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector3FA" node="fractal3d" type="vector3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_vector4" node="fractal3d" type="vector4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+    <parameter name="octaves" type="integer" value="3"/>
+    <parameter name="lacunarity" type="float" value="2.0"/>
+    <parameter name="diminish" type="float" value="0.5"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_fractal3d_color2FA" node="fractal3d" type="color2" nodegroup="procedural3d" default="0.0, 0.0">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector4" node="fractal3d" type="vector4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+  <nodedef name="ND_fractal3d_color3FA" node="fractal3d" type="color3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="octaves" type="integer" value="3"/>
+    <parameter name="lacunarity" type="float" value="2.0"/>
+    <parameter name="diminish" type="float" value="0.5"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_fractal3d_color4FA" node="fractal3d" type="color4" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="octaves" type="integer" value="3"/>
+    <parameter name="lacunarity" type="float" value="2.0"/>
+    <parameter name="diminish" type="float" value="0.5"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_fractal3d_vector2FA" node="fractal3d" type="vector2" nodegroup="procedural3d" default="0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
+    <parameter name="octaves" type="integer" value="3"/>
+    <parameter name="lacunarity" type="float" value="2.0"/>
+    <parameter name="diminish" type="float" value="0.5"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+  <nodedef name="ND_fractal3d_vector3FA" node="fractal3d" type="vector3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+    <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
@@ -863,7 +863,7 @@
     2D cellular noise in 1 channel.
   -->
   <nodedef name="ND_cellnoise2d_float" node="cellnoise2d" type="float" nodegroup="procedural2d" default="0.0">
-     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
   </nodedef>
 
   <!--
@@ -871,7 +871,41 @@
     3D cellular noise in 1 channel.
   -->
   <nodedef name="ND_cellnoise3d_float" node="cellnoise3d" type="float" nodegroup="procedural3d" default="0.0">
-     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+  </nodedef>
+
+  <!--
+    Node: <worleynoise2d>
+    2D Worley (voronoi) noise in 1, 2 or 3 channels.
+  -->
+  <nodedef name="ND_worleynoise2d_float" node="worleynoise2d" type="float" nodegroup="procedural2d" default="0.0">
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+    <parameter name="jitter" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_worleynoise2d_vector2" node="worleynoise2d" type="vector2" nodegroup="procedural2d" default="0.0, 0.0">
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+    <parameter name="jitter" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_worleynoise2d_vector3" node="worleynoise2d" type="vector3" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
+    <parameter name="jitter" type="float" value="1.0"/>
+  </nodedef>
+
+  <!--
+    Node: <worleynoise3d>
+    3D Worley (voronoi) noise in 1, 2 or 3 channels.
+  -->
+  <nodedef name="ND_worleynoise3d_float" node="worleynoise3d" type="float" nodegroup="procedural3d" default="0.0">
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+    <parameter name="jitter" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_worleynoise3d_vector2" node="worleynoise3d" type="vector2" nodegroup="procedural3d" default="0.0, 0.0">
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+    <parameter name="jitter" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_worleynoise3d_vector3" node="worleynoise3d" type="vector3" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+    <input name="position" type="vector3" defaultgeomprop="Pobject"/>
+    <parameter name="jitter" type="float" value="1.0"/>
   </nodedef>
 
 
@@ -948,37 +982,83 @@
 
   <!--
     Node: <geomattrvalue>
-    The value assigned to the current geometry through the specified geomattr name.
+    The value of the specified geomattr for the current geometry.
+    (This will be replaced by <geompropvalue> in 1.37)
   -->
   <nodedef name="ND_geomattrvalue_integer" node="geomattrvalue" type="integer" nodegroup="geometric" default="0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_boolean" node="geomattrvalue" type="boolean" nodegroup="geometric" default="false">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_string" node="geomattrvalue" type="string" nodegroup="geometric" default="">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_float" node="geomattrvalue" type="float" nodegroup="geometric" default="0.0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_color2" node="geomattrvalue" type="color2" nodegroup="geometric" default="0.0, 0.0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_color3" node="geomattrvalue" type="color3" nodegroup="geometric" default="0.0, 0.0, 0.0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_color4" node="geomattrvalue" type="color4" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_vector2" node="geomattrvalue" type="vector2" nodegroup="geometric" default="0.0, 0.0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_vector3" node="geomattrvalue" type="vector3" nodegroup="geometric" default="0.0, 0.0, 0.0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_geomattrvalue_vector4" node="geomattrvalue" type="vector4" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
-    <parameter name="attrname" type="string"/>
+    <parameter name="attrname" type="string" value=""/>
+  </nodedef>
+
+  <!--
+    Node: <geompropvalue>
+    The value of the specified geometric property for the current geometry.
+  -->
+  <nodedef name="ND_geompropvalue_integer" node="geompropvalue" type="integer" nodegroup="geometric" default="0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="integer" value="0"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_boolean" node="geompropvalue" type="boolean" nodegroup="geometric" default="false">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="boolean" value="false"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_string" node="geompropvalue" type="string" nodegroup="geometric" default="">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="string" value=""/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_float" node="geompropvalue" type="float" nodegroup="geometric" default="0.0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_color2" node="geompropvalue" type="color2" nodegroup="geometric" default="0.0, 0.0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="color2" value="0.0, 0.0"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_color3" node="geompropvalue" type="color3" nodegroup="geometric" default="0.0, 0.0, 0.0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="color3" value="0.0, 0.0, 0.0"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_color4" node="geompropvalue" type="color4" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_vector2" node="geompropvalue" type="vector2" nodegroup="geometric" default="0.0, 0.0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="vector2" value="0.0, 0.0"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_vector3" node="geompropvalue" type="vector3" nodegroup="geometric" default="0.0, 0.0, 0.0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="vector3" value="0.0, 0.0, 0.0"/>
+  </nodedef>
+  <nodedef name="ND_geompropvalue_vector4" node="geompropvalue" type="vector4" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
+    <parameter name="geomprop" type="string" value=""/>
+    <parameter name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
 
@@ -1035,84 +1115,84 @@
     Add "in2" value/stream to the incoming float/color/vector/matrix.
   -->
   <nodedef name="ND_add_float" node="add" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_add_color2" node="add" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_add_color2FA" node="add" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_add_color3" node="add" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_add_color3FA" node="add" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_add_color4" node="add" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_add_color4FA" node="add" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_add_vector2" node="add" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_add_vector2FA" node="add" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_add_vector3" node="add" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_add_vector3FA" node="add" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_add_vector4" node="add" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
-  </nodedef>
-  <nodedef name="ND_add_vector4FA" node="add" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_add_matrix33" node="add" type="matrix33" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix33"/>
-    <input name="in2" type="matrix33"/>
-  </nodedef>
-  <nodedef name="ND_add_matrix33FA" node="add" type="matrix33" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix33"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0"/>
   </nodedef>
   <nodedef name="ND_add_matrix44" node="add" type="matrix44" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix44"/>
-    <input name="in2" type="matrix44"/>
-  </nodedef>
-  <nodedef name="ND_add_matrix44FA" node="add" type="matrix44" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix44"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0"/>
   </nodedef>
   <nodedef name="ND_add_surfaceshader" node="add" type="surfaceshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="surfaceshader"/>
-    <input name="in2" type="surfaceshader"/>
+    <input name="in1" type="surfaceshader" value=""/>
+    <input name="in2" type="surfaceshader" value=""/>
   </nodedef>
   <nodedef name="ND_add_displacementshader" node="add" type="displacementshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="displacementshader"/>
-    <input name="in2" type="displacementshader"/>
+    <input name="in1" type="displacementshader" value=""/>
+    <input name="in2" type="displacementshader" value=""/>
   </nodedef>
   <nodedef name="ND_add_volumeshader" node="add" type="volumeshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="volumeshader"/>
-    <input name="in2" type="volumeshader"/>
+    <input name="in1" type="volumeshader" value=""/>
+    <input name="in2" type="volumeshader" value=""/>
+  </nodedef>
+  <nodedef name="ND_add_color2FA" node="add" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_add_color3FA" node="add" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_add_color4FA" node="add" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_add_vector2FA" node="add" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_add_vector3FA" node="add" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_add_vector4FA" node="add" type="vector4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_add_matrix33FA" node="add" type="matrix33" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_add_matrix44FA" node="add" type="matrix44" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
 
   <!--
@@ -1120,72 +1200,72 @@
     Subtract "in2" value/stream from the incoming float/color/vector/matrix.
   -->
   <nodedef name="ND_subtract_float" node="subtract" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_color2" node="subtract" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_subtract_color2FA" node="subtract" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_color3" node="subtract" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_subtract_color3FA" node="subtract" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_color4" node="subtract" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_subtract_color4FA" node="subtract" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_vector2" node="subtract" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_subtract_vector2FA" node="subtract" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_vector3" node="subtract" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_subtract_vector3FA" node="subtract" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_vector4" node="subtract" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
-  </nodedef>
-  <nodedef name="ND_subtract_vector4FA" node="subtract" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_matrix33" node="subtract" type="matrix33" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix33"/>
-    <input name="in2" type="matrix33"/>
-  </nodedef>
-  <nodedef name="ND_subtract_matrix33FA" node="subtract" type="matrix33" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix33"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_matrix44" node="subtract" type="matrix44" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix44"/>
-    <input name="in2" type="matrix44"/>
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0"/>
+  </nodedef>
+  <nodedef name="ND_subtract_color2FA" node="subtract" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_subtract_color3FA" node="subtract" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_subtract_color4FA" node="subtract" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_subtract_vector2FA" node="subtract" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_subtract_vector3FA" node="subtract" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_subtract_vector4FA" node="subtract" type="vector4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_subtract_matrix33FA" node="subtract" type="matrix33" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_subtract_matrix44FA" node="subtract" type="matrix44" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix44"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
 
   <!--
@@ -1194,88 +1274,88 @@
     two matrices.
   -->
   <nodedef name="ND_multiply_float" node="multiply" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_color2" node="multiply" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_multiply_color2FA" node="multiply" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_color3" node="multiply" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_multiply_color3FA" node="multiply" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_color4" node="multiply" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_multiply_color4FA" node="multiply" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_vector2" node="multiply" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_multiply_vector2FA" node="multiply" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_vector3" node="multiply" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_multiply_vector3FA" node="multiply" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_vector4" node="multiply" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
-  </nodedef>
-  <nodedef name="ND_multiply_vector4FA" node="multiply" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_matrix33" node="multiply" type="matrix33" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix33"/>
-    <input name="in2" type="matrix33"/>
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_matrix44" node="multiply" type="matrix44" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix44"/>
-    <input name="in2" type="matrix44"/>
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_color2FA" node="multiply" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_color3FA" node="multiply" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_color4FA" node="multiply" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_vector2FA" node="multiply" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_vector3FA" node="multiply" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_vector4FA" node="multiply" type="vector4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_surfaceshaderF" node="multiply" type="surfaceshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="surfaceshader"/>
-    <input name="in2" type="float"/>
-  </nodedef>
-  <nodedef name="ND_multiply_surfaceshaderC" node="multiply" type="surfaceshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="surfaceshader"/>
-    <input name="in2" type="color3"/>
+    <input name="in1" type="surfaceshader" value=""/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_displacementshaderF" node="multiply" type="displacementshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="displacementshader"/>
-    <input name="in2" type="float"/>
-  </nodedef>
-  <nodedef name="ND_multiply_displacementshaderV" node="multiply" type="displacementshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="displacementshader"/>
-    <input name="in2" type="vector3"/>
+    <input name="in1" type="displacementshader" value=""/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_volumeshaderF" node="multiply" type="volumeshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="volumeshader"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="volumeshader" value=""/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_surfaceshaderC" node="multiply" type="surfaceshader" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="surfaceshader" value=""/>
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_multiply_volumeshaderC" node="multiply" type="volumeshader" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="volumeshader"/>
-    <input name="in2" type="color3"/>
+    <input name="in1" type="volumeshader" value=""/>
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
+  </nodedef>
+  <nodedef name="ND_multiply_displacementshaderV" node="multiply" type="displacementshader" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="displacementshader" value=""/>
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
 
   <!--
@@ -1285,64 +1365,64 @@
     inverse of a second matrix.
   -->
   <nodedef name="ND_divide_float" node="divide" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_divide_color2" node="divide" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_divide_color2FA" node="divide" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_divide_color3" node="divide" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_divide_color3FA" node="divide" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_divide_color4" node="divide" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_divide_color4FA" node="divide" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_divide_vector2" node="divide" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_divide_vector2FA" node="divide" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_divide_vector3" node="divide" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_divide_vector3FA" node="divide" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_divide_vector4" node="divide" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
-  </nodedef>
-  <nodedef name="ND_divide_vector4FA" node="divide" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_divide_matrix33" node="divide" type="matrix33" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix33"/>
-    <input name="in2" type="matrix33"/>
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_divide_matrix44" node="divide" type="matrix44" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="matrix44"/>
-    <input name="in2" type="matrix44"/>
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
+  </nodedef>
+  <nodedef name="ND_divide_color2FA" node="divide" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_divide_color3FA" node="divide" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_divide_color4FA" node="divide" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_divide_vector2FA" node="divide" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_divide_vector3FA" node="divide" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_divide_vector4FA" node="divide" type="vector4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
 
   <!--
@@ -1351,56 +1431,56 @@
     "amount" and subtracting the integer portion. The modula "amount" cannot be 0.
   -->
   <nodedef name="ND_modulo_float" node="modulo" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_modulo_color2" node="modulo" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_modulo_color2FA" node="modulo" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_modulo_color3" node="modulo" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_modulo_color3FA" node="modulo" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_modulo_color4" node="modulo" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_modulo_color4FA" node="modulo" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_modulo_vector2" node="modulo" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_modulo_vector2FA" node="modulo" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_modulo_vector3" node="modulo" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_modulo_vector3FA" node="modulo" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_modulo_vector4" node="modulo" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+  </nodedef>
+  <nodedef name="ND_modulo_color2FA" node="modulo" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_modulo_color3FA" node="modulo" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_modulo_color4FA" node="modulo" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_modulo_vector2FA" node="modulo" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_modulo_vector3FA" node="modulo" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_modulo_vector4FA" node="modulo" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
 
   <!--
@@ -1409,62 +1489,62 @@
     outputting: amount - in.  Or, invert an incoming matrix.
   -->
   <nodedef name="ND_invert_float" node="invert" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_invert_color2" node="invert" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="amount" type="color2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_invert_color2FA" node="invert" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="amount" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_invert_color3" node="invert" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="amount" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_invert_color3FA" node="invert" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="amount" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_invert_color4" node="invert" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_invert_color4FA" node="invert" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="amount" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_invert_vector2" node="invert" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="amount" type="vector2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_invert_vector2FA" node="invert" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="amount" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_invert_vector3" node="invert" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="amount" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_invert_vector3FA" node="invert" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="amount" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_invert_vector4" node="invert" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
+  <nodedef name="ND_invert_color2FA" node="invert" type="color2" nodegroup="math" defaultinput="in">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_invert_color3FA" node="invert" type="color3" nodegroup="math" defaultinput="in">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_invert_color4FA" node="invert" type="color4" nodegroup="math" defaultinput="in">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_invert_vector2FA" node="invert" type="vector2" nodegroup="math" defaultinput="in">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_invert_vector3FA" node="invert" type="vector3" nodegroup="math" defaultinput="in">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+  </nodedef>
   <nodedef name="ND_invert_vector4FA" node="invert" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_invert_matrix33" node="invert" type="matrix33" nodegroup="math" defaultinput="in">
-    <input name="in" type="matrix33"/>
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_invert_matrix44" node="invert" type="matrix44" nodegroup="math" defaultinput="in">
-    <input name="in" type="matrix44"/>
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
 
   <!--
@@ -1472,25 +1552,25 @@
     The per-channel absolute value of the incoming float/color/vector.
   -->
   <nodedef name="ND_absval_float" node="absval" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_absval_color2" node="absval" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_absval_color3" node="absval" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_absval_color4" node="absval" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_absval_vector2" node="absval" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_absval_vector3" node="absval" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_absval_vector4" node="absval" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1498,25 +1578,25 @@
     Find the nearest integer less than or equal to the parameter.
   -->
   <nodedef name="ND_floor_float" node="floor" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_floor_color2" node="floor" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_floor_color3" node="floor" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_floor_color4" node="floor" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_floor_vector2" node="floor" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_floor_vector3" node="floor" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_floor_vector4" node="floor" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1524,25 +1604,25 @@
     Find the nearest integer greater than or equal to the parameter.
   -->
   <nodedef name="ND_ceil_float" node="ceil" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_ceil_color2" node="ceil" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_ceil_color3" node="ceil" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_ceil_color4" node="ceil" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_ceil_vector2" node="ceil" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_ceil_vector3" node="ceil" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_ceil_vector4" node="ceil" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1550,56 +1630,56 @@
     Raise incoming float/color/vector values to the "in2" power.
   -->
   <nodedef name="ND_power_float" node="power" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_power_color2" node="power" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_power_color2FA" node="power" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_power_color3" node="power" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_power_color3FA" node="power" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_power_color4" node="power" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_power_color4FA" node="power" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_power_vector2" node="power" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_power_vector2FA" node="power" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_power_vector3" node="power" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_power_vector3FA" node="power" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_power_vector4" node="power" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+  </nodedef>
+  <nodedef name="ND_power_color2FA" node="power" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_power_color3FA" node="power" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_power_color4FA" node="power" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_power_vector2FA" node="power" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_power_vector3FA" node="power" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_power_vector4FA" node="power" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="1.0"/>
   </nodedef>
 
   <!--
@@ -1607,23 +1687,23 @@
     Standard trigonometric functions; angles are given in radians.
   -->
   <nodedef name="ND_sin_float" node="sin" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_cos_float" node="cos" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_tan_float" node="tan" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_asin_float" node="asin" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_acos_float" node="acos" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_atan2_float" node="atan2" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="1.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
 
   <!--
@@ -1631,13 +1711,13 @@
     Standard math functions.
   -->
   <nodedef name="ND_sqrt_float" node="sqrt" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_ln_float" node="ln" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_exp_float" node="exp" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
 
   <!--
@@ -1645,25 +1725,25 @@
     Sign of eachinput channel: -1, 0 or +1
   -->
   <nodedef name="ND_sign_float" node="sign" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_sign_color2" node="sign" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_sign_color3" node="sign" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_sign_color4" node="sign" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_sign_vector2" node="sign" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_sign_vector3" node="sign" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_sign_vector4" node="sign" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1671,67 +1751,67 @@
     Clamp incoming value to a specified range of values.
   -->
   <nodedef name="ND_clamp_float" node="clamp" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_clamp_color2" node="clamp" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="low" type="color2" value="0.0, 0.0"/>
     <parameter name="high" type="color2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_clamp_color2FA" node="clamp" type="color2" nodegroup="math" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_clamp_color3" node="clamp" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="high" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_clamp_color3FA" node="clamp" type="color3" nodegroup="math" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_clamp_color4" node="clamp" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="high" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_clamp_color4FA" node="clamp" type="color4" nodegroup="math" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_clamp_vector2" node="clamp" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="low" type="vector2" value="0.0, 0.0"/>
     <parameter name="high" type="vector2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector2FA" node="clamp" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_clamp_vector3" node="clamp" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="high" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector3FA" node="clamp" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_clamp_vector4" node="clamp" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
+  <nodedef name="ND_clamp_color2FA" node="clamp" type="color2" nodegroup="math" defaultinput="in">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_clamp_color3FA" node="clamp" type="color3" nodegroup="math" defaultinput="in">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_clamp_color4FA" node="clamp" type="color4" nodegroup="math" defaultinput="in">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_clamp_vector2FA" node="clamp" type="vector2" nodegroup="math" defaultinput="in">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_clamp_vector3FA" node="clamp" type="vector3" nodegroup="math" defaultinput="in">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
   <nodedef name="ND_clamp_vector4FA" node="clamp" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
   </nodedef>
@@ -1741,56 +1821,56 @@
     Select the minimum among incoming values.
   -->
   <nodedef name="ND_min_float" node="min" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_min_color2" node="min" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_min_color2FA" node="min" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_min_color3" node="min" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_min_color3FA" node="min" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_min_color4" node="min" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_min_color4FA" node="min" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_min_vector2" node="min" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_min_vector2FA" node="min" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_min_vector3" node="min" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_min_vector3FA" node="min" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_min_vector4" node="min" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+  </nodedef>
+  <nodedef name="ND_min_color2FA" node="min" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_min_color3FA" node="min" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_min_color4FA" node="min" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_min_vector2FA" node="min" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_min_vector3FA" node="min" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_min_vector4FA" node="min" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
 
   <!--
@@ -1798,56 +1878,56 @@
     Select the maximum among incoming values.
   -->
   <nodedef name="ND_max_float" node="max" type="float" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_max_color2" node="max" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_max_color2FA" node="max" type="color2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_max_color3" node="max" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_max_color3FA" node="max" type="color3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_max_color4" node="max" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
-  </nodedef>
-  <nodedef name="ND_max_color4FA" node="max" type="color4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_max_vector2" node="max" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
-  </nodedef>
-  <nodedef name="ND_max_vector2FA" node="max" type="vector2" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_max_vector3" node="max" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
-  </nodedef>
-  <nodedef name="ND_max_vector3FA" node="max" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_max_vector4" node="max" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+  </nodedef>
+  <nodedef name="ND_max_color2FA" node="max" type="color2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_max_color3FA" node="max" type="color3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_max_color4FA" node="max" type="color4" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_max_vector2FA" node="max" type="vector2" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+  </nodedef>
+  <nodedef name="ND_max_vector3FA" node="max" type="vector3" nodegroup="math" defaultinput="in1">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_max_vector4FA" node="max" type="vector4" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
 
   <!--
@@ -1855,44 +1935,44 @@
     Outputs the normalized vector from the incoming vector stream.
   -->
   <nodedef name="ND_normalize_vector2" node="normalize" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_normalize_vector3" node="normalize" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_normalize_vector4" node="normalize" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <magnitude>
     Outputs the float magnitude (vector length) of the incoming vector stream.
   -->
-  <nodedef name="ND_magnitude_vector2" node="magnitude" type="float" nodegroup="math">
-    <input name="in" type="vector2"/>
+  <nodedef name="ND_magnitude_vector2" node="magnitude" type="float" nodegroup="math" default="0.0">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_magnitude_vector3" node="magnitude" type="float" nodegroup="math">
-    <input name="in" type="vector3"/>
+  <nodedef name="ND_magnitude_vector3" node="magnitude" type="float" nodegroup="math" default="0.0">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_magnitude_vector4" node="magnitude" type="float" nodegroup="math">
-    <input name="in" type="vector4"/>
+  <nodedef name="ND_magnitude_vector4" node="magnitude" type="float" nodegroup="math" default="0.0">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <dotproduct>
     Perform a dot product of two 2-4 channel vectors
   -->
-  <nodedef name="ND_dotproduct_vector2" node="dotproduct" type="float" nodegroup="math">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
+  <nodedef name="ND_dotproduct_vector2" node="dotproduct" type="float" nodegroup="math" default="0.0">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_dotproduct_vector3" node="dotproduct" type="float" nodegroup="math">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
+  <nodedef name="ND_dotproduct_vector3" node="dotproduct" type="float" nodegroup="math" default="0.0">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_dotproduct_vector4" node="dotproduct" type="float" nodegroup="math">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
+  <nodedef name="ND_dotproduct_vector4" node="dotproduct" type="float" nodegroup="math" default="0.0">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1900,8 +1980,8 @@
     Perform a cross product of two vectors
   -->
   <nodedef name="ND_crossproduct_vector3" node="crossproduct" type="vector3" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1910,20 +1990,20 @@
     matrix.
   -->
   <nodedef name="ND_transformpoint_vector2M3" node="transformpoint" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_transformpoint_vector3" node="transformpoint" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="fromspace" type="string" value=""/>
     <parameter name="tospace" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_transformpoint_vector3M" node="transformpoint" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_transformpoint_vector3M4" node="transformpoint" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
 
@@ -1932,24 +2012,24 @@
     Transform a vector from one named space to another, or by a specified matrix.
   -->
   <nodedef name="ND_transformvector_vector2M3" node="transformvector" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_transformvector_vector3" node="transformvector" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="fromspace" type="string" value=""/>
     <parameter name="tospace" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_transformvector_vector3M" node="transformvector" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_transformvector_vector3M4" node="transformvector" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_transformvector_vector4M" node="transformvector" type="vector4" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
 
@@ -1958,16 +2038,16 @@
     Transform a normal vector from one named space to another, or by a specified matrix.
   -->
   <nodedef name="ND_transformnormal_vector3" node="transformnormal" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 1.0"/>
     <parameter name="fromspace" type="string" value=""/>
     <parameter name="tospace" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_transformnormal_vector3M" node="transformnormal" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 1.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_transformnormal_vector3M4" node="transformnormal" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 1.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
 
@@ -1976,21 +2056,21 @@
     Output the transpose of the incoming matrix.
   -->
   <nodedef name="ND_transpose_matrix33" node="transpose" type="matrix33" nodegroup="math" defaultinput="in">
-    <input name="in" type="matrix33"/>
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
   <nodedef name="ND_transpose_matrix44" node="transpose" type="matrix44" nodegroup="math" defaultinput="in">
-    <input name="in" type="matrix44"/>
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
 
   <!--
     Node: <determinant>
     Output the determinant of the incoming matrix.
   -->
-  <nodedef name="ND_determinant_matrix33" node="determinant" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="matrix33"/>
+  <nodedef name="ND_determinant_matrix33" node="determinant" type="float" nodegroup="math" default="1.0">
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
-  <nodedef name="ND_determinant_matrix44" node="determinant" type="float" nodegroup="math" defaultinput="in">
-    <input name="in" type="matrix44"/>
+  <nodedef name="ND_determinant_matrix44" node="determinant" type="float" nodegroup="math" default="1.0">
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
 
   <!--
@@ -1998,21 +2078,21 @@
     Rotates a vector value about the origin; for vector3 types, rotate about a specified axis
   -->
   <nodedef name="ND_rotate_vector2" node="rotate" type="vector2" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="amount" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_rotate_vector3" node="rotate" type="vector3" nodegroup="math" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="0.0"/>
-    <parameter name="axis" type="vector3"/>
+    <parameter name="axis" type="vector3" value="0.0, 1.0, 0.0"/>
   </nodedef>
 
   <!--
-    Node: <place2d>
+    Node: <place2d> Supplemental Node
     Transform incoming UV texture coordinates for 2D texture placement.
   -->
   <nodedef name="ND_place2d_vector2" node="place2d" type="vector2" nodegroup="math" defaultinput="texcoord">
-    <input name="texcoord" type="vector2"/>
+    <input name="texcoord" type="vector2" value="0.0, 0.0"/>
     <parameter name="pivot" type="vector2" value="0.0,0.0"/>
     <input name="scale" type="vector2" value="1.0,1.0"/>
     <input name="rotate" type="float" value="0.0"/>
@@ -2024,77 +2104,77 @@
     Creates a two-element array from two base types, or appends a base-type value to an array of
     the same type.
   -->
-  <nodedef name="ND_arrayappend_integer_integerarray" node="arrayappend" type="integerarray" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="integer"/>
-    <input name="in2" type="integer"/>
+  <nodedef name="ND_arrayappend_integer_integerarray" node="arrayappend" type="integerarray" nodegroup="math" default="[]">
+    <input name="in1" type="integer" value="0"/>
+    <input name="in2" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_integerarray_integerarray" node="arrayappend" type="integerarray" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="integerarray"/>
-    <input name="in2" type="integer"/>
+    <input name="in1" type="integerarray" value=""/>
+    <input name="in2" type="integer" value="0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_float_floatarray" node="arrayappend" type="floatarray" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+  <nodedef name="ND_arrayappend_float_floatarray" node="arrayappend" type="floatarray" nodegroup="math" default="[]">
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_floatarray_floatarray" node="arrayappend" type="floatarray" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="floatarray"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="floatarray" value=""/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color2_color2array" node="arrayappend" type="color2array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
+  <nodedef name="ND_arrayappend_color2_color2array" node="arrayappend" type="color2array" nodegroup="math" default="[]">
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_color2array_color2array" node="arrayappend" type="color2array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color2array"/>
-    <input name="in2" type="color2"/>
+    <input name="in1" type="color2array" value=""/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color3_color3array" node="arrayappend" type="color3array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
+  <nodedef name="ND_arrayappend_color3_color3array" node="arrayappend" type="color3array" nodegroup="math" default="[]">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_color3array_color3array" node="arrayappend" type="color3array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color3array"/>
-    <input name="in2" type="color3"/>
+    <input name="in1" type="color3array" value=""/>
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color4_color4array" node="arrayappend" type="color4array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
+  <nodedef name="ND_arrayappend_color4_color4array" node="arrayappend" type="color4array" nodegroup="math" default="[]">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_color4array_color4array" node="arrayappend" type="color4array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="color4array"/>
-    <input name="in2" type="color4"/>
+    <input name="in1" type="color4array" value=""/>
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector2_vector2array" node="arrayappend" type="vector2array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
+  <nodedef name="ND_arrayappend_vector2_vector2array" node="arrayappend" type="vector2array" nodegroup="math" default="[]">
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_vector2array_vector2array" node="arrayappend" type="vector2array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector2array"/>
-    <input name="in2" type="vector2"/>
+    <input name="in1" type="vector2array" value=""/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector3_vector3array" node="arrayappend" type="vector3array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
+  <nodedef name="ND_arrayappend_vector3_vector3array" node="arrayappend" type="vector3array" nodegroup="math" default="[]">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_vector3array_vector3array" node="arrayappend" type="vector3array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector3array"/>
-    <input name="in2" type="vector3"/>
+    <input name="in1" type="vector3array" value=""/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector4_vector4array" node="arrayappend" type="vector4array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
+  <nodedef name="ND_arrayappend_vector4_vector4array" node="arrayappend" type="vector4array" nodegroup="math" default="[]">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_arrayappend_vector4array_vector4array" node="arrayappend" type="vector4array" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="vector4array"/>
-    <input name="in2" type="vector4"/>
+    <input name="in1" type="vector4array" value=""/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_string_stringarray" node="arrayappend" type="stringarray" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="string"/>
-    <input name="in2" type="string"/>
+  <nodedef name="ND_arrayappend_string_stringarray" node="arrayappend" type="stringarray" nodegroup="math" default="[]">
+    <input name="in1" type="string" value=""/>
+    <input name="in2" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_arrayappend_stringarray_stringarray" node="arrayappend" type="stringarray" nodegroup="math" defaultinput="in1">
-    <input name="in1" type="stringarray"/>
-    <input name="in2" type="string"/>
+    <input name="in1" type="stringarray" value=""/>
+    <input name="in2" type="string" value=""/>
   </nodedef>
 
 
@@ -2107,91 +2187,91 @@
     Remap a value from one range of float/color/vector values to another.
   -->
   <nodedef name="ND_remap_float" node="remap" type="float" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="inlow" type="float" value="0.0"/>
     <parameter name="inhigh" type="float" value="1.0"/>
     <parameter name="outlow" type="float" value="0.0"/>
     <parameter name="outhigh" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_remap_color2" node="remap" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="inlow" type="color2" value="0.0, 0.0"/>
     <parameter name="inhigh" type="color2" value="1.0, 1.0"/>
     <parameter name="outlow" type="color2" value="0.0, 0.0"/>
     <parameter name="outhigh" type="color2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_remap_color2FA" node="remap" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_remap_color3" node="remap" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="color3" value="1.0, 1.0, 1.0"/>
     <parameter name="outlow" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="outhigh" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_remap_color3FA" node="remap" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_remap_color4" node="remap" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_remap_color4FA" node="remap" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_remap_vector2" node="remap" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="inlow" type="vector2" value="0.0, 0.0"/>
     <parameter name="inhigh" type="vector2" value="1.0, 1.0"/>
     <parameter name="outlow" type="vector2" value="0.0, 0.0"/>
     <parameter name="outhigh" type="vector2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_remap_vector2FA" node="remap" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_remap_vector3" node="remap" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="outlow" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="outhigh" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_remap_vector3FA" node="remap" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_remap_vector4" node="remap" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
+  <nodedef name="ND_remap_color2FA" node="remap" type="color2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_remap_color3FA" node="remap" type="color3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_remap_color4FA" node="remap" type="color4" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_remap_vector2FA" node="remap" type="vector2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_remap_vector3FA" node="remap" type="vector3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+  </nodedef>
   <nodedef name="ND_remap_vector4FA" node="remap" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="float" value="0.0"/>
     <parameter name="inhigh" type="float" value="1.0"/>
     <parameter name="outlow" type="float" value="0.0"/>
@@ -2204,67 +2284,67 @@
     to output 0-1.
   -->
   <nodedef name="ND_smoothstep_float" node="smoothstep" type="float" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_color2" node="smoothstep" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="low" type="color2" value="0.0, 0.0"/>
     <parameter name="high" type="color2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color2FA" node="smoothstep" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_smoothstep_color3" node="smoothstep" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="high" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color3FA" node="smoothstep" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_smoothstep_color4" node="smoothstep" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="high" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color4FA" node="smoothstep" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_smoothstep_vector2" node="smoothstep" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="low" type="vector2" value="0.0, 0.0"/>
     <parameter name="high" type="vector2" value="1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector2FA" node="smoothstep" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_smoothstep_vector3" node="smoothstep" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="high" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector3FA" node="smoothstep" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
-  </nodedef>
   <nodedef name="ND_smoothstep_vector4" node="smoothstep" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
+  <nodedef name="ND_smoothstep_color2FA" node="smoothstep" type="color2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_smoothstep_color3FA" node="smoothstep" type="color3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_smoothstep_color4FA" node="smoothstep" type="color4" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_smoothstep_vector2FA" node="smoothstep" type="vector2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
+  <nodedef name="ND_smoothstep_vector3FA" node="smoothstep" type="vector3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="low" type="float" value="0.0"/>
+    <parameter name="high" type="float" value="1.0"/>
+  </nodedef>
   <nodedef name="ND_smoothstep_vector4FA" node="smoothstep" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
   </nodedef>
@@ -2277,32 +2357,32 @@
     All channels of the input will be remapped using the same curve.
   -->
   <nodedef name="ND_curveadjust_float" node="curveadjust" type="float" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="float"/>
-    <parameter name="knots" type="vector2array"/>
+    <input name="in" type="float" value="0.0"/>
+    <parameter name="knots" type="vector2array" value=""/>
   </nodedef>
   <nodedef name="ND_curveadjust_color2" node="curveadjust" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="knots" type="vector2array"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="knots" type="vector2array" value=""/>
   </nodedef>
   <nodedef name="ND_curveadjust_color3" node="curveadjust" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="knots" type="vector2array"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="knots" type="vector2array" value=""/>
   </nodedef>
   <nodedef name="ND_curveadjust_color4" node="curveadjust" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="knots" type="vector2array"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="knots" type="vector2array" value=""/>
   </nodedef>
   <nodedef name="ND_curveadjust_vector2" node="curveadjust" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="knots" type="vector2array"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="knots" type="vector2array" value=""/>
   </nodedef>
   <nodedef name="ND_curveadjust_vector3" node="curveadjust" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="knots" type="vector2array"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="knots" type="vector2array" value=""/>
   </nodedef>
   <nodedef name="ND_curveadjust_vector4" node="curveadjust" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="knots" type="vector2array"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="knots" type="vector2array" value=""/>
   </nodedef>
 
   <!--
@@ -2311,16 +2391,16 @@
     the alpha channel is left unchanged if present.
   -->
   <nodedef name="ND_luminance_color3" node="luminance" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287, 0.6740818, 0.0536895, 0.2126, 0.7152, 0.0722, 0.2627, 0.6780, 0.0593, 0.2627, 0.6780, 0.0593"/>
+	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
   <nodedef name="ND_luminance_color4" node="luminance" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287, 0.6740818, 0.0536895, 0.2126, 0.7152, 0.0722, 0.2627, 0.6780, 0.0593, 0.2627, 0.6780, 0.0593"/>
+	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
 
   <!--
@@ -2328,16 +2408,16 @@
     Convert an incoming color between RGB and HSV space, with H and S ranging from 0-1.
   -->
   <nodedef name="ND_rgbtohsv_color3" node="rgbtohsv" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_rgbtohsv_color4" node="rgbtohsv" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_hsvtorgb_color3" node="hsvtorgb" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_hsvtorgb_color4" node="hsvtorgb" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -2345,67 +2425,67 @@
     Increase or decrease contrast of a float/color value using a linear slope multiplier.
   -->
   <nodedef name="ND_contrast_float" node="contrast" type="float" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
   </nodedef>
   <nodedef name="ND_contrast_color2" node="contrast" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="amount" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="amount" type="color2" value="1.0, 1.0"/>
     <parameter name="pivot" type="color2" value="0.5, 0.5"/>
   </nodedef>
-  <nodedef name="ND_contrast_color2FA" node="contrast" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="amount" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.5"/>
-  </nodedef>
   <nodedef name="ND_contrast_color3" node="contrast" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="amount" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="color3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="color3" value="0.5, 0.5, 0.5"/>
   </nodedef>
-  <nodedef name="ND_contrast_color3FA" node="contrast" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="amount" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.5"/>
-  </nodedef>
   <nodedef name="ND_contrast_color4" node="contrast" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="amount" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="color4" value="0.5, 0.5, 0.5, 0.5"/>
   </nodedef>
-  <nodedef name="ND_contrast_color4FA" node="contrast" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="amount" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.5"/>
-  </nodedef>
   <nodedef name="ND_contrast_vector2" node="contrast" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="amount" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="amount" type="vector2" value="1.0, 1.0"/>
     <parameter name="pivot" type="vector2" value="0.5, 0.5"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector2FA" node="contrast" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="amount" type="float" value="1.0"/>
-    <parameter name="pivot" type="float" value="0.5"/>
-  </nodedef>
   <nodedef name="ND_contrast_vector3" node="contrast" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="amount" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="vector3" value="0.5, 0.5, 0.5"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector3FA" node="contrast" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
+  <nodedef name="ND_contrast_vector4" node="contrast" type="vector4" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+    <parameter name="pivot" type="vector4" value="0.5, 0.5, 0.5, 0.5"/>
+  </nodedef>
+  <nodedef name="ND_contrast_color2FA" node="contrast" type="color2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector4" node="contrast" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="amount" type="vector4"/>
-    <parameter name="pivot" type="vector4" value="0.5, 0.5, 0.5, 0.5"/>
+  <nodedef name="ND_contrast_color3FA" node="contrast" type="color3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.5"/>
+  </nodedef>
+  <nodedef name="ND_contrast_color4FA" node="contrast" type="color4" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.5"/>
+  </nodedef>
+  <nodedef name="ND_contrast_vector2FA" node="contrast" type="vector2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.5"/>
+  </nodedef>
+  <nodedef name="ND_contrast_vector3FA" node="contrast" type="vector3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="amount" type="float" value="1.0"/>
+    <parameter name="pivot" type="float" value="0.5"/>
   </nodedef>
   <nodedef name="ND_contrast_vector4FA" node="contrast" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
   </nodedef>
@@ -2416,7 +2496,7 @@
     applying a gamma correction in the middle, and optionally clamping output values.
   -->
   <nodedef name="ND_range_float" node="range" type="float" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="inlow" type="float" value="0.0"/>
     <parameter name="inhigh" type="float" value="1.0"/>
     <parameter name="gamma" type="float" value="1.0"/>
@@ -2425,7 +2505,7 @@
     <parameter name="doclamp" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_range_color2" node="range" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="inlow" type="color2" value="0.0, 0.0"/>
     <parameter name="inhigh" type="color2" value="1.0, 1.0"/>
     <parameter name="gamma" type="color2" value="1.0, 1.0"/>
@@ -2433,17 +2513,8 @@
     <parameter name="outhigh" type="color2" value="1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
   </nodedef>
-  <nodedef name="ND_range_color2FA" node="range" type="color2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="gamma" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-    <parameter name="doclamp" type="boolean" value="false"/>
-  </nodedef>
   <nodedef name="ND_range_color3" node="range" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="color3" value="1.0, 1.0, 1.0"/>
     <parameter name="gamma" type="color3" value="1.0, 1.0, 1.0"/>
@@ -2451,17 +2522,8 @@
     <parameter name="outhigh" type="color3" value="1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
   </nodedef>
-  <nodedef name="ND_range_color3FA" node="range" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="gamma" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-    <parameter name="doclamp" type="boolean" value="false"/>
-  </nodedef>
   <nodedef name="ND_range_color4" node="range" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="gamma" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
@@ -2469,17 +2531,8 @@
     <parameter name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
   </nodedef>
-  <nodedef name="ND_range_color4FA" node="range" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="gamma" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-    <parameter name="doclamp" type="boolean" value="false"/>
-  </nodedef>
   <nodedef name="ND_range_vector2" node="range" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="inlow" type="vector2" value="0.0, 0.0"/>
     <parameter name="inhigh" type="vector2" value="1.0, 1.0"/>
     <parameter name="gamma" type="vector2" value="1.0, 1.0"/>
@@ -2487,17 +2540,8 @@
     <parameter name="outhigh" type="vector2" value="1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
   </nodedef>
-  <nodedef name="ND_range_vector2FA" node="range" type="vector2" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="gamma" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-    <parameter name="doclamp" type="boolean" value="false"/>
-  </nodedef>
   <nodedef name="ND_range_vector3" node="range" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="gamma" type="vector3" value="1.0, 1.0, 1.0"/>
@@ -2505,17 +2549,8 @@
     <parameter name="outhigh" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
   </nodedef>
-  <nodedef name="ND_range_vector3FA" node="range" type="vector3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="inlow" type="float" value="0.0"/>
-    <parameter name="inhigh" type="float" value="1.0"/>
-    <parameter name="gamma" type="float" value="1.0"/>
-    <parameter name="outlow" type="float" value="0.0"/>
-    <parameter name="outhigh" type="float" value="1.0"/>
-    <parameter name="doclamp" type="boolean" value="false"/>
-  </nodedef>
   <nodedef name="ND_range_vector4" node="range" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="gamma" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
@@ -2523,8 +2558,53 @@
     <parameter name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
   </nodedef>
+  <nodedef name="ND_range_color2FA" node="range" type="color2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="gamma" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+    <parameter name="doclamp" type="boolean" value="false"/>
+  </nodedef>
+  <nodedef name="ND_range_color3FA" node="range" type="color3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="gamma" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+    <parameter name="doclamp" type="boolean" value="false"/>
+  </nodedef>
+  <nodedef name="ND_range_color4FA" node="range" type="color4" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="gamma" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+    <parameter name="doclamp" type="boolean" value="false"/>
+  </nodedef>
+  <nodedef name="ND_range_vector2FA" node="range" type="vector2" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="gamma" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+    <parameter name="doclamp" type="boolean" value="false"/>
+  </nodedef>
+  <nodedef name="ND_range_vector3FA" node="range" type="vector3" nodegroup="adjustment" defaultinput="in">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="inlow" type="float" value="0.0"/>
+    <parameter name="inhigh" type="float" value="1.0"/>
+    <parameter name="gamma" type="float" value="1.0"/>
+    <parameter name="outlow" type="float" value="0.0"/>
+    <parameter name="outhigh" type="float" value="1.0"/>
+    <parameter name="doclamp" type="boolean" value="false"/>
+  </nodedef>
   <nodedef name="ND_range_vector4FA" node="range" type="vector4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="inlow" type="float" value="0.0"/>
     <parameter name="inhigh" type="float" value="1.0"/>
     <parameter name="gamma" type="float" value="1.0"/>
@@ -2540,11 +2620,11 @@
     multiplying the value by amount.z, then converting back to RGB.
   -->
   <nodedef name="ND_hsvadjust_color3" node="hsvadjust" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="amount" type="vector3" value="0.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_hsvadjust_color4" node="hsvadjust" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="vector3" value="0.0, 1.0, 1.0"/>
   </nodedef>
 
@@ -2555,18 +2635,18 @@
     coefficients; the alpha channel will be unchanged if present.
   -->
   <nodedef name="ND_saturate_color3" node="saturate" type="color3" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="amount" type="float" value="1.0"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="amount" type="float" value="1.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287, 0.6740818, 0.0536895, 0.2126, 0.7152, 0.0722, 0.2627, 0.6780, 0.0593, 0.2627, 0.6780, 0.0593"/>
+	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
   <nodedef name="ND_saturate_color4" node="saturate" type="color4" nodegroup="adjustment" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="amount" type="float" value="1.0"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="amount" type="float" value="1.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287, 0.6740818, 0.0536895, 0.2126, 0.7152, 0.0722, 0.2627, 0.6780, 0.0593, 0.2627, 0.6780, 0.0593"/>
+	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
 
 
@@ -2579,14 +2659,10 @@
     Multiply the R or RGB channels of the input by the Alpha channel of the input.
   -->
   <nodedef name="ND_premult_color2" node="premult" type="color2" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_premult_color3" node="premult" type="color3" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color3"/>
-    <input name="alpha" type="float"/>
+    <input name="in" type="color2" value="0.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_premult_color4" node="premult" type="color4" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0"/>
   </nodedef>
 
   <!--
@@ -2595,14 +2671,10 @@
     If the Alpha value is zero, it is passed through unchanged.
   -->
   <nodedef name="ND_unpremult_color2" node="unpremult" type="color2" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color2"/>
-  </nodedef>
-  <nodedef name="ND_unpremult_color3" node="unpremult" type="color3" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color3"/>
-    <input name="alpha" type="float"/>
+    <input name="in" type="color2" value="0.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_unpremult_color4" node="unpremult" type="color4" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0"/>
   </nodedef>
 
   <!--
@@ -2610,23 +2682,23 @@
     Add two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
   <nodedef name="ND_plus_float" node="plus" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_plus_color2" node="plus" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_plus_color3" node="plus" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_plus_color4" node="plus" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2635,23 +2707,23 @@
     Subtract two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
   <nodedef name="ND_minus_float" node="minus" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_minus_color2" node="minus" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_minus_color3" node="minus" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_minus_color4" node="minus" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2661,23 +2733,23 @@
     the bg input and the result.
   -->
   <nodedef name="ND_difference_float" node="difference" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_difference_color2" node="difference" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_difference_color3" node="difference" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_difference_color4" node="difference" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2686,23 +2758,23 @@
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-B)/F
   -->
   <nodedef name="ND_burn_float" node="burn" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_burn_color2" node="burn" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_burn_color3" node="burn" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_burn_color4" node="burn" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2711,23 +2783,23 @@
     Take two 1-4 channel inputs and apply the same operator to all channels: B/(1-F)
   -->
   <nodedef name="ND_dodge_float" node="dodge" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_dodge_color2" node="dodge" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_dodge_color3" node="dodge" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_dodge_color4" node="dodge" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2736,23 +2808,23 @@
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-F)*(1-B)
   -->
   <nodedef name="ND_screen_float" node="screen" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_screen_color2" node="screen" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_screen_color3" node="screen" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_screen_color4" node="screen" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2763,23 +2835,23 @@
       1-(1-F)(1-B) if F>=0.5
   -->
   <nodedef name="ND_overlay_float" node="overlay" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_overlay_color2" node="overlay" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_overlay_color3" node="overlay" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_overlay_color4" node="overlay" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2792,13 +2864,13 @@
       alpha: min(f+b,1)
   -->
   <nodedef name="ND_disjointover_color2" node="disjointover" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_disjointover_color4" node="disjointover" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2808,13 +2880,13 @@
     channel(s) to control the compositing of the fg and bg inputs: Fb  (alpha: fb)
   -->
   <nodedef name="ND_in_color2" node="in" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_in_color4" node="in" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2824,13 +2896,13 @@
     channel(s) to control the compositing of the fg and bg inputs: Bf  (alpha: bf)
   -->
   <nodedef name="ND_mask_color2" node="mask" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_mask_color4" node="mask" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2840,13 +2912,13 @@
     channel(s) to control the compositing of the fg and bg inputs: Ff+B(1-f)  (alpha: f+b(1-f))
   -->
   <nodedef name="ND_matte_color2" node="matte" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_matte_color4" node="matte" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2856,13 +2928,13 @@
     channel(s) to control the compositing of the fg and bg inputs: F(1-b)  (alpha: f(1-b))
   -->
   <nodedef name="ND_out_color2" node="out" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_out_color4" node="out" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2872,13 +2944,13 @@
     channel(s) to control the compositing of the fg and bg inputs: F+B(1-f)  (alpha: f+b(1-f))
   -->
   <nodedef name="ND_over_color2" node="over" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_over_color4" node="over" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
   </nodedef>
 
@@ -2888,20 +2960,20 @@
     operator to all channels: in * mask
   -->
   <nodedef name="ND_inside_float" node="inside" type="float" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="float"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="float" value="0.0"/>
+    <input name="mask" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_inside_color2" node="inside" type="color2" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color2"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <input name="mask" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_inside_color3" node="inside" type="color3" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color3"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="mask" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_inside_color4" node="inside" type="color4" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color4"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="mask" type="float" value="1.0"/>
   </nodedef>
 
   <!--
@@ -2910,20 +2982,20 @@
     operator to all channels: in * (1-mask)
   -->
   <nodedef name="ND_outside_float" node="outside" type="float" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="float"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="float" value="0.0"/>
+    <input name="mask" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_outside_color2" node="outside" type="color2" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color2"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <input name="mask" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_outside_color3" node="outside" type="color3" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color3"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="mask" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_outside_color4" node="outside" type="color4" nodegroup="compositing" defaultinput="in">
-    <input name="in" type="color4"/>
-    <input name="mask" type="float"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="mask" type="float" value="0.0"/>
   </nodedef>
 
   <!--
@@ -2931,54 +3003,54 @@
     Mix two inputs according to an input mix amount.
   -->
   <nodedef name="ND_mix_float" node="mix" type="float" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="float"/>
-    <input name="bg" type="float"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="float" value="0.0"/>
+    <input name="bg" type="float" value="0.0"/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_color2" node="mix" type="color2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color2"/>
-    <input name="bg" type="color2"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="color2" value="0.0, 0.0"/>
+    <input name="bg" type="color2" value="0.0, 0.0"/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_color3" node="mix" type="color3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color3"/>
-    <input name="bg" type="color3"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_color4" node="mix" type="color4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="color4"/>
-    <input name="bg" type="color4"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_vector2" node="mix" type="vector2" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="vector2"/>
-    <input name="bg" type="vector2"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="vector2" value="0.0, 0.0"/>
+    <input name="bg" type="vector2" value="0.0, 0.0"/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_vector3" node="mix" type="vector3" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="vector3"/>
-    <input name="bg" type="vector3"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="bg" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_vector4" node="mix" type="vector4" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="vector4"/>
-    <input name="bg" type="vector4"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_surfaceshader" node="mix" type="surfaceshader" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="surfaceshader"/>
-    <input name="bg" type="surfaceshader"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="surfaceshader" value=""/>
+    <input name="bg" type="surfaceshader" value=""/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_displacementshader" node="mix" type="displacementshader" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="displacementshader"/>
-    <input name="bg" type="displacementshader"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="displacementshader" value=""/>
+    <input name="bg" type="displacementshader" value=""/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_mix_volumeshader" node="mix" type="volumeshader" nodegroup="compositing" defaultinput="bg">
-    <input name="fg" type="volumeshader"/>
-    <input name="bg" type="volumeshader"/>
-    <input name="mix" type="float"/>
+    <input name="fg" type="volumeshader" value=""/>
+    <input name="bg" type="volumeshader" value=""/>
+    <input name="mix" type="float" value="0.0"/>
   </nodedef>
 
 
@@ -2993,46 +3065,46 @@
     stream value is greater than the fixed cutoff value.
   -->
   <nodedef name="ND_compare_float" node="compare" type="float" nodegroup="conditional" defaultinput="in1">
-    <input name="intest" type="float"/>
+    <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_compare_color2" node="compare" type="color2" nodegroup="conditional" defaultinput="in1">
-    <input name="intest" type="float"/>
+    <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_compare_color3" node="compare" type="color3" nodegroup="conditional" defaultinput="in1">
-    <input name="intest" type="float"/>
+    <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
-    <input name="in1" type="color3"/>
-    <input name="in2" type="color3"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_compare_color4" node="compare" type="color4" nodegroup="conditional" defaultinput="in1">
-    <input name="intest" type="float"/>
+    <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
-    <input name="in1" type="color4"/>
-    <input name="in2" type="color4"/>
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_compare_vector2" node="compare" type="vector2" nodegroup="conditional" defaultinput="in1">
-    <input name="intest" type="float"/>
+    <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_compare_vector3" node="compare" type="vector3" nodegroup="conditional" defaultinput="in1">
-    <input name="intest" type="float"/>
+    <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="vector3"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_compare_vector4" node="compare" type="vector4" nodegroup="conditional" defaultinput="in1">
-    <input name="intest" type="float"/>
+    <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
-    <input name="in1" type="vector4"/>
-    <input name="in2" type="vector4"/>
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -3045,7 +3117,7 @@
     <input name="in3" type="float" value="0.0"/>
     <input name="in4" type="float" value="0.0"/>
     <input name="in5" type="float" value="0.0"/>
-    <parameter name="which" type="float"/>
+    <parameter name="which" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_switch_color2" node="switch" type="color2" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color2" value="0.0, 0.0"/>
@@ -3053,7 +3125,7 @@
     <input name="in3" type="color2" value="0.0, 0.0"/>
     <input name="in4" type="color2" value="0.0, 0.0"/>
     <input name="in5" type="color2" value="0.0, 0.0"/>
-    <parameter name="which" type="float"/>
+    <parameter name="which" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_switch_color3" node="switch" type="color3" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
@@ -3061,7 +3133,7 @@
     <input name="in3" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="color3" value="0.0, 0.0, 0.0"/>
-    <parameter name="which" type="float"/>
+    <parameter name="which" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_switch_color4" node="switch" type="color4" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
@@ -3069,7 +3141,7 @@
     <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="which" type="float"/>
+    <parameter name="which" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_switch_vector2" node="switch" type="vector2" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
@@ -3077,7 +3149,7 @@
     <input name="in3" type="vector2" value="0.0, 0.0"/>
     <input name="in4" type="vector2" value="0.0, 0.0"/>
     <input name="in5" type="vector2" value="0.0, 0.0"/>
-    <parameter name="which" type="float"/>
+    <parameter name="which" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_switch_vector3" node="switch" type="vector3" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
@@ -3085,7 +3157,7 @@
     <input name="in3" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="vector3" value="0.0, 0.0, 0.0"/>
-    <parameter name="which" type="float"/>
+    <parameter name="which" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_switch_vector4" node="switch" type="vector4" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
@@ -3093,7 +3165,7 @@
     <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="which" type="float"/>
+    <parameter name="which" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_switch_floatI" node="switch" type="float" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="float" value="0.0"/>
@@ -3101,7 +3173,7 @@
     <input name="in3" type="float" value="0.0"/>
     <input name="in4" type="float" value="0.0"/>
     <input name="in5" type="float" value="0.0"/>
-    <parameter name="which" type="integer"/>
+    <parameter name="which" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_switch_color2I" node="switch" type="color2" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color2" value="0.0, 0.0"/>
@@ -3109,7 +3181,7 @@
     <input name="in3" type="color2" value="0.0, 0.0"/>
     <input name="in4" type="color2" value="0.0, 0.0"/>
     <input name="in5" type="color2" value="0.0, 0.0"/>
-    <parameter name="which" type="integer"/>
+    <parameter name="which" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_switch_color3I" node="switch" type="color3" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
@@ -3117,7 +3189,7 @@
     <input name="in3" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="color3" value="0.0, 0.0, 0.0"/>
-    <parameter name="which" type="integer"/>
+    <parameter name="which" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_switch_color4I" node="switch" type="color4" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
@@ -3125,7 +3197,7 @@
     <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="which" type="integer"/>
+    <parameter name="which" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_switch_vector2I" node="switch" type="vector2" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
@@ -3133,7 +3205,7 @@
     <input name="in3" type="vector2" value="0.0, 0.0"/>
     <input name="in4" type="vector2" value="0.0, 0.0"/>
     <input name="in5" type="vector2" value="0.0, 0.0"/>
-    <parameter name="which" type="integer"/>
+    <parameter name="which" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_switch_vector3I" node="switch" type="vector3" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
@@ -3141,7 +3213,7 @@
     <input name="in3" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="vector3" value="0.0, 0.0, 0.0"/>
-    <parameter name="which" type="integer"/>
+    <parameter name="which" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_switch_vector4I" node="switch" type="vector4" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
@@ -3149,42 +3221,42 @@
     <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="which" type="integer"/>
+    <parameter name="which" type="integer" value="0"/>
   </nodedef>
   <nodedef name="ND_switch_floatB" node="switch" type="float" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <parameter name="which" type="boolean"/>
+    <parameter name="which" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_switch_color2B" node="switch" type="color2" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <parameter name="which" type="boolean"/>
+    <parameter name="which" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_switch_color3B" node="switch" type="color3" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <parameter name="which" type="boolean"/>
+    <parameter name="which" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_switch_color4B" node="switch" type="color4" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="which" type="boolean"/>
+    <parameter name="which" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_switch_vector2B" node="switch" type="vector2" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <parameter name="which" type="boolean"/>
+    <parameter name="which" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_switch_vector3B" node="switch" type="vector3" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <parameter name="which" type="boolean"/>
+    <parameter name="which" type="boolean" value="false"/>
   </nodedef>
   <nodedef name="ND_switch_vector4B" node="switch" type="vector4" nodegroup="conditional" defaultinput="in1">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="which" type="boolean"/>
+    <parameter name="which" type="boolean" value="false"/>
   </nodedef>
 
 
@@ -3197,65 +3269,65 @@
     Convert a stream from one type to another; only certain unambiguous conversion
     types are supported.
   -->
-  <nodedef name="ND_convert_float_color2" node="convert" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
+  <nodedef name="ND_convert_float_color2" node="convert" type="color2" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_float_color3" node="convert" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
+  <nodedef name="ND_convert_float_color3" node="convert" type="color3" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_float_color4" node="convert" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
+  <nodedef name="ND_convert_float_color4" node="convert" type="color4" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_float_vector2" node="convert" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
+  <nodedef name="ND_convert_float_vector2" node="convert" type="vector2" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_float_vector3" node="convert" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
+  <nodedef name="ND_convert_float_vector3" node="convert" type="vector3" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_float_vector4" node="convert" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
+  <nodedef name="ND_convert_float_vector4" node="convert" type="vector4" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_vector2_color2" node="convert" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
+  <nodedef name="ND_convert_vector2_color2" node="convert" type="color2" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_vector2_vector3" node="convert" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
+  <nodedef name="ND_convert_vector2_vector3" node="convert" type="vector3" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_vector3_vector2" node="convert" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
+  <nodedef name="ND_convert_vector3_color3" node="convert" type="color3" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_vector3_color3" node="convert" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
+  <nodedef name="ND_convert_vector3_vector2" node="convert" type="vector2" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_vector3_vector4" node="convert" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
+  <nodedef name="ND_convert_vector3_vector4" node="convert" type="vector4" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_vector4_vector3" node="convert" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
+  <nodedef name="ND_convert_vector4_color4" node="convert" type="color4" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_vector4_color4" node="convert" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
+  <nodedef name="ND_convert_vector4_vector3" node="convert" type="vector3" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_color2_vector2" node="convert" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
+  <nodedef name="ND_convert_color2_vector2" node="convert" type="vector2" nodegroup="channel">
+    <input name="in" type="color2" value="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_color3_vector3" node="convert" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
+  <nodedef name="ND_convert_color3_vector3" node="convert" type="vector3" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_color4_vector4" node="convert" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
+  <nodedef name="ND_convert_color4_vector4" node="convert" type="vector4" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_color3_color4" node="convert" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
+  <nodedef name="ND_convert_color3_color4" node="convert" type="color4" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_color4_color3" node="convert" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
+  <nodedef name="ND_convert_color4_color3" node="convert" type="color3" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_convert_boolean_float" node="convert" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="boolean"/>
+  <nodedef name="ND_convert_boolean_float" node="convert" type="float" nodegroup="channel">
+    <input name="in" type="boolean" value="false"/>
   </nodedef>
-  <nodedef name="ND_convert_integer_float" node="convert" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="integer"/>
+  <nodedef name="ND_convert_integer_float" node="convert" type="float" nodegroup="channel">
+    <input name="in" type="integer" value="0"/>
   </nodedef>
 
   <!--
@@ -3265,203 +3337,203 @@
     stream may have a different number of channels than the input.
   -->
   <!-- from type: float -->
-  <nodedef name="ND_swizzle_float_color2" node="swizzle" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_float_color2" node="swizzle" type="color2" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
+    <parameter name="channels" type="string" value="rr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_float_color3" node="swizzle" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_float_color3" node="swizzle" type="color3" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
+    <parameter name="channels" type="string" value="rrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_float_color4" node="swizzle" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_float_color4" node="swizzle" type="color4" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
+    <parameter name="channels" type="string" value="rrrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_float_vector2" node="swizzle" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_float_vector2" node="swizzle" type="vector2" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
+    <parameter name="channels" type="string" value="xx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_float_vector3" node="swizzle" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_float_vector3" node="swizzle" type="vector3" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
+    <parameter name="channels" type="string" value="xxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_float_vector4" node="swizzle" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="float"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_float_vector4" node="swizzle" type="vector4" nodegroup="channel">
+    <input name="in" type="float" value="0.0"/>
+    <parameter name="channels" type="string" value="xxxx"/>
   </nodedef>
   <!-- from type: color2 -->
-  <nodedef name="ND_swizzle_color2_float" node="swizzle" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color2_float" node="swizzle" type="float" nodegroup="channel">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="r"/>
   </nodedef>
   <nodedef name="ND_swizzle_color2_color2" node="swizzle" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="channels" type="string"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color2_color3" node="swizzle" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color2_color3" node="swizzle" type="color3" nodegroup="channel">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color2_color4" node="swizzle" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color2_color4" node="swizzle" type="color4" nodegroup="channel">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color2_vector2" node="swizzle" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color2_vector2" node="swizzle" type="vector2" nodegroup="channel">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color2_vector3" node="swizzle" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color2_vector3" node="swizzle" type="vector3" nodegroup="channel">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color2_vector4" node="swizzle" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color2_vector4" node="swizzle" type="vector4" nodegroup="channel">
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrrr"/>
   </nodedef>
   <!-- from type: color3 -->
-  <nodedef name="ND_swizzle_color3_float" node="swizzle" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color3_float" node="swizzle" type="float" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="r"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color3_color2" node="swizzle" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color3_color2" node="swizzle" type="color2" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rr"/>
   </nodedef>
   <nodedef name="ND_swizzle_color3_color3" node="swizzle" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="channels" type="string"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color3_color4" node="swizzle" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color3_color4" node="swizzle" type="color4" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color3_vector2" node="swizzle" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color3_vector2" node="swizzle" type="vector2" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color3_vector3" node="swizzle" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color3_vector3" node="swizzle" type="vector3" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color3_vector4" node="swizzle" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color3_vector4" node="swizzle" type="vector4" nodegroup="channel">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrrr"/>
   </nodedef>
   <!-- from type: color4 -->
-  <nodedef name="ND_swizzle_color4_float" node="swizzle" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color4_float" node="swizzle" type="float" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="r"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color4_color2" node="swizzle" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color4_color2" node="swizzle" type="color2" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color4_color3" node="swizzle" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color4_color3" node="swizzle" type="color3" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrr"/>
   </nodedef>
   <nodedef name="ND_swizzle_color4_color4" node="swizzle" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="channels" type="string"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color4_vector2" node="swizzle" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color4_vector2" node="swizzle" type="vector2" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color4_vector3" node="swizzle" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color4_vector3" node="swizzle" type="vector3" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrr"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color4_vector4" node="swizzle" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_color4_vector4" node="swizzle" type="vector4" nodegroup="channel">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="rrrr"/>
   </nodedef>
   <!-- from type: vector2 -->
-  <nodedef name="ND_swizzle_vector2_float" node="swizzle" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector2_float" node="swizzle" type="float" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="x"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector2_color2" node="swizzle" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector2_color2" node="swizzle" type="color2" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector2_color3" node="swizzle" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector2_color3" node="swizzle" type="color3" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector2_color4" node="swizzle" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector2_color4" node="swizzle" type="color4" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxxx"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector2_vector2" node="swizzle" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="channels" type="string"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector2_vector3" node="swizzle" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector2_vector3" node="swizzle" type="vector3" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector2_vector4" node="swizzle" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector2_vector4" node="swizzle" type="vector4" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxxx"/>
   </nodedef>
   <!-- from type: vector3 -->
-  <nodedef name="ND_swizzle_vector3_float" node="swizzle" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector3_float" node="swizzle" type="float" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="x"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector3_color2" node="swizzle" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector3_color2" node="swizzle" type="color2" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector3_color3" node="swizzle" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector3_color3" node="swizzle" type="color3" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector3_color4" node="swizzle" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector3_color4" node="swizzle" type="color4" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector3_vector2" node="swizzle" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector3_vector2" node="swizzle" type="vector2" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xx"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector3_vector3" node="swizzle" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="channels" type="string"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector3_vector4" node="swizzle" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector3_vector4" node="swizzle" type="vector4" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxxx"/>
   </nodedef>
   <!-- from type: vector4 -->
-  <nodedef name="ND_swizzle_vector4_float" node="swizzle" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector4_float" node="swizzle" type="float" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="x"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector4_color2" node="swizzle" type="color2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector4_color2" node="swizzle" type="color2" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector4_color3" node="swizzle" type="color3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector4_color3" node="swizzle" type="color3" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector4_color4" node="swizzle" type="color4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector4_color4" node="swizzle" type="color4" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxxx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector4_vector2" node="swizzle" type="vector2" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector4_vector2" node="swizzle" type="vector2" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xx"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector4_vector3" node="swizzle" type="vector3" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="channels" type="string"/>
+  <nodedef name="ND_swizzle_vector4_vector3" node="swizzle" type="vector3" nodegroup="channel">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxx"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector4_vector4" node="swizzle" type="vector4" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="channels" type="string"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="channels" type="string" value="xxxx"/>
   </nodedef>
 
   <!--
@@ -3470,50 +3542,50 @@
     single output stream of a specified compatible type.
   -->
   <nodedef name="ND_combine_color2" node="combine" type="color2" nodegroup="channel" default="0.0, 0.0">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_vector2" node="combine" type="vector2" nodegroup="channel" default="0.0, 0.0">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_color3" node="combine" type="color3" nodegroup="channel" default="0.0, 0.0, 0.0">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
-    <input name="in3" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+    <input name="in3" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_vector3" node="combine" type="vector3" nodegroup="channel" default="0.0, 0.0, 0.0">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
-    <input name="in3" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+    <input name="in3" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_color4" node="combine" type="color4" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
-    <input name="in3" type="float"/>
-    <input name="in4" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+    <input name="in3" type="float" value="0.0"/>
+    <input name="in4" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_vector4" node="combine" type="vector4" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
-    <input name="in1" type="float"/>
-    <input name="in2" type="float"/>
-    <input name="in3" type="float"/>
-    <input name="in4" type="float"/>
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+    <input name="in3" type="float" value="0.0"/>
+    <input name="in4" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_color4CF" node="combine" type="color4" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
-    <input name="in1" type="color3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_vector4VF" node="combine" type="vector4" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
-    <input name="in1" type="vector3"/>
-    <input name="in2" type="float"/>
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="in2" type="float" value="0.0"/>
   </nodedef>
   <nodedef name="ND_combine_color4CC" node="combine" type="color4" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
-    <input name="in1" type="color2"/>
-    <input name="in2" type="color2"/>
+    <input name="in1" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_combine_vector4VV" node="combine" type="vector4" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
-    <input name="in1" type="vector2"/>
-    <input name="in2" type="vector2"/>
+    <input name="in1" type="vector2" value="0.0, 0.0"/>
+    <input name="in2" type="vector2" value="0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -3521,28 +3593,28 @@
     Extract a single channel from a colorN or vectorN stream, outputting a float.
   -->
   <nodedef name="ND_extract_color2" node="extract" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color2"/>
-    <parameter name="index" type="integer" uimin="0" uimax="1"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
+    <parameter name="index" type="integer" value="0" uimin="0" uimax="1"/>
   </nodedef>
   <nodedef name="ND_extract_color3" node="extract" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color3"/>
-    <parameter name="index" type="integer" uimin="0" uimax="2"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
+    <parameter name="index" type="integer" value="0" uimin="0" uimax="2"/>
   </nodedef>
   <nodedef name="ND_extract_color4" node="extract" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="color4"/>
-    <parameter name="index" type="integer" uimin="0" uimax="3"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="index" type="integer" value="0" uimin="0" uimax="3"/>
   </nodedef>
   <nodedef name="ND_extract_vector2" node="extract" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector2"/>
-    <parameter name="index" type="integer" uimin="0" uimax="1"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <parameter name="index" type="integer" value="0" uimin="0" uimax="1"/>
   </nodedef>
   <nodedef name="ND_extract_vector3" node="extract" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector3"/>
-    <parameter name="index" type="integer" uimin="0" uimax="2"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <parameter name="index" type="integer" value="0" uimin="0" uimax="2"/>
   </nodedef>
   <nodedef name="ND_extract_vector4" node="extract" type="float" nodegroup="channel" defaultinput="in">
-    <input name="in" type="vector4"/>
-    <parameter name="index" type="integer" uimin="0" uimax="3"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <parameter name="index" type="integer" value="0" uimin="0" uimax="3"/>
   </nodedef>
 
   <!--
@@ -3550,36 +3622,36 @@
     Output each of the channels of a color/vector stream as a separate float output.
   -->
   <nodedef name="ND_separate_color2" node="separate" type="multioutput" nodegroup="channel">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <output name="outr" type="float" default="0.0"/>
     <output name="outa" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_separate_color3" node="separate" type="multioutput" nodegroup="channel">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <output name="outr" type="float" default="0.0"/>
     <output name="outg" type="float" default="0.0"/>
     <output name="outb" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_separate_color4" node="separate" type="multioutput" nodegroup="channel">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <output name="outr" type="float" default="0.0"/>
     <output name="outg" type="float" default="0.0"/>
     <output name="outb" type="float" default="0.0"/>
     <output name="outa" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_separate_vector2" node="separate" type="multioutput" nodegroup="channel">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <output name="outx" type="float" default="0.0"/>
     <output name="outy" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_separate_vector3" node="separate" type="multioutput" nodegroup="channel">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <output name="outx" type="float" default="0.0"/>
     <output name="outy" type="float" default="0.0"/>
     <output name="outz" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_separate_vector4" node="separate" type="multioutput" nodegroup="channel">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <output name="outx" type="float" default="0.0"/>
     <output name="outy" type="float" default="0.0"/>
     <output name="outz" type="float" default="0.0"/>
@@ -3596,37 +3668,37 @@
     A gaussian-falloff blur.
   -->
   <nodedef name="ND_blur_float" node="blur" type="float" nodegroup="convolution2d" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
   </nodedef>
   <nodedef name="ND_blur_color2" node="blur" type="color2" nodegroup="convolution2d" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
   </nodedef>
   <nodedef name="ND_blur_color3" node="blur" type="color3" nodegroup="convolution2d" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
   </nodedef>
   <nodedef name="ND_blur_color4" node="blur" type="color4" nodegroup="convolution2d" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
   </nodedef>
   <nodedef name="ND_blur_vector2" node="blur" type="vector2" nodegroup="convolution2d" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
   </nodedef>
   <nodedef name="ND_blur_vector3" node="blur" type="vector3" nodegroup="convolution2d" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
   </nodedef>
   <nodedef name="ND_blur_vector4" node="blur" type="vector4" nodegroup="convolution2d" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
   </nodedef>
@@ -3636,7 +3708,7 @@
     Convert a scalar height map to a normal map of type vector3.
   -->
   <nodedef name="ND_heighttonormal_vector3" node="heighttonormal" type="vector3" nodegroup="convolution2d" default="0.0, 1.0, 0.0">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="scale" type="float" value="1.0"/>
   </nodedef>
 
@@ -3650,71 +3722,71 @@
     No-op; passes its input to the output unchanged.
   -->
   <nodedef name="ND_dot_float" node="dot" type="float" nodegroup="organization" defaultinput="in">
-    <input name="in" type="float"/>
+    <input name="in" type="float" value="0.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_color2" node="dot" type="color2" nodegroup="organization" defaultinput="in">
-    <input name="in" type="color2"/>
+    <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_color3" node="dot" type="color3" nodegroup="organization" defaultinput="in">
-    <input name="in" type="color3"/>
+    <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_color4" node="dot" type="color4" nodegroup="organization" defaultinput="in">
-    <input name="in" type="color4"/>
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_vector2" node="dot" type="vector2" nodegroup="organization" defaultinput="in">
-    <input name="in" type="vector2"/>
+    <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_vector3" node="dot" type="vector3" nodegroup="organization" defaultinput="in">
-    <input name="in" type="vector3"/>
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_vector4" node="dot" type="vector4" nodegroup="organization" defaultinput="in">
-    <input name="in" type="vector4"/>
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_boolean" node="dot" type="boolean" nodegroup="organization" defaultinput="in">
-    <input name="in" type="boolean"/>
+    <input name="in" type="boolean" value="false"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_integer" node="dot" type="integer" nodegroup="organization" defaultinput="in">
-    <input name="in" type="integer"/>
+    <input name="in" type="integer" value="0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_matrix33" node="dot" type="matrix33" nodegroup="organization" defaultinput="in">
-    <input name="in" type="matrix33"/>
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_matrix44" node="dot" type="matrix44" nodegroup="organization" defaultinput="in">
-    <input name="in" type="matrix44"/>
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_string" node="dot" type="string" nodegroup="organization" defaultinput="in">
-    <input name="in" type="string"/>
+    <input name="in" type="string" value=""/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_filename" node="dot" type="filename" nodegroup="organization" defaultinput="in">
-    <input name="in" type="filename"/>
+    <input name="in" type="filename" value=""/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_surfaceshader" node="dot" type="surfaceshader" nodegroup="organization" defaultinput="in">
-    <input name="in" type="surfaceshader"/>
+    <input name="in" type="surfaceshader" value=""/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_displacementshader" node="dot" type="displacementshader" nodegroup="organization" defaultinput="in">
-    <input name="in" type="displacementshader"/>
+    <input name="in" type="displacementshader" value=""/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_volumeshader" node="dot" type="volumeshader" nodegroup="organization" defaultinput="in">
-    <input name="in" type="volumeshader"/>
+    <input name="in" type="volumeshader" value=""/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
   <nodedef name="ND_dot_lightshader" node="dot" type="lightshader" nodegroup="organization" defaultinput="in">
-    <input name="in" type="lightshader"/>
+    <input name="in" type="lightshader" value=""/>
     <parameter name="note" type="string" value=""/>
   </nodedef>
 
@@ -3722,7 +3794,7 @@
     Node: <backdrop>
     A layout element used to contain, group and document other nodes
   -->
-  <nodedef name="ND_backdrop_float" node="backdrop" type="none" nodegroup="organization">
+  <nodedef name="ND_backdrop" node="backdrop" type="none" nodegroup="organization">
     <parameter name="note" type="string" value=""/>
     <parameter name="contains" type="stringarray" value=""/>
     <parameter name="width" type="float" value="1.0"/>

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1181,6 +1181,93 @@
   <!-- ======================================================================== -->
 
   <!--
+    Node: <transformpoint>  (2M3 and 3M4 variants)
+    Transform a vector coordinate by a specified matrix.
+  -->
+  <nodegraph name="NG_transformpoint_vector2M3" nodedef="ND_transformpoint_vector2M3">
+    <convert name="N_convtov3" type="vector3">
+      <input name="in" type="vector2" interfacename="in"/>
+    </convert>
+    <transformpoint name="N_transformpt" type="vector3">
+      <input name="in" type="vector3" nodename="N_convtov3"/>
+      <input name="mat" type="matrix33" interfacename="mat"/>
+    </transformpoint>
+    <convert name="N_convtov2" type="vector2">
+      <input name="in" type="vector3" nodename="N_transformpt"/>
+    </convert>
+    <output name="N_out_vec2" type="vector2" nodename="N_convtov2"/>
+  </nodegraph>
+  <nodegraph name="NG_transformpoint_vector3M4" nodedef="ND_transformpoint_vector3M4">
+    <convert name="N_convtov4" type="vector4">
+      <input name="in" type="vector3" interfacename="in"/>
+    </convert>
+    <transformpoint name="N_transformpt" type="vector4">
+      <input name="in" type="vector4" nodename="N_convtov4"/>
+      <input name="mat" type="matrix44" interfacename="mat"/>
+    </transformpoint>
+    <divide name="N_convtov3" type="vector3">
+      <input name="in1" type="vector3" nodename="N_transformpt" channels="xyz"/>
+      <input name="in2" type="float" nodename="N_transformpt" channels="w"/>
+    </divide>
+    <output name="N_out_vec3" type="vector3" nodename="N_convtov3"/>
+  </nodegraph>
+
+  <!--
+    Node: <transformvector>  (2M3 and 3M4 variants)
+    Transform a vector coordinate by a specified matrix.
+  -->
+  <nodegraph name="NG_transformvector_vector2M3" nodedef="ND_transformvector_vector2M3">
+    <convert name="N_convtov3" type="vector3">
+      <input name="in" type="vector2" interfacename="in"/>
+    </convert>
+    <transformvector name="N_transformvec" type="vector3">
+      <input name="in" type="vector3" nodename="N_convtov3"/>
+      <input name="mat" type="matrix33" interfacename="mat"/>
+    </transformvector>
+    <convert name="N_convtov2" type="vector2">
+      <input name="in" type="vector3" nodename="N_transformvec"/>
+    </convert>
+    <output name="N_out_vec2" type="vector2" nodename="N_convtov2"/>
+  </nodegraph>
+  <nodegraph name="NG_transformvector_vector3M4" nodedef="ND_transformvector_vector3M4">
+    <convert name="N_convtov4" type="vector4">
+      <input name="in" type="vector3" interfacename="in"/>
+    </convert>
+    <transformvector name="N_transformvec" type="vector4">
+      <input name="in" type="vector4" nodename="N_convtov4"/>
+      <input name="mat" type="matrix44" interfacename="mat"/>
+    </transformvector>
+    <convert name="N_convtov3" type="vector3">
+      <input name="in" type="vector4" nodename="N_transformvec"/>
+    </convert>
+    <output name="N_out_vec3" type="vector3" nodename="N_convtov3"/>
+  </nodegraph>
+
+  <!--
+    Node: <transformnormal>  (3M4 variant)
+    Transform a vector coordinate by a specified matrix.
+    Fourth channel of converted vector3 set to zero since normals typically can only
+    be scaled or rotated, not translated.
+  -->
+  <nodegraph name="NG_transformnormal_vector3M4" nodedef="ND_transformnormal_vector3M4">
+    <convert name="N_convtov4" type="vector4">
+      <input name="in" type="vector3" interfacename="in"/>
+    </convert>
+    <multiply name="N_zerow" type="vector4">
+      <input name="in1" type="vector4" nodename="N_convtov4"/>
+      <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 0.0"/>
+    </multiply>
+    <transformnormal name="N_transformnorm" type="vector4">
+      <input name="in" type="vector4" nodename="N_zerow"/>
+      <input name="mat" type="matrix44" interfacename="mat"/>
+    </transformnormal>
+    <convert name="N_convtov3" type="vector3">
+      <input name="in" type="vector4" nodename="N_transformnorm"/>
+    </convert>
+    <output name="N_out_vec3" type="vector3" nodename="N_convtov3"/>
+  </nodegraph>
+
+  <!--
     Node: <place2d>
     Transform incoming UV texture coordinates for 2D texture placement.
   -->
@@ -2149,17 +2236,17 @@
   </nodegraph>
 
   <nodegraph name="NG_extract_vector2" nodedef="ND_extract_vector2">
-    <swizzle name="N_r_vector2" type="float">
+    <swizzle name="N_x_vector2" type="float">
       <input name="in" type="vector2" interfacename="in"/>
       <parameter name="channels" type="string" value="x"/>
     </swizzle>
-    <swizzle name="N_g_vector2" type="float">
+    <swizzle name="N_y_vector2" type="float">
       <input name="in" type="vector2" interfacename="in"/>
       <parameter name="channels" type="string" value="y"/>
     </swizzle>
     <switch name="N_sw_vector2" type="float">
-      <input name="in1" type="float" nodename="N_r_vector2"/>
-      <input name="in2" type="float" nodename="N_g_vector2"/>
+      <input name="in1" type="float" nodename="N_x_vector2"/>
+      <input name="in2" type="float" nodename="N_y_vector2"/>
       <parameter name="which" type="integer" interfacename="index"/>
     </switch>
     <output name="N_out_vector2" type="float" nodename="N_sw_vector2"/>
@@ -2188,22 +2275,22 @@
   </nodegraph>
 
   <nodegraph name="NG_extract_vector3" nodedef="ND_extract_vector3">
-    <swizzle name="N_r_vector3" type="float">
+    <swizzle name="N_x_vector3" type="float">
       <input name="in" type="vector3" interfacename="in"/>
       <parameter name="channels" type="string" value="x"/>
     </swizzle>
-    <swizzle name="N_g_vector3" type="float">
+    <swizzle name="N_y_vector3" type="float">
       <input name="in" type="vector3" interfacename="in"/>
       <parameter name="channels" type="string" value="y"/>
     </swizzle>
-    <swizzle name="N_b_vector3" type="float">
+    <swizzle name="N_z_vector3" type="float">
       <input name="in" type="vector3" interfacename="in"/>
       <parameter name="channels" type="string" value="z"/>
     </swizzle>
     <switch name="N_sw_vector3" type="float">
-      <input name="in1" type="float" nodename="N_r_vector3"/>
-      <input name="in2" type="float" nodename="N_g_vector3"/>
-      <input name="in3" type="float" nodename="N_b_vector3"/>
+      <input name="in1" type="float" nodename="N_x_vector3"/>
+      <input name="in2" type="float" nodename="N_y_vector3"/>
+      <input name="in3" type="float" nodename="N_z_vector3"/>
       <parameter name="which" type="integer" interfacename="index"/>
     </switch>
     <output name="N_out_vector3" type="float" nodename="N_sw_vector3"/>
@@ -2237,27 +2324,27 @@
   </nodegraph>
 
   <nodegraph name="NG_extract_vector4" nodedef="ND_extract_vector4">
-    <swizzle name="N_r_vector4" type="float">
+    <swizzle name="N_x_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="x"/>
     </swizzle>
-    <swizzle name="N_g_vector4" type="float">
+    <swizzle name="N_y_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="y"/>
     </swizzle>
-    <swizzle name="N_b_vector4" type="float">
+    <swizzle name="N_z_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="z"/>
     </swizzle>
-    <swizzle name="N_a_vector4" type="float">
+    <swizzle name="N_w_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="w"/>
     </swizzle>
     <switch name="N_sw_vector4" type="float">
-      <input name="in1" type="float" nodename="N_r_vector4"/>
-      <input name="in2" type="float" nodename="N_g_vector4"/>
-      <input name="in3" type="float" nodename="N_b_vector4"/>
-      <input name="in4" type="float" nodename="N_a_vector4"/>
+      <input name="in1" type="float" nodename="N_x_vector4"/>
+      <input name="in2" type="float" nodename="N_y_vector4"/>
+      <input name="in3" type="float" nodename="N_z_vector4"/>
+      <input name="in4" type="float" nodename="N_w_vector4"/>
       <parameter name="which" type="integer" interfacename="index"/>
     </switch>
     <output name="N_out_vector4" type="float" nodename="N_sw_vector4"/>
@@ -2282,16 +2369,16 @@
   </nodegraph>
 
   <nodegraph name="NG_separate_vector2" nodedef="ND_separate_vector2">
-    <swizzle name="N_r_vector2" type="float">
+    <swizzle name="N_x_vector2" type="float">
       <input name="in" type="vector2" interfacename="in"/>
       <parameter name="channels" type="string" value="x"/>
     </swizzle>
-    <swizzle name="N_g_vector2" type="float">
+    <swizzle name="N_y_vector2" type="float">
       <input name="in" type="vector2" interfacename="in"/>
       <parameter name="channels" type="string" value="y"/>
     </swizzle>
-    <output name="outx" type="float" nodename="N_r_vector2"/>
-    <output name="outy" type="float" nodename="N_g_vector2"/>
+    <output name="outx" type="float" nodename="N_x_vector2"/>
+    <output name="outy" type="float" nodename="N_y_vector2"/>
   </nodegraph>
 
   <nodegraph name="NG_separate_color3" nodedef="ND_separate_color3">
@@ -2313,21 +2400,21 @@
   </nodegraph>
 
   <nodegraph name="NG_separate_vector3" nodedef="ND_separate_vector3">
-    <swizzle name="N_r_vector3" type="float">
+    <swizzle name="N_x_vector3" type="float">
       <input name="in" type="vector3" interfacename="in"/>
       <parameter name="channels" type="string" value="x"/>
     </swizzle>
-    <swizzle name="N_g_vector3" type="float">
+    <swizzle name="N_y_vector3" type="float">
       <input name="in" type="vector3" interfacename="in"/>
       <parameter name="channels" type="string" value="y"/>
     </swizzle>
-    <swizzle name="N_b_vector3" type="float">
+    <swizzle name="N_z_vector3" type="float">
       <input name="in" type="vector3" interfacename="in"/>
       <parameter name="channels" type="string" value="z"/>
     </swizzle>
-    <output name="outx" type="float" nodename="N_r_vector3"/>
-    <output name="outy" type="float" nodename="N_g_vector3"/>
-    <output name="outz" type="float" nodename="N_b_vector3"/>
+    <output name="outx" type="float" nodename="N_x_vector3"/>
+    <output name="outy" type="float" nodename="N_y_vector3"/>
+    <output name="outz" type="float" nodename="N_z_vector3"/>
   </nodegraph>
 
   <nodegraph name="NG_separate_color4" nodedef="ND_separate_color4">
@@ -2354,26 +2441,26 @@
   </nodegraph>
 
   <nodegraph name="NG_separate_vector4" nodedef="ND_separate_vector4">
-    <swizzle name="N_r_vector4" type="float">
+    <swizzle name="N_x_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="x"/>
     </swizzle>
-    <swizzle name="N_g_vector4" type="float">
+    <swizzle name="N_y_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="y"/>
     </swizzle>
-    <swizzle name="N_b_vector4" type="float">
+    <swizzle name="N_z_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="z"/>
     </swizzle>
-    <swizzle name="N_a_vector4" type="float">
+    <swizzle name="N_w_vector4" type="float">
       <input name="in" type="vector4" interfacename="in"/>
       <parameter name="channels" type="string" value="w"/>
     </swizzle>
-    <output name="outx" type="float" nodename="N_r_vector4"/>
-    <output name="outy" type="float" nodename="N_g_vector4"/>
-    <output name="outz" type="float" nodename="N_b_vector4"/>
-    <output name="outw" type="float" nodename="N_a_vector4"/>
+    <output name="outx" type="float" nodename="N_x_vector4"/>
+    <output name="outy" type="float" nodename="N_y_vector4"/>
+    <output name="outz" type="float" nodename="N_z_vector4"/>
+    <output name="outw" type="float" nodename="N_w_vector4"/>
   </nodegraph>
 
 

--- a/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
@@ -508,7 +508,7 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="saturate_color3" type="" xpos="6.02899" ypos="45.8736">
     <saturate name="saturate1" type="color3" xpos="5.74483" ypos="4.74">
       <input name="in" type="color3" value="1.0000, 0.5000, 0.2500" />
-      <parameter name="amount" type="float" value="0.5000" />
+      <input name="amount" type="float" value="0.5000" />
       <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895" />
     </saturate>
     <output name="out" type="color3" nodename="saturate1" />
@@ -516,7 +516,7 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="saturate_color4" type="" xpos="7.05529" ypos="45.8386">
     <saturate name="saturate1" type="color4" xpos="5.74483" ypos="4.74">
       <input name="in" type="color4" value="1.0000, 0.5000, 0.2500, 1.0" />
-      <parameter name="amount" type="float" value="0.5000" />
+      <input name="amount" type="float" value="0.5000" />
       <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895" />
     </saturate>
     <output name="out" type="color4" nodename="saturate1" />

--- a/resources/Materials/TestSuite/stdlib/compositing/compositing.mtlx
+++ b/resources/Materials/TestSuite/stdlib/compositing/compositing.mtlx
@@ -434,13 +434,6 @@ Basic compositing function tests each test is in a separate graph for each varia
     </premult>
     <output name="out" type="color2" nodename="premult1" />
   </nodegraph>
-  <nodegraph name="premult_color3" type="" xpos="7.20799" ypos="41.4614">
-    <premult name="premult1" type="color3" xpos="5.74483" ypos="4.58">
-      <input name="in" type="color3" value="1.0000, 0.0, 0.5000" />
-      <input name="alpha" type="float" value="0.5000" />
-    </premult>
-    <output name="out" type="color3" nodename="premult1" />
-  </nodegraph>
   <nodegraph name="premult_color4" type="" xpos="8.25474" ypos="41.4442">
     <premult name="premult1" type="color4" xpos="5.74483" ypos="4.74">
       <input name="in" type="color4" value="1.0000, 0.0, 0.5000, 0.5000" />
@@ -452,13 +445,6 @@ Basic compositing function tests each test is in a separate graph for each varia
       <input name="in" type="color2" value="1.0000, 0.5000" />
     </unpremult>
     <output name="out" type="color2" nodename="unpremult1" />
-  </nodegraph>
-  <nodegraph name="unpremult_color3" type="" xpos="7.23191" ypos="43.0052">
-    <unpremult name="unpremult1" type="color3" xpos="5.74483" ypos="4.58">
-      <input name="in" type="color3" value="1.0000, 0.0, 0.5000" />
-      <input name="alpha" type="float" value="0.5000" />
-    </unpremult>
-    <output name="out" type="color3" nodename="unpremult1" />
   </nodegraph>
   <nodegraph name="unpremult_color4" type="" xpos="8.27269" ypos="42.9706">
     <unpremult name="unpremult1" type="color4" xpos="5.74483" ypos="4.58">

--- a/resources/Materials/TestSuite/stdlib/texture/image_addressing.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image_addressing.mtlx
@@ -11,7 +11,7 @@
       <parameter name="filtertype" type="string" value="linear" />
       <parameter name="framerange" type="string" value="" />
       <parameter name="frameoffset" type="integer" value="0" />
-      <parameter name="frameendaction" type="string" value="black" />
+      <parameter name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
@@ -33,7 +33,7 @@
       <parameter name="filtertype" type="string" value="linear" />
       <parameter name="framerange" type="string" value="" />
       <parameter name="frameoffset" type="integer" value="0" />
-      <parameter name="frameendaction" type="string" value="black" />
+      <parameter name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
@@ -55,7 +55,7 @@
       <parameter name="filtertype" type="string" value="linear" />
       <parameter name="framerange" type="string" value="" />
       <parameter name="frameoffset" type="integer" value="0" />
-      <parameter name="frameendaction" type="string" value="black" />
+      <parameter name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
@@ -77,7 +77,7 @@
       <parameter name="filtertype" type="string" value="linear" />
       <parameter name="framerange" type="string" value="" />
       <parameter name="frameoffset" type="integer" value="0" />
-      <parameter name="frameendaction" type="string" value="black" />
+      <parameter name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
@@ -99,7 +99,7 @@
       <parameter name="filtertype" type="string" value="linear" />
       <parameter name="framerange" type="string" value="" />
       <parameter name="frameoffset" type="integer" value="0" />
-      <parameter name="frameendaction" type="string" value="black" />
+      <parameter name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
@@ -125,7 +125,7 @@
       <parameter name="filtertype" type="string" value="linear" />
       <parameter name="framerange" type="string" value="" />
       <parameter name="frameoffset" type="integer" value="0" />
-      <parameter name="frameendaction" type="string" value="black" />
+      <parameter name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
@@ -147,7 +147,7 @@
       <parameter name="filtertype" type="string" value="linear" />
       <parameter name="framerange" type="string" value="" />
       <parameter name="frameoffset" type="integer" value="0" />
-      <parameter name="frameendaction" type="string" value="black" />
+      <parameter name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">

--- a/resources/Materials/TestSuite/stdlib/texture/tiledimage.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/tiledimage.mtlx
@@ -10,17 +10,17 @@ used to lookup each image
    <output name="tiled_image4_output" type="color4" nodename="tiled_image4" />
    <tiledimage name="tiled_image4" type="color4">
       <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
-      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+      <input name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <input name="uvoffset" type="vector2" value="0.5, 0.5"/>
       <parameter name="filtertype" type="string" value="cubic"/>
-      <parameter name="frameendaction" type="string" value="black"/>
+      <parameter name="frameendaction" type="string" value="constant"/>
 </tiledimage>
 
    <output name="tiled_image3_output" type="color3" nodename="tiled_image3" />
    <tiledimage name="tiled_image3" type="color3">
       <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
-      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+      <input name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <input name="uvoffset" type="vector2" value="0.5, 0.5"/>
       <parameter name="filtertype" type="string" value="closest"/>
       <parameter name="frameendaction" type="string" value="clamp"/>
    </tiledimage>
@@ -28,8 +28,8 @@ used to lookup each image
    <output name="tiled_image2_output" type="color2" nodename="tiled_image2" />
    <tiledimage name="tiled_image2" type="color2">
       <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
-      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+      <input name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <input name="uvoffset" type="vector2" value="0.5, 0.5"/>
       <parameter name="filtertype" type="string" value="linear"/>
       <parameter name="frameendaction" type="string" value="periodic"/>
    </tiledimage>
@@ -37,17 +37,17 @@ used to lookup each image
    <output name="tiled_image1_output" type="float" nodename="tiled_image1" />
    <tiledimage name="tiled_image1" type="float">
       <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
-      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+      <input name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <input name="uvoffset" type="vector2" value="0.5, 0.5"/>
       <parameter name="filtertype" type="string" value="cubic"/>
-      <parameter name="frameendaction" type="string" value="black"/>
+      <parameter name="frameendaction" type="string" value="constant"/>
    </tiledimage>
 
    <output name="tiled_image4v_output" type="vector4" nodename="tiled_image4v" />
    <tiledimage name="tiled_image4v" type="vector4">
       <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
-      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+      <input name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <input name="uvoffset" type="vector2" value="0.5, 0.5"/>
       <parameter name="filtertype" type="string" value="closest"/>
       <parameter name="frameendaction" type="string" value="clamp"/>
    </tiledimage>
@@ -55,8 +55,8 @@ used to lookup each image
    <output name="tiled_image3v_output" type="vector3" nodename="tiled_image3v" />
    <tiledimage name="tiled_image3v" type="vector3">
       <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
-      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+      <input name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <input name="uvoffset" type="vector2" value="0.5, 0.5"/>
       <parameter name="filtertype" type="string" value="linear"/>
       <parameter name="frameendaction" type="string" value="periodic"/>
    </tiledimage>
@@ -64,8 +64,8 @@ used to lookup each image
    <output name="tiled_image2v_output" type="vector2" nodename="tiled_image2v" />
    <tiledimage name="tiled_image2v" type="vector2">
       <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
-      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+      <input name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <input name="uvoffset" type="vector2" value="0.5, 0.5"/>
       <parameter name="filtertype" type="string" value="closest"/>
       <parameter name="frameendaction" type="string" value="periodic"/>
    </tiledimage>


### PR DESCRIPTION
Updated stdlib_defs: conforms to 1.37 spec other than having child output elems for nodedefs, and kept geomattrvalue as well as adding geompropvalue.
Updated stdlib_ng: new transform* nodegraph implementations, minor naming fixes.
Updated stdlib TestSuite files to conform to new stdlib_defs.