### PR TITLE
Improvements to duplicate element handling

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -498,11 +498,13 @@ class TestMaterialX(unittest.TestCase):
                 doc2.importLibrary(lib)
             self.assertTrue(doc2.validate()[0])
 
-        # Import duplicate libraries into document.
-        dupDoc = mx.createDocument()
-        for lib in libs:
-            dupDoc.importLibrary(lib)
-        self.assertTrue(dupDoc.validate()[0])
+        # Read the same document twice, and verify that duplicate elements
+        # are skipped.
+        doc = mx.createDocument()
+        filename = 'PostShaderComposite.mtlx'
+        mx.readFromXmlFile(doc, filename, _searchPath)
+        mx.readFromXmlFile(doc, filename, _searchPath)
+        self.assertTrue(doc.validate()[0])
 
 #--------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -60,7 +60,10 @@ class Document : public GraphElement
     /// The contents of the library document are copied into this one, and
     /// are assigned the source URI of the library.
     /// @param library The library document to be imported.
-    void importLibrary(const ConstDocumentPtr& library);
+    /// @param copyOptions An optional pointer to a CopyOptions object.
+    ///    If provided, then the given options will affect the behavior of the
+    ///    import function.  Defaults to a null pointer.
+    void importLibrary(const ConstDocumentPtr& library, const CopyOptions* copyOptions = nullptr);
 
     /// @}
     /// @name NodeGraph Elements

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -25,6 +25,7 @@ class Token;
 class StringResolver;
 class Document;
 class Material;
+class CopyOptions;
 
 /// A shared pointer to an Element
 using ElementPtr = shared_ptr<Element>;
@@ -53,7 +54,7 @@ using StringResolverPtr = shared_ptr<StringResolver>;
 using ElementMap = std::unordered_map<string, ElementPtr>;
 
 /// A standard function taking an ElementPtr and returning a boolean.
-using ElementPredicate = std::function<bool(ElementPtr)>;
+using ElementPredicate = std::function<bool(ConstElementPtr)>;
 
 /// @class Element
 /// The base class for MaterialX elements.
@@ -422,7 +423,7 @@ class Element : public std::enable_shared_from_this<Element>
     ///     If no name is specified, then a unique name will automatically be
     ///     generated.
     /// @throws Exception if a child of this element already possesses the
-    ///    given name.
+    ///     given name.
     /// @return A shared pointer to the new child element.
     template<class T> shared_ptr<T> addChild(const string& name = EMPTY_STRING);
 
@@ -433,11 +434,14 @@ class Element : public std::enable_shared_from_this<Element>
     /// @param name The name of the new child element.
     ///     If no name is specified, then a unique name will automatically be
     ///     generated.
+    /// @param registerChild If true, then the child will be registered as
+    ///     belonging to this element tree.  Defaults to true.
     /// @throws Exception if a child of this element already possesses the
-    ///    given name.
+    ///     given name.
     /// @return A shared pointer to the new child element.
     ElementPtr addChildOfCategory(const string& category,
-                                  const string& name = EMPTY_STRING);
+                                  string name = EMPTY_STRING,
+                                  bool registerChild = true);
 
     /// Return the child element, if any, with the given name.
     ElementPtr getChild(const string& name) const
@@ -767,7 +771,10 @@ class Element : public std::enable_shared_from_this<Element>
 
     /// Copy all attributes and descendants from the given element to this one.
     /// @param source The element from which content is copied.
-    void copyContentFrom(const ConstElementPtr& source);
+    /// @param copyOptions An optional pointer to a CopyOptions object.
+    ///    If provided, then the given options will affect the behavior of the
+    ///    copy function.  Defaults to a null pointer.
+    void copyContentFrom(const ConstElementPtr& source, const CopyOptions* copyOptions = nullptr);
 
     /// Clear all attributes and descendants from this element.
     void clearContent();
@@ -1273,6 +1280,22 @@ class StringResolver
     string _geomPrefix;
     StringMap _filenameMap;
     StringMap _geomNameMap;
+};
+
+/// @class CopyOptions
+/// A set of options for controlling the behavior of element copy operations.
+class CopyOptions
+{
+  public:
+    CopyOptions() :
+        skipConflictingElements(false)
+    {
+    }
+    ~CopyOptions() { }
+
+    /// If true, duplicate elements with non-identical content will be skipped;
+    /// otherwise they will trigger an exception.  Defaults to false.
+    bool skipConflictingElements;
 };
 
 /// @class ExceptionOrphanedElement

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -25,19 +25,16 @@ const string MTLX_EXTENSION = "mtlx";
 
 namespace {
 
-const string SOURCE_URI_ATTRIBUTE = "__sourceUri";
 const string XINCLUDE_TAG = "xi:include";
 
 void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptions* readOptions)
 {
+    bool skipConflictingElements = readOptions && readOptions->skipConflictingElements;
+
     // Store attributes in element.
     for (const xml_attribute& xmlAttr : xmlNode.attributes())
     {
-        if (xmlAttr.name() == SOURCE_URI_ATTRIBUTE)
-        {
-            elem->setSourceUri(xmlAttr.value());
-        }
-        else if (xmlAttr.name() != Element::NAME_ATTRIBUTE)
+        if (xmlAttr.name() != Element::NAME_ATTRIBUTE)
         {
             elem->setAttribute(xmlAttr.name(), xmlAttr.value());
         }
@@ -57,8 +54,22 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
             }
         }
 
-        ElementPtr child = elem->addChildOfCategory(category, name);
+        // Check for duplicate elements.
+        ConstElementPtr previous = elem->getChild(name);
+        if (previous && skipConflictingElements)
+        {
+            continue;
+        }
+
+        // Create the new element.
+        ElementPtr child = elem->addChildOfCategory(category, name, !previous);
         elementFromXml(xmlChild, child, readOptions);
+
+        // Check for conflicting elements.
+        if (previous && *previous != *child)
+        {
+            throw Exception("Duplicate element with conflicting content: " + name);
+        }
     }
 }
 
@@ -80,7 +91,7 @@ void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions
 
     // Create child nodes and recurse.
     StringSet writtenSourceFiles;
-    for (ElementPtr child : elem->getChildren())
+    for (const ConstElementPtr& child : elem->getChildren())
     {
         if (elementPredicate && !elementPredicate(child))
         {
@@ -191,7 +202,7 @@ void processXIncludes(DocumentPtr doc, xml_node& xmlNode, const string& searchPa
                 readXIncludeFunction(library, filename, includeSearchPath, &xiReadOptions);
 
                 // Import the library document.
-                doc->importLibrary(library);
+                doc->importLibrary(library, readOptions);
             }
 
             // Remove include directive.

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -26,7 +26,7 @@ using XmlReadFunction = std::function<void(DocumentPtr, string, string, const Xm
 
 /// @class XmlReadOptions
 /// A set of options for controlling the behavior of XML read functions.
-class XmlReadOptions
+class XmlReadOptions : public CopyOptions
 {
   public:
     XmlReadOptions();

--- a/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
@@ -17,7 +17,8 @@ void bindPyDocument(py::module& mod)
     py::class_<mx::Document, mx::DocumentPtr, mx::GraphElement>(mod, "Document")
         .def("initialize", &mx::Document::initialize)
         .def("copy", &mx::Document::copy)
-        .def("importLibrary", &mx::Document::importLibrary)
+        .def("importLibrary", &mx::Document::importLibrary, 
+            py::arg("library"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
         .def("addNodeGraph", &mx::Document::addNodeGraph,
             py::arg("name") = mx::EMPTY_STRING)
         .def("getNodeGraph", &mx::Document::getNodeGraph)

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -26,6 +26,10 @@ namespace mx = MaterialX;
 
 void bindPyElement(py::module& mod)
 {
+    py::class_<mx::CopyOptions>(mod, "CopyOptions")
+        .def(py::init())
+        .def_readwrite("skipConflictingElements", &mx::CopyOptions::skipConflictingElements);
+
     py::class_<mx::Element, mx::ElementPtr>(mod, "Element")
         .def(py::self == py::self)
         .def(py::self != py::self)
@@ -67,7 +71,8 @@ void bindPyElement(py::module& mod)
         .def("getVersionIntegers", &mx::Element::getVersionIntegers)
         .def("setDefaultVersion", &mx::Element::setDefaultVersion)
         .def("getDefaultVersion", &mx::Element::getDefaultVersion)
-        .def("addChildOfCategory", &mx::Element::addChildOfCategory)
+        .def("addChildOfCategory", &mx::Element::addChildOfCategory,
+            py::arg("category"), py::arg("name") = mx::EMPTY_STRING, py::arg("registerChild") = true)
         .def("_getChild", &mx::Element::getChild)
         .def("getChildren", &mx::Element::getChildren)
         .def("setChildIndex", &mx::Element::setChildIndex)
@@ -101,7 +106,8 @@ void bindPyElement(py::module& mod)
                 bool res = elem.validate(&message);
                 return std::pair<bool, std::string>(res, message);
             })
-        .def("copyContentFrom", &mx::Element::copyContentFrom)
+        .def("copyContentFrom", &mx::Element::copyContentFrom,
+            py::arg("source"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
         .def("clearContent", &mx::Element::clearContent)
         .def("createValidChildName", &mx::Element::createValidChildName)
         .def("createStringResolver", &mx::Element::createStringResolver,

--- a/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
@@ -13,7 +13,7 @@ namespace mx = MaterialX;
 
 void bindPyXmlIo(py::module& mod)
 {
-    py::class_<mx::XmlReadOptions>(mod, "XmlReadOptions")
+    py::class_<mx::XmlReadOptions, mx::CopyOptions>(mod, "XmlReadOptions")
         .def(py::init())
         .def_readwrite("readXIncludeFunction", &mx::XmlReadOptions::readXIncludeFunction)
         .def_readwrite("parentXIncludes", &mx::XmlReadOptions::parentXIncludes);


### PR DESCRIPTION
-  By default, load and import operations now skip duplicate elements with identical content.  This handles the common case where the same library is imported multiple times into a document, without depending on the file paths from which the library is loaded.
- Restore the CopyOptions class with a new skipConflictingElements flag, which requests that duplicate elements with non-identical content also be skipped.
- Extend C++ unit tests to cover new functionality.