### PR TITLE
Enable trilinear texture filtering in the viewer

### DIFF
--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -239,11 +239,7 @@ int GLTextureHandler::mapFilterTypeToGL(ImageSamplingProperties::FilterType filt
     int filterType = GL_LINEAR_MIPMAP_LINEAR;
     if (filterTypeEnum == ImageSamplingProperties::FilterType::CLOSEST)
     {
-        filterType = GL_NEAREST;
-    }
-    else if (filterTypeEnum == ImageSamplingProperties::FilterType::LINEAR)
-    {
-        filterType = GL_LINEAR;
+        filterType = GL_NEAREST_MIPMAP_NEAREST;
     }
     return filterType;
 }


### PR DESCRIPTION
This changelist enables trilinear texture filtering for the linear filter type, which is the default for image nodes in the viewer.