### PR TITLE
Add handling for duplicate library imports

### DIFF
--- a/python/MaterialXTest/genshader.py
+++ b/python/MaterialXTest/genshader.py
@@ -22,9 +22,7 @@ def _loadLibrary(file, doc):
     libDoc = mx.createDocument()
     _readFromXmlFile(libDoc, file)
     libDoc.setSourceUri(file)
-    copyOptions = mx.CopyOptions()
-    copyOptions.skipDuplicateElements = True;
-    doc.importLibrary(libDoc, copyOptions)
+    doc.importLibrary(libDoc)
 
 def _loadLibraries(doc, searchPath, libraryPath):
     librarySubPaths = _getSubDirectories(libraryPath)

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -445,6 +445,7 @@ class TestMaterialX(unittest.TestCase):
             lib = mx.createDocument()
             mx.readFromXmlFile(lib, filename, _searchPath)
             libs.append(lib)
+
         # Read and validate each example document.
         for filename in _exampleFilenames:
             doc = mx.createDocument()
@@ -497,14 +498,11 @@ class TestMaterialX(unittest.TestCase):
                 doc2.importLibrary(lib)
             self.assertTrue(doc2.validate()[0])
 
-        # Read the same document twice with duplicate elements skipped.
-        doc = mx.createDocument()
-        readOptions = mx.XmlReadOptions()
-        readOptions.skipDuplicateElements = True
-        filename = 'PostShaderComposite.mtlx'
-        mx.readFromXmlFile(doc, filename, _searchPath, readOptions)
-        mx.readFromXmlFile(doc, filename, _searchPath, readOptions)
-        self.assertTrue(doc.validate()[0])
+        # Import duplicate libraries into document.
+        dupDoc = mx.createDocument()
+        for lib in libs:
+            dupDoc.importLibrary(lib)
+        self.assertTrue(dupDoc.validate()[0])
 
 #--------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -144,19 +144,21 @@ void Document::initialize()
     setVersionString(DOCUMENT_VERSION_STRING);
 }
 
-void Document::importLibrary(const ConstDocumentPtr& library, const CopyOptions* copyOptions)
+void Document::importLibrary(const ConstDocumentPtr& library)
 {
-    bool skipDuplicateElements = copyOptions && copyOptions->skipDuplicateElements;
     for (const ConstElementPtr& child : library->getChildren())
     {
         string childName = child->getQualifiedName(child->getName());
-        if (skipDuplicateElements && getChild(childName))
+
+        // Skip elements from a previous import of the same library.
+        ConstElementPtr previous = getChild(childName);
+        if (previous && previous->getActiveSourceUri() == library->getSourceUri())
         {
             continue;
         }
 
         ElementPtr childCopy = addChildOfCategory(child->getCategory(), childName);
-        childCopy->copyContentFrom(child, copyOptions);
+        childCopy->copyContentFrom(child);
         if (!childCopy->hasFilePrefix() && library->hasFilePrefix())
         {
             childCopy->setFilePrefix(library->getFilePrefix());

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -60,10 +60,7 @@ class Document : public GraphElement
     /// The contents of the library document are copied into this one, and
     /// are assigned the source URI of the library.
     /// @param library The library document to be imported.
-    /// @param copyOptions An optional pointer to a CopyOptions object.
-    ///    If provided, then the given options will affect the behavior of the
-    ///    import function.  Defaults to a null pointer.
-    void importLibrary(const ConstDocumentPtr& library, const CopyOptions* copyOptions = nullptr);
+    void importLibrary(const ConstDocumentPtr& library);
 
     /// @}
     /// @name NodeGraph Elements

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -373,10 +373,9 @@ InheritanceIterator Element::traverseInheritance() const
     return InheritanceIterator(getSelf());
 }
 
-void Element::copyContentFrom(const ConstElementPtr& source, const CopyOptions* copyOptions)
+void Element::copyContentFrom(const ConstElementPtr& source)
 {
     DocumentPtr doc = getDocument();
-    bool skipDuplicateElements = copyOptions && copyOptions->skipDuplicateElements;
 
     // Handle change notifications.
     ScopedUpdate update(doc);
@@ -388,12 +387,7 @@ void Element::copyContentFrom(const ConstElementPtr& source, const CopyOptions* 
 
     for (const ConstElementPtr& child : source->getChildren())
     {
-        const string& name = child->getName();
-        if (skipDuplicateElements && getChild(name))
-        {
-            continue;
-        }
-        ElementPtr childCopy = addChildOfCategory(child->getCategory(), name);
+        ElementPtr childCopy = addChildOfCategory(child->getCategory(), child->getName());
         childCopy->copyContentFrom(child);
     }
 }

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -25,7 +25,6 @@ class Token;
 class StringResolver;
 class Document;
 class Material;
-class CopyOptions;
 
 /// A shared pointer to an Element
 using ElementPtr = shared_ptr<Element>;
@@ -768,10 +767,7 @@ class Element : public std::enable_shared_from_this<Element>
 
     /// Copy all attributes and descendants from the given element to this one.
     /// @param source The element from which content is copied.
-    /// @param copyOptions An optional pointer to a CopyOptions object.
-    ///    If provided, then the given options will affect the behavior of the
-    ///    copy function.  Defaults to a null pointer.
-    void copyContentFrom(const ConstElementPtr& source, const CopyOptions* copyOptions = nullptr);
+    void copyContentFrom(const ConstElementPtr& source);
 
     /// Clear all attributes and descendants from this element.
     void clearContent();
@@ -1277,22 +1273,6 @@ class StringResolver
     string _geomPrefix;
     StringMap _filenameMap;
     StringMap _geomNameMap;
-};
-
-/// @class CopyOptions
-/// A set of options for controlling the behavior of element copy operations.
-class CopyOptions
-{
-  public:
-    CopyOptions() :
-        skipDuplicateElements(false)
-    {
-    }
-    ~CopyOptions() { }
-
-    /// If true, elements at the same scope with duplicate names will be skipped;
-    /// otherwise, they will trigger an exception.  Defaults to false.
-    bool skipDuplicateElements;
 };
 
 /// @class ExceptionOrphanedElement

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -30,8 +30,6 @@ const string XINCLUDE_TAG = "xi:include";
 
 void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptions* readOptions)
 {
-    bool skipDuplicateElements = readOptions && readOptions->skipDuplicateElements;
-
     // Store attributes in element.
     for (const xml_attribute& xmlAttr : xmlNode.attributes())
     {
@@ -57,12 +55,6 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
                 name = xmlAttr.value();
                 break;
             }
-        }
-
-        // If requested, skip elements with duplicate names.
-        if (skipDuplicateElements && elem->getChild(name))
-        {
-            continue;
         }
 
         ElementPtr child = elem->addChildOfCategory(category, name);
@@ -199,7 +191,7 @@ void processXIncludes(DocumentPtr doc, xml_node& xmlNode, const string& searchPa
                 readXIncludeFunction(library, filename, includeSearchPath, &xiReadOptions);
 
                 // Import the library document.
-                doc->importLibrary(library, readOptions);
+                doc->importLibrary(library);
             }
 
             // Remove include directive.

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -26,7 +26,7 @@ using XmlReadFunction = std::function<void(DocumentPtr, string, string, const Xm
 
 /// @class XmlReadOptions
 /// A set of options for controlling the behavior of XML read functions.
-class XmlReadOptions : public CopyOptions
+class XmlReadOptions
 {
   public:
     XmlReadOptions();

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -21,9 +21,7 @@ void loadLibrary(const mx::FilePath& file, mx::DocumentPtr doc)
 {
     mx::DocumentPtr libDoc = mx::createDocument();
     mx::readFromXmlFile(libDoc, file);
-    mx::CopyOptions copyOptions;
-    copyOptions.skipDuplicateElements = true;
-    doc->importLibrary(libDoc, &copyOptions);
+    doc->importLibrary(libDoc);
 }
 
 void loadLibraries(const mx::StringVec& libraryNames,
@@ -595,13 +593,11 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
     context.getOptions() = generateOptions;
     context.registerSourceCodeSearchPath(_srcSearchPath);
 
-    mx::XmlReadOptions importOptions;
-    importOptions.skipDuplicateElements = true;
     size_t documentIndex = 0;
     for (auto doc : _documents)
     {
         // Add in dependent libraries
-        doc->importLibrary(_dependLib, &importOptions);
+        doc->importLibrary(_dependLib);
 
         // Find and register lights
         findLights(doc, _lights);

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -164,9 +164,6 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
     setupTime.endTimer();
 
-    mx::CopyOptions importOptions;
-    importOptions.skipDuplicateElements = true;
-
     registerLights(dependLib, options, context);
 
     // Map to replace "/" in Element path names with "_".
@@ -206,12 +203,10 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
             const mx::FilePath filePath = mx::FilePath(dir) / mx::FilePath(file);
             const std::string filename = filePath;
 
-            mx::XmlReadOptions readOptions;
-            readOptions.skipDuplicateElements = true;
             mx::DocumentPtr doc = mx::createDocument();
             try
             {
-                mx::readFromXmlFile(doc, filename, dir, &readOptions);
+                mx::readFromXmlFile(doc, filename, dir);
             }
             catch (mx::Exception& e)
             {
@@ -219,7 +214,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                 WARN("Failed to load in file: " + filename + "See: " + docValidLogFilename + " for details.");                    
             }
 
-            doc->importLibrary(dependLib, &importOptions);
+            doc->importLibrary(dependLib);
             ioTimer.endTimer();
 
             validateTimer.startTimer();

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -133,18 +133,14 @@ TEST_CASE("Load content", "[xmlio]")
         REQUIRE(referencesValid);
     }
 
-    // Read the same document twice with duplicate elements skipped.
+    // Read reference document.
     mx::DocumentPtr doc = mx::createDocument();
-    mx::XmlReadOptions readOptions;
-    readOptions.skipDuplicateElements = true;
     std::string filename = "PostShaderComposite.mtlx";
-    mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
-    mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
-    REQUIRE(doc->validate());
+    mx::readFromXmlFile(doc, filename, searchPath);
 
     // Read document without XIncludes.
     mx::DocumentPtr flatDoc = mx::createDocument();
-    readOptions = mx::XmlReadOptions();
+    mx::XmlReadOptions readOptions;
     readOptions.readXIncludeFunction = nullptr;
     mx::readFromXmlFile(flatDoc, filename, searchPath, &readOptions);
     REQUIRE(*flatDoc != *doc);
@@ -180,6 +176,15 @@ TEST_CASE("Load content", "[xmlio]")
         }
     }
     REQUIRE(imageElementCount == 0);
+
+    // Import duplicate libraries into document.
+    mx::DocumentPtr dupDoc = mx::createDocument();
+    for (mx::DocumentPtr lib : libs)
+    {
+        dupDoc->importLibrary(lib);
+        dupDoc->importLibrary(lib);
+    }
+    REQUIRE(dupDoc->validate());
 
     // Read a non-existent document.
     mx::DocumentPtr nonExistentDoc = mx::createDocument();

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -84,9 +84,7 @@ mx::DocumentPtr loadLibraries(const mx::StringVec& libraryFolders, const mx::Fil
             mx::DocumentPtr libDoc = mx::createDocument();
             mx::readFromXmlFile(libDoc, file);
             libDoc->setSourceUri(file);
-            mx::CopyOptions copyOptions;
-            copyOptions.skipDuplicateElements = true;
-            doc->importLibrary(libDoc, &copyOptions);
+            doc->importLibrary(libDoc);
         }
     }
     return doc;
@@ -348,9 +346,6 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
 
 void Viewer::setupLights(mx::DocumentPtr doc)
 {
-    mx::CopyOptions copyOptions;
-    copyOptions.skipDuplicateElements = true;
-
     // Import lights
     mx::DocumentPtr lightDoc = mx::createDocument();
     mx::FilePath path = _searchPath.find(_lightFileName);
@@ -360,7 +355,7 @@ void Viewer::setupLights(mx::DocumentPtr doc)
         {
             mx::readFromXmlFile(lightDoc, path.asString());
             lightDoc->setSourceUri(path);
-            doc->importLibrary(lightDoc, &copyOptions);
+            doc->importLibrary(lightDoc);
         }
         catch (std::exception& e)
         {
@@ -755,9 +750,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         mx::readFromXmlFile(doc, filename, _searchPath.asString(), &readOptions);
 
         // Import libraries.
-        mx::CopyOptions copyOptions;
-        copyOptions.skipDuplicateElements = true;
-        doc->importLibrary(libraries, &copyOptions);
+        doc->importLibrary(libraries);
 
         // Add lighting 
         setupLights(doc);

--- a/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
@@ -17,8 +17,7 @@ void bindPyDocument(py::module& mod)
     py::class_<mx::Document, mx::DocumentPtr, mx::GraphElement>(mod, "Document")
         .def("initialize", &mx::Document::initialize)
         .def("copy", &mx::Document::copy)
-        .def("importLibrary", &mx::Document::importLibrary, 
-            py::arg("library"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
+        .def("importLibrary", &mx::Document::importLibrary)
         .def("addNodeGraph", &mx::Document::addNodeGraph,
             py::arg("name") = mx::EMPTY_STRING)
         .def("getNodeGraph", &mx::Document::getNodeGraph)

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -26,10 +26,6 @@ namespace mx = MaterialX;
 
 void bindPyElement(py::module& mod)
 {
-    py::class_<mx::CopyOptions>(mod, "CopyOptions")
-        .def(py::init())
-        .def_readwrite("skipDuplicateElements", &mx::CopyOptions::skipDuplicateElements);
-
     py::class_<mx::Element, mx::ElementPtr>(mod, "Element")
         .def(py::self == py::self)
         .def(py::self != py::self)
@@ -105,8 +101,7 @@ void bindPyElement(py::module& mod)
                 bool res = elem.validate(&message);
                 return std::pair<bool, std::string>(res, message);
             })
-        .def("copyContentFrom", &mx::Element::copyContentFrom,
-            py::arg("source"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
+        .def("copyContentFrom", &mx::Element::copyContentFrom)
         .def("clearContent", &mx::Element::clearContent)
         .def("createValidChildName", &mx::Element::createValidChildName)
         .def("createStringResolver", &mx::Element::createStringResolver,

--- a/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
@@ -13,7 +13,7 @@ namespace mx = MaterialX;
 
 void bindPyXmlIo(py::module& mod)
 {
-    py::class_<mx::XmlReadOptions, mx::CopyOptions>(mod, "XmlReadOptions")
+    py::class_<mx::XmlReadOptions>(mod, "XmlReadOptions")
         .def(py::init())
         .def_readwrite("readXIncludeFunction", &mx::XmlReadOptions::readXIncludeFunction)
         .def_readwrite("parentXIncludes", &mx::XmlReadOptions::parentXIncludes);


### PR DESCRIPTION
- At import time, automatically skip elements with the same name and source URI as an existing element.
- Remove the CopyOptions class, as manual selection of duplicate element behavior should no longer be needed.