### PR TITLE
Merges from dev to ILM master

### DIFF
--- a/libraries/stdlib/genglsl/lib/mx_get_target_uv_noop.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_get_target_uv_noop.glsl
@@ -1,7 +1,0 @@
-//
-// Function to transform uv-coordinates before texture sampling
-//
-vec2 mx_get_target_uv(vec2 uv)
-{
-   return uv;
-}

--- a/libraries/stdlib/genglsl/lib/mx_get_target_uv_vflip.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_get_target_uv_vflip.glsl
@@ -1,7 +1,0 @@
-//
-// Function to transform uv-coordinates before texture sampling
-//
-vec2 mx_get_target_uv(vec2 uv)
-{
-   return vec2(uv.x, 1.0 - uv.y);
-}

--- a/libraries/stdlib/genglsl/lib/mx_transform_uv.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_transform_uv.glsl
@@ -1,0 +1,8 @@
+//
+// Function to transform uv-coordinates before texture sampling
+//
+vec2 mx_transform_uv(vec2 uv, vec2 uv_scale, vec2 uv_offset)
+{
+    uv = uv * uv_scale + uv_offset;
+    return uv;
+}

--- a/libraries/stdlib/genglsl/lib/mx_transform_uv_vflip.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_transform_uv_vflip.glsl
@@ -1,0 +1,8 @@
+//
+// Function to transform uv-coordinates before texture sampling
+//
+vec2 mx_transform_uv(vec2 uv, vec2 uv_scale, vec2 uv_offset)
+{
+    uv = uv * uv_scale + uv_offset;
+    return vec2(uv.x, 1.0 - uv.y);
+}

--- a/libraries/stdlib/genglsl/mx_image_color2.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color2.glsl
@@ -1,9 +1,9 @@
-void mx_image_color2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec2 result)
+void mx_image_color2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
 {
     // TODO: Fix handling of addressmode
     if(textureSize(tex_sampler, 0).x > 1)
     {
-        vec2 uv = mx_get_target_uv(texcoord);
+        vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rg;
     }
     else

--- a/libraries/stdlib/genglsl/mx_image_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color3.glsl
@@ -1,9 +1,9 @@
-void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec3 result)
+void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {
     // TODO: Fix handling of addressmode
     if(textureSize(tex_sampler, 0).x > 1)
     {
-        vec2 uv = mx_get_target_uv(texcoord);
+        vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rgb;
     }
     else

--- a/libraries/stdlib/genglsl/mx_image_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color4.glsl
@@ -1,9 +1,9 @@
-void mx_image_color4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec4 result)
+void mx_image_color4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {
     // TODO: Fix handling of addressmode
     if(textureSize(tex_sampler, 0).x > 1)
     {
-        vec2 uv = mx_get_target_uv(texcoord);
+        vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv);
     }
     else

--- a/libraries/stdlib/genglsl/mx_image_float.glsl
+++ b/libraries/stdlib/genglsl/mx_image_float.glsl
@@ -1,9 +1,9 @@
-void mx_image_float(sampler2D tex_sampler, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out float result)
+void mx_image_float(sampler2D tex_sampler, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out float result)
 {
     // TODO: Fix handling of addressmode
     if(textureSize(tex_sampler, 0).x > 1)
     {
-        vec2 uv = mx_get_target_uv(texcoord);
+        vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).r;
     }
     else

--- a/libraries/stdlib/genglsl/mx_image_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector2.glsl
@@ -1,9 +1,9 @@
-void mx_image_vector2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec2 result)
+void mx_image_vector2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
 {
     // TODO: Fix handling of addressmode
     if(textureSize(tex_sampler, 0).x > 1)
     {
-        vec2 uv = mx_get_target_uv(texcoord);
+        vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rg;
     }
     else

--- a/libraries/stdlib/genglsl/mx_image_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector3.glsl
@@ -1,9 +1,9 @@
-void mx_image_vector3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec3 result)
+void mx_image_vector3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {
     // TODO: Fix handling of addressmode
     if(textureSize(tex_sampler, 0).x > 1)
     {
-        vec2 uv = mx_get_target_uv(texcoord);
+        vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rgb;
     }
     else

--- a/libraries/stdlib/genglsl/mx_image_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector4.glsl
@@ -1,9 +1,9 @@
-void mx_image_vector4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec4 result)
+void mx_image_vector4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {
     // TODO: Fix handling of addressmode
     if(textureSize(tex_sampler, 0).x > 1)
     {
-        vec2 uv = mx_get_target_uv(texcoord);
+        vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv);
     }
     else

--- a/libraries/stdlib/genosl/lib/mx_get_target_uv_vflip.osl
+++ b/libraries/stdlib/genosl/lib/mx_get_target_uv_vflip.osl
@@ -1,7 +1,0 @@
-//
-// Function to transform texture coordinates before texture sampling
-//
-vector2 mx_get_target_uv(vector2 texcoord)
-{
-   return vector2(texcoord.x, 1.0 - texcoord.y);
-}

--- a/libraries/stdlib/genosl/lib/mx_transform_uv.osl
+++ b/libraries/stdlib/genosl/lib/mx_transform_uv.osl
@@ -1,7 +1,7 @@
 //
 // Function to transform texture coordinates before texture sampling
 //
-vector2 mx_get_target_uv(vector2 texcoord)
+vector2 mx_transform_uv(vector2 texcoord)
 {
-   return texcoord;
+    return texcoord;
 }

--- a/libraries/stdlib/genosl/lib/mx_transform_uv_vflip.osl
+++ b/libraries/stdlib/genosl/lib/mx_transform_uv_vflip.osl
@@ -1,0 +1,7 @@
+//
+// Function to transform texture coordinates before texture sampling
+//
+vector2 mx_transform_uv(vector2 texcoord)
+{
+    return vector2(texcoord.x, 1.0 - texcoord.y);
+}

--- a/libraries/stdlib/genosl/mx_image_color2.osl
+++ b/libraries/stdlib/genosl/mx_image_color2.osl
@@ -9,7 +9,7 @@ void mx_image_color2(string file, string layer, color2 default_value, vector2 te
     }
 
     color missingColor = color(default_value.r, default_value.a, 0.0);
-    vector2 st = mx_get_target_uv(texcoord);
+    vector2 st = mx_transform_uv(texcoord);
     color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
 
     out.r = rgb[0];

--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -9,6 +9,6 @@ void mx_image_color3(string file, string layer, color default_value, vector2 tex
     }
 
     color missingColor = default_value;
-    vector2 st = mx_get_target_uv(texcoord);
+    vector2 st = mx_transform_uv(texcoord);
     out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
 }

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -10,7 +10,7 @@ void mx_image_color4(string file, string layer, color4 default_value, vector2 te
 
     color missingColor = default_value.rgb;
     float missingAlpha = default_value.a;
-    vector2 st = mx_get_target_uv(texcoord);
+    vector2 st = mx_transform_uv(texcoord);
     float alpha;
     color rgb = texture(file, st.x, st.y, "alpha", alpha, "subimage", layer,
                         "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode);

--- a/libraries/stdlib/genosl/mx_image_float.osl
+++ b/libraries/stdlib/genosl/mx_image_float.osl
@@ -9,7 +9,7 @@ void mx_image_float(string file, string layer, float default_value, vector2 texc
     }
 
     color missingColor = color(default_value);
-    vector2 st = mx_get_target_uv(texcoord);
+    vector2 st = mx_transform_uv(texcoord);
     color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
     out = rgb[0];
 }

--- a/libraries/stdlib/genosl/mx_image_vector2.osl
+++ b/libraries/stdlib/genosl/mx_image_vector2.osl
@@ -9,7 +9,7 @@ void mx_image_vector2(string file, string layer, vector2 default_value, vector2 
     }
 
     color missingColor = color(default_value.x, default_value.y, 0.0);
-    vector2 st = mx_get_target_uv(texcoord);
+    vector2 st = mx_transform_uv(texcoord);
     color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
     out.x = rgb[0];
     out.y = rgb[1];

--- a/libraries/stdlib/genosl/mx_image_vector3.osl
+++ b/libraries/stdlib/genosl/mx_image_vector3.osl
@@ -9,6 +9,6 @@ void mx_image_vector3(string file, string layer, vector default_value, vector2 t
     }
 
     color missingColor = default_value;
-    vector2 st = mx_get_target_uv(texcoord);
+    vector2 st = mx_transform_uv(texcoord);
     out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
 }

--- a/libraries/stdlib/genosl/mx_image_vector4.osl
+++ b/libraries/stdlib/genosl/mx_image_vector4.osl
@@ -10,7 +10,7 @@ void mx_image_vector4(string file, string layer, vector4 default_value, vector2 
 
     color missingColor = color(default_value.x, default_value.y, default_value.z);
     float missingAlpha = default_value.w;
-    vector2 st = mx_get_target_uv(texcoord);
+    vector2 st = mx_transform_uv(texcoord);
     float alpha;
     color rgb = texture(file, st.x, st.y, "alpha", alpha, "subimage", layer,
                         "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode);

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -86,5 +86,11 @@
       <!-- Transforms UVs of loaded geometry -->
       <parameter name="transformUVs" type="matrix44" value="1.0f, 0.0f, 0.0f, -0.235f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f" />
 
+      <!-- External testing: extra comma separated list of library paths -->
+      <parameter name="externalLibraryPaths" type="string" value="" />
+
+      <!-- External testing: extra comma separated list of test root paths -->
+      <parameter name="externalTestPaths" type="string" value="" />
+
    </nodedef>
 </materialx>

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -32,6 +32,7 @@ const string ValueElement::UI_NAME_ATTRIBUTE = "uiname";
 const string ValueElement::UI_FOLDER_ATTRIBUTE = "uifolder";
 const string ValueElement::UI_MIN_ATTRIBUTE = "uimin";
 const string ValueElement::UI_MAX_ATTRIBUTE = "uimax";
+const string ValueElement::UI_ADVANCED_ATTRIBUTE = "uiadvanced";
 
 Element::CreatorMap Element::_creatorMap;
 

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1119,6 +1119,7 @@ class ValueElement : public TypedElement
     static const string UI_FOLDER_ATTRIBUTE;
     static const string UI_MIN_ATTRIBUTE;
     static const string UI_MAX_ATTRIBUTE;
+    static const string UI_ADVANCED_ATTRIBUTE;
 };
 
 /// @class Token

--- a/source/MaterialXCore/Geom.cpp
+++ b/source/MaterialXCore/Geom.cpp
@@ -12,6 +12,7 @@ namespace MaterialX
 
 const string GEOM_PATH_SEPARATOR = "/";
 const string UNIVERSAL_GEOM_NAME = GEOM_PATH_SEPARATOR;
+const string UDIMSET = "udimset";
 const string UDIM_TOKEN = "<UDIM>";
 const string UV_TILE_TOKEN = "<UVTILE>";
 

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -19,6 +19,7 @@ namespace MaterialX
 extern const string GEOM_PATH_SEPARATOR;
 extern const string UNIVERSAL_GEOM_NAME;
 extern const string UDIM_TOKEN;
+extern const string UDIMSET;
 extern const string UV_TILE_TOKEN;
 
 class GeomElement;

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -206,7 +206,7 @@ void GraphElement::flattenSubgraphs(const string& target)
         processNodeVec.clear();
 
         // Iterate through nodes with graph implementations.
-        for (auto pair : graphImplMap)
+        for (const auto& pair : graphImplMap)
         {
             NodePtr processNode = pair.first;
             NodeGraphPtr sourceSubGraph = pair.second;
@@ -260,7 +260,7 @@ void GraphElement::flattenSubgraphs(const string& target)
             }
 
             // Transfer internal connections between subgraphs.
-            for (auto subNodePair : subNodeMap)
+            for (const auto& subNodePair : subNodeMap)
             {
                 NodePtr sourceSubNode = subNodePair.first;
                 NodePtr destSubNode = subNodePair.second;

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -93,7 +93,7 @@ StringVec splitString(const string& str, const string& sep)
 
 string replaceSubstrings(string str, const StringMap& stringMap)
 {
-    for (auto& pair : stringMap)
+    for (const auto& pair : stringMap)
     {
         if (pair.first.empty())
             continue;

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -76,7 +76,6 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
 void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions* writeOptions)
 {
     bool writeXIncludeEnable = writeOptions ? writeOptions->writeXIncludeEnable : true;
-    const StringVec& ignoredXIncludes = writeOptions ? writeOptions->ignoredXIncludes : StringVec();
     ElementPredicate elementPredicate = writeOptions ? writeOptions->elementPredicate : nullptr;
 
     // Store attributes in XML.
@@ -107,11 +106,6 @@ void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions
             {
                 if (!writtenSourceFiles.count(sourceUri))
                 {
-                    // Check to see if we have flagged this XInclude to be ignored, if so skip it.
-                    if (std::find(ignoredXIncludes.begin(), ignoredXIncludes.end(), sourceUri) != ignoredXIncludes.end())
-                    {
-                        continue;
-                    }
                     xml_node includeNode = xmlNode.append_child(XINCLUDE_TAG.c_str());
                     xml_attribute includeAttr = includeNode.append_attribute("href");
                     includeAttr.set_value(sourceUri.c_str());

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -76,6 +76,7 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
 void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions* writeOptions)
 {
     bool writeXIncludeEnable = writeOptions ? writeOptions->writeXIncludeEnable : true;
+    const StringVec& ignoredXIncludes = writeOptions ? writeOptions->ignoredXIncludes : StringVec();
     ElementPredicate elementPredicate = writeOptions ? writeOptions->elementPredicate : nullptr;
 
     // Store attributes in XML.
@@ -106,6 +107,11 @@ void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions
             {
                 if (!writtenSourceFiles.count(sourceUri))
                 {
+                    // Check to see if we have flagged this XInclude to be ignored, if so skip it.
+                    if (std::find(ignoredXIncludes.begin(), ignoredXIncludes.end(), sourceUri) != ignoredXIncludes.end())
+                    {
+                        continue;
+                    }
                     xml_node includeNode = xmlNode.append_child(XINCLUDE_TAG.c_str());
                     xml_attribute includeAttr = includeNode.append_attribute("href");
                     includeAttr.set_value(sourceUri.c_str());

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -52,14 +52,10 @@ class XmlWriteOptions
     /// If true, elements with source file markings will be written as
     /// XIncludes rather than explicit data.  Defaults to true.
     bool writeXIncludeEnable;
-
+    
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;
-
-    /// The vector of XIncludes to ignore saving out.  Defaults to an empty
-    /// vector.
-    StringVec ignoredXIncludes;
 };
 
 /// @class ExceptionParseError

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -31,7 +31,7 @@ class XmlReadOptions : public CopyOptions
   public:
     XmlReadOptions();
     ~XmlReadOptions() { }
-    
+
     /// If provided, this function will be invoked when an XInclude reference
     /// needs to be read into a document.  Defaults to readFromXmlFile.
     XmlReadFunction readXIncludeFunction;
@@ -52,10 +52,14 @@ class XmlWriteOptions
     /// If true, elements with source file markings will be written as
     /// XIncludes rather than explicit data.  Defaults to true.
     bool writeXIncludeEnable;
-    
+
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;
+
+    /// The vector of XIncludes to ignore saving out.  Defaults to an empty
+    /// vector.
+    StringVec ignoredXIncludes;
 };
 
 /// @class ExceptionParseError

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
@@ -37,7 +37,7 @@ void LightSamplerNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContext&
         if (lightShaders)
         {
             string ifstatement = "if ";
-            for (auto it : lightShaders->get())
+            for (const auto& it : lightShaders->get())
             {
                 shadergen.emitLine(ifstatement + "(light.type == " + std::to_string(it.first) + ")", stage, false);
                 shadergen.emitScopeBegin(stage);

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -16,6 +16,7 @@
 #include <MaterialXGenShader/Nodes/SwitchNode.h>
 #include <MaterialXGenShader/Nodes/CompareNode.h>
 #include <MaterialXGenShader/Nodes/BlurNode.h>
+#include <MaterialXGenShader/Nodes/SourceCodeNode.h>
 
 namespace MaterialX
 {
@@ -191,16 +192,15 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     }
 
     // Emit uv transform function
-    if (context.getOptions().fileTextureVerticalFlip)
+    if (!context.getOptions().fileTextureVerticalFlip)
     {
-        emitInclude("stdlib/" + OslShaderGenerator::LANGUAGE + "/lib/mx_get_target_uv_vflip.osl", context, stage);
-        emitLineBreak(stage);
+        emitInclude("stdlib/" + OslShaderGenerator::LANGUAGE + "/lib/mx_transform_uv.osl", context, stage);
     }
     else
     {
-        emitInclude("stdlib/" + OslShaderGenerator::LANGUAGE + "/lib/mx_get_target_uv_noop.osl", context, stage);
-        emitLineBreak(stage);
+        emitInclude("stdlib/" + OslShaderGenerator::LANGUAGE + "/lib/mx_transform_uv_vflip.osl", context, stage);
     }
+    emitLineBreak(stage);
 
     // Emit function definitions for all nodes
     emitFunctionDefinitions(graph, context, stage);
@@ -220,7 +220,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
         emitString("shader ", stage);
     }
 
-    // Begin shader signature.
+    // Begin shader signature. Note that makeIdentifier() will sanitize the name.
     string functionName = shader->getName();
     context.makeIdentifier(functionName);
     setFunctionName(functionName, stage);
@@ -274,6 +274,9 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
 
     // End shader body
     emitScopeEnd(stage);
+
+    // Perform token substitution
+    replaceTokens(_tokenSubstitutions, stage);
 
     return shader;
 }

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -255,8 +255,7 @@ OslSyntax::OslSyntax()
         "signed", "sizeof", "static", "switch", "template", "this", "throw", "true", "try", "typedef", "uniform",
         "union", "unsigned", "varying", "virtual", "volatile",
         "emission", "background", "diffuse", "oren_nayer", "translucent", "phong", "ward", "microfacet",
-        "reflection", "transparent", "debug", "holdout", "subsurface",
-        ""
+        "reflection", "transparent", "debug", "holdout", "subsurface"
     });
 
     //

--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -26,6 +26,10 @@ GenContext::GenContext(ShaderGeneratorPtr sg) :
 
 void GenContext::addIdentifier(const string& name)
 {
+    if (name.empty())
+    {
+        throw ExceptionShaderGenError("Cannot add empty string as identifier");
+    }
     if (_identifiers.count(name))
     {
         throw ExceptionShaderGenError("Identifier '" + name + "' is already used.");
@@ -36,6 +40,7 @@ void GenContext::addIdentifier(const string& name)
 
 void GenContext::makeIdentifier(string& name)
 {
+    name = createValidName(name, '_');
     string id = name;
     while (_identifiers.count(id))
     {

--- a/source/MaterialXGenShader/GenOptions.cpp
+++ b/source/MaterialXGenShader/GenOptions.cpp
@@ -14,7 +14,7 @@ GenOptions::GenOptions() :
     hwTransparency(false),
     hwSpecularEnvironmentMethod(SPECULAR_ENVIRONMENT_FIS),
     hwMaxActiveLightSources(3),
-    emitVersionString(true)
+    hwNormalizeUdimTexCoords(false)
 {
 }
 GenOptions::~GenOptions()

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -87,8 +87,12 @@ class GenOptions
     /// be active at once.
     unsigned int hwMaxActiveLightSources;
 
-    /// Emit version string (if applicable)
-    bool emitVersionString;
+    /// Sets whether to transform texture coordinates to normalize
+    /// uv space when UDIMs images are bound to an image. Can be
+    /// enabled for when texture atlas generation is performed to
+    /// compress a set of UDIMs into a single normalized image for
+    /// hardware rendering.
+    bool hwNormalizeUdimTexCoords;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -282,7 +282,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     if (lightShaders && graph->hasClassification(ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE))
     {
         // Create shader variables for all bound light shaders
-        for (auto it : lightShaders->get())
+        for (const auto& it : lightShaders->get())
         {
             ShaderNode* node = it.second.get();
             node->getImplementation().createVariables(*node, context, *shader);
@@ -299,7 +299,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     std::deque<ShaderGraph*> graphQueue = { graph.get() };
     if (lightShaders)
     {
-        for (auto it : lightShaders->get())
+        for (const auto& it : lightShaders->get())
         {
             ShaderNode* node = it.second.get();
             ShaderGraph* lightGraph = node->getImplementation().getGraph();

--- a/source/MaterialXGenShader/Nodes/HwImageNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.cpp
@@ -1,0 +1,72 @@
+//
+// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXGenShader/Nodes/HwSourceCodeNode.h>
+#include <MaterialXGenShader/Nodes/HwImageNode.h>
+#include <MaterialXGenShader/HwShaderGenerator.h>
+#include <MaterialXGenShader/Util.h>
+
+#include <iostream>
+
+namespace MaterialX
+{
+// Additional implementaton arguments for image nodes
+const string UV_SCALE = "uv_scale";
+const string UV_OFFSET = "uv_offset";
+
+ShaderNodeImplPtr HwImageNode::create()
+{
+    return std::make_shared<HwImageNode>();
+}
+
+void HwImageNode::addInputs(ShaderNode& node, GenContext&) const
+{
+    // Add additional scale and offset inputs to match implementation arguments
+    ShaderInput* input = node.addInput(UV_SCALE, Type::VECTOR2);
+    input->setValue(Value::createValue<Vector2>(Vector2(1.0f, 1.0f)));
+    input = node.addInput(UV_OFFSET, Type::VECTOR2);
+    input->setValue(Value::createValue<Vector2>(Vector2(0.0f, 0.0f)));
+}
+
+void HwImageNode::setValues(const Node& node, ShaderNode& shaderNode, GenContext& context) const
+{
+    // Remap uvs to normalized 0..1 space if the original UDIMs in a UDIM set
+    // have been mapped to a single texture atlas which must be accessed in 0..1 space.
+    if (context.getOptions().hwNormalizeUdimTexCoords)
+    {
+        ParameterPtr file = node.getParameter("file");
+        if (file)
+        {
+            // set the uv scale and offset properly.
+            const string& fileName = file->getValueString();
+            if (fileName.find(UDIM_TOKEN) != string::npos)
+            {
+                ValuePtr udimSetValue = node.getDocument()->getGeomAttrValue(UDIMSET);
+                if (udimSetValue && udimSetValue->isA<StringVec>())
+                {
+                    const StringVec& udimIdentifiers = udimSetValue->asA<StringVec>();
+                    vector<Vector2> udimCoordinates{ getUdimCoordinates(udimIdentifiers) };
+
+                    Vector2 scaleUV{ 1.0f, 1.0f };
+                    Vector2 offsetUV{ 0.0f, 0.0f };
+                    getUdimScaleAndOffset(udimCoordinates, scaleUV, offsetUV);
+
+                    ShaderInput* input = shaderNode.getInput(UV_SCALE);
+                    if (input)
+                    {
+                        input->setValue(Value::createValue<Vector2>(scaleUV));
+                    }
+                    input = shaderNode.getInput(UV_OFFSET);
+                    if (input)
+                    {
+                        input->setValue(Value::createValue<Vector2>(offsetUV));
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // namespace MaterialX

--- a/source/MaterialXGenShader/Nodes/HwImageNode.h
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.h
@@ -1,0 +1,26 @@
+//
+// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_HWIMAGECODENODE_H
+#define MATERIALX_HWIMAGECODENODE_H
+
+#include <MaterialXGenShader/Nodes/HwSourceCodeNode.h>
+
+namespace MaterialX
+{
+
+/// Extending the HwSourceCodeNodewith requirements for image nodes.
+class HwImageNode : public HwSourceCodeNode
+{
+public:
+    static ShaderNodeImplPtr create();
+
+    void addInputs(ShaderNode& node, GenContext& context) const override;
+    void setValues(const Node& node, ShaderNode& shaderNode, GenContext& context) const override;
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -125,7 +125,7 @@ void ShaderGenerator::emitFunctionCalls(const ShaderGraph& graph, GenContext& co
 void ShaderGenerator::emitTypeDefinitions(GenContext&, ShaderStage& stage) const
 {
     // Emit typedef statements for all data types that have an alias
-    for (auto syntax : _syntax->getTypeSyntaxes())
+    for (const auto& syntax : _syntax->getTypeSyntaxes())
     {
         if (!syntax->getTypeAlias().empty())
         {
@@ -233,15 +233,19 @@ void ShaderGenerator::resetIdentifiers(GenContext& context) const
     context.clearIdentifiers();
 
     // Add in the restricted names as taken names.
-    for (auto name : _syntax->getRestrictedNames())
+    for (const auto& name : _syntax->getRestrictedNames())
     {
         context.addIdentifier(name);
     }
 
     // Add in the token substitution identifiers as taken names
-    for (auto it : _tokenSubstitutions)
+    for (const auto& it : _tokenSubstitutions)
     {
-        context.addIdentifier(it.second);
+        // Do no add empty token substitutions as identifiers
+        if (!it.second.empty())
+        {
+            context.addIdentifier(it.second);
+        }
     }
 }
 
@@ -321,7 +325,7 @@ void ShaderGenerator::replaceTokens(const StringMap& substitutions, ShaderStage&
     {
         replace(substitutions, stage._constants[i]);
     }
-    for (auto it : stage._uniforms)
+    for (const auto& it : stage._uniforms)
     {
         VariableBlock& uniforms = *it.second;
         for (size_t i = 0; i < uniforms.size(); ++i)
@@ -329,7 +333,7 @@ void ShaderGenerator::replaceTokens(const StringMap& substitutions, ShaderStage&
             replace(substitutions, uniforms[i]);
         }
     }
-    for (auto it : stage._inputs)
+    for (const auto& it : stage._inputs)
     {
         VariableBlock& inputs = *it.second;
         for (size_t i = 0; i < inputs.size(); ++i)
@@ -337,7 +341,7 @@ void ShaderGenerator::replaceTokens(const StringMap& substitutions, ShaderStage&
             replace(substitutions, inputs[i]);
         }
     }
-    for (auto it : stage._outputs)
+    for (const auto& it : stage._outputs)
     {
         VariableBlock& outputs = *it.second;
         for (size_t i = 0; i < outputs.size(); ++i)

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -712,11 +712,11 @@ const ShaderNode* ShaderGraph::getNode(const string& name) const
 void ShaderGraph::finalize(GenContext& context)
 {
     // Insert color transformation nodes where needed
-    for (auto it : _inputColorTransformMap)
+    for (const auto& it : _inputColorTransformMap)
     {
         addColorTransformNode(it.first, it.second, context);
     }
-    for (auto it : _outputColorTransformMap)
+    for (const auto& it : _outputColorTransformMap)
     {
         addColorTransformNode(it.first, it.second, context);
     }
@@ -948,7 +948,7 @@ void ShaderGraph::topologicalSort()
     // Calculate in-degrees for all nodes, and enqueue those with degree 0.
     std::unordered_map<ShaderNode*, int> inDegree(_nodeMap.size());
     std::deque<ShaderNode*> nodeQueue;
-    for (auto it : _nodeMap)
+    for (const auto& it : _nodeMap)
     {
         ShaderNode* node = it.second.get();
 
@@ -981,9 +981,9 @@ void ShaderGraph::topologicalSort()
 
         // Find connected nodes and decrease their in-degree,
         // adding node to the queue if in-degrees becomes 0.
-        for (auto output : node->getOutputs())
+        for (const auto& output : node->getOutputs())
         {
-            for (auto input : output->getConnections())
+            for (const auto& input : output->getConnections())
             {
                 if (input->getNode() != this)
                 {

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -256,6 +256,9 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
         }
     }
 
+    // Add any additional inputs required by the implementation
+    newNode->getImplementation().addInputs(*newNode, context);
+
     // Add a default output if needed
     if (newNode->numOutputs() == 0)
     {
@@ -401,6 +404,12 @@ void ShaderNode::setValues(const Node& node, const NodeDef& nodeDef, GenContext&
                 input->setChannels(inputElem->getChannels());
             }
         }
+    }
+
+    // Set implementation specific values.
+    if (_impl)
+    {
+        _impl->setValues(node, *this, context);
     }
 }
 

--- a/source/MaterialXGenShader/ShaderNodeImpl.cpp
+++ b/source/MaterialXGenShader/ShaderNodeImpl.cpp
@@ -34,6 +34,14 @@ void ShaderNodeImpl::initialize(const InterfaceElement& element, GenContext&)
     _hash = std::hash<string>{}(_name);
 }
 
+void ShaderNodeImpl::addInputs(ShaderNode&, GenContext&) const
+{
+}
+
+void ShaderNodeImpl::setValues(const Node&, ShaderNode&, GenContext&) const
+{
+}
+
 void ShaderNodeImpl::createVariables(const ShaderNode&, GenContext&, Shader&) const
 {
 }

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -17,6 +17,7 @@ namespace MaterialX
 {
 
 class InterfaceElement;
+class Node;
 using ShaderGraphInputSocket = ShaderOutput;
 
 /// Shared pointer to a ShaderNodeImpl
@@ -62,6 +63,12 @@ class ShaderNodeImpl
     {
         return _hash;
     }
+
+    /// Add additional inputs on the node 
+    virtual void addInputs(ShaderNode& node, GenContext& context) const;
+
+    /// Set values for additional inputs on the node 
+    virtual void setValues(const Node& node, ShaderNode& shaderNode, GenContext& context) const;
 
     /// Create shader variables needed for the implementation of this node (e.g. uniforms, inputs and outputs).
     /// Used if the node requires input data from the application.

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -29,10 +29,27 @@ string removeExtension(const string& filename);
 bool readFile(const string& filename, string& content);
 
 /// Scans for all documents under a root path and returns documents which can be loaded
-void loadDocuments(const FilePath& rootPath, 
+void loadDocuments(const FilePath& rootPath,
+                   const FileSearchPath& searchPath,
                    const StringSet& skipFiles, const StringSet& includeFiles,
-                   vector<DocumentPtr>& documents, StringVec& documentsPaths, 
+                   vector<DocumentPtr>& documents, StringVec& documentsPaths,
                    StringVec& errorLog);
+
+/// Load a given MaterialX library into a document
+void loadLibrary(const FilePath& file, DocumentPtr doc);
+
+/// Load all MaterialX files with given library names in given search paths.
+/// Note that all library files will have a URI set on them.
+StringVec loadLibraries(const StringVec& libraryNames,
+                        const FileSearchPath& searchPath,
+                        DocumentPtr doc,
+                        const StringSet* excludeFiles = nullptr);
+
+/// Load all MaterialX files with given library names in a given path.
+StringVec loadLibraries(const StringVec& libraryNames,
+                        const FilePath& filePath,
+                        DocumentPtr doc,
+                        const StringSet* excludeFiles = nullptr);
 
 /// Returns true if the given element is a surface shader with the potential
 /// of beeing transparent. This can be used by HW shader generators to determine
@@ -43,7 +60,7 @@ void loadDocuments(const FilePath& rootPath,
 /// how transparency can be done and target applications might need to do
 /// additional checks to track transparency correctly. For example, custom
 /// surface shader nodes implemented in source code will not be tracked by this
-/// function and transprency for such nodes must be tracked separately by the 
+/// function and transprency for such nodes must be tracked separately by the
 /// target application.
 ///
 bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen);
@@ -65,7 +82,7 @@ bool elementRequiresShading(ConstTypedElementPtr element);
 /// This includes all outputs on node graphs and shader references which are not
 /// part of any included library. Light shaders are not considered to be renderable.
 /// The option to include node graphs referened by shader references is disabled by default.
-void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& elements, 
+void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& elements,
                             bool includeReferencedGraphs = false);
 
 /// Given a path to a element, find the corresponding element with the same name
@@ -73,11 +90,27 @@ void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& eleme
 /// if the path is to a Node as definitions for Nodes can be target specific.
 ValueElementPtr findNodeDefChild(const string& path, DocumentPtr doc, const string& target);
 
-/// Perform token substitutions on the given source string, using the given substituation map. 
+/// Perform token substitutions on the given source string, using the given substituation map.
 /// Tokens are required to start with '$' and can only consist of alphanumeric characters.
 /// The full token name, including '$' and all following alphanumeric character, will be replaced
 /// by the corresponding string in the substitution map, if the token exists in the map.
 void tokenSubstitution(const StringMap& substitutions, string& source);
+
+/// Perform UDIM token replace using an input file path and a list of token
+/// replacements (UDIM identifiers). A new path will be created for
+/// each identifier.
+/// @param filePath File path with UDIM token
+/// @param udimIdentifiers List of UDIM identifiers
+/// @returns List of file paths
+FilePathVec getUdimPaths(const FilePath& filePath, const StringVec& udimIdentifiers);
+
+/// Compute the UDIM coordinates for a set of UDIM identifiers
+/// @return List of UDIM coordinates
+vector<Vector2> getUdimCoordinates(const StringVec& udimIdentifiers);
+
+/// Get the UV scale and offset to transform uv coordinates from UDIM uv space to
+/// 0..1 space.
+void getUdimScaleAndOffset(const vector<Vector2>& udimCoordinates, Vector2& scaleUV, Vector2& offsetUV);
 
 } // namespace MaterialX
 

--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -11,7 +11,7 @@ namespace MaterialX
 void GeometryHandler::addLoader(GeometryLoaderPtr loader)
 {
     const StringSet& extensions = loader->supportedExtensions();
-    for (auto extension : extensions)
+    for (const auto& extension : extensions)
     {
         _geometryLoaders.insert(std::pair<std::string, GeometryLoaderPtr>(extension, loader));
     }
@@ -20,7 +20,7 @@ void GeometryHandler::addLoader(GeometryLoaderPtr loader)
 void GeometryHandler::supportedExtensions(StringSet& extensions)
 {
     extensions.clear();
-    for (auto loader : _geometryLoaders)
+    for (const auto& loader : _geometryLoaders)
     {
         const StringSet& loaderExtensions = loader.second->supportedExtensions();
         extensions.insert(loaderExtensions.begin(), loaderExtensions.end());
@@ -35,7 +35,7 @@ void GeometryHandler::clearGeometry()
 
 bool GeometryHandler::hasGeometry(const string& location)
 {
-    for (auto mesh : _meshes)
+    for (const auto& mesh : _meshes)
     {
         if (mesh->getSourceUri() == location)
         {
@@ -48,7 +48,7 @@ bool GeometryHandler::hasGeometry(const string& location)
 void GeometryHandler::getGeometry(MeshList& meshes, const string& location)
 {
     meshes.clear();
-    for (auto mesh : _meshes)
+    for (const auto& mesh : _meshes)
     {
         if (mesh->getSourceUri() == location)
         {
@@ -62,7 +62,7 @@ void GeometryHandler::computeBounds()
     const float MAX_FLOAT = std::numeric_limits<float>::max();
     _minimumBounds = { MAX_FLOAT, MAX_FLOAT, MAX_FLOAT };
     _maximumBounds = { -MAX_FLOAT, -MAX_FLOAT, -MAX_FLOAT };
-    for (auto mesh : _meshes)
+    for (const auto& mesh : _meshes)
     {
         const Vector3& minMesh = mesh->getMinimumBounds();
         _minimumBounds[0] = std::min(minMesh[0], _minimumBounds[0]);

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -19,6 +19,8 @@
 
 namespace MaterialX
 {
+class VariableBlock;
+
 /// A function to perform image buffer deallocation
 using ImageBufferDeallocator = std::function<void(void*)>;
 
@@ -95,6 +97,12 @@ class ImageDescRestrictions
 class ImageSamplingProperties
 {
   public:
+    /// Set the properties based on data in a uniform block.
+    /// @param fileNameUniform Name of the file name uniform. Used to find
+    ///        corresponding sampler data in the uniform block
+    /// @param uniformBlock Block containing sampler uniforms
+    void setProperties(const string& fileNameUniform,
+                       const VariableBlock& uniformBlock);
 
     /// Address mode options. Matches enumerations
     /// allowed for <image> address modes, except
@@ -306,18 +314,6 @@ class ImageHandler
     {
         return -1;
     }
-
-    /// Perform UDIM token replace using an input file path and a list of token
-    /// replacements (UDIM identifiers). A new path will be created for 
-    /// each identifier.
-    /// @param filePath File path with UDIM token
-    /// @param udimIdentifiers List of UDIM identifiers
-    /// @returns List of file paths
-    static FilePathVec getUdimPaths(const FilePath& filePath, const StringVec& udimIdentifiers);
-
-    /// Compute the UDIM coordinates for a set of UDIM identifiers
-    /// @return List of UDIM coordinates
-    static vector<Vector2> getUdimCoordinates(const StringVec& udimIdentifiers);
 
   protected:
     /// Cache an image for reuse.

--- a/source/MaterialXRender/LightHandler.cpp
+++ b/source/MaterialXRender/LightHandler.cpp
@@ -27,7 +27,7 @@ void LightHandler::mapNodeDefToIdentiers(const std::vector<NodePtr>& nodes,
                                            std::unordered_map<string, unsigned int>& ids)
 {
     unsigned int id = 1;
-    for (auto node : nodes)
+    for (const auto& node : nodes)
     {
         auto nodedef = node->getNodeDef();
         if (nodedef)
@@ -65,7 +65,7 @@ void LightHandler::registerLights(DocumentPtr doc, const std::vector<NodePtr>& l
     {
         // Create a list of unique nodedefs and ids for them
         mapNodeDefToIdentiers(lights, _lightIdentifierMap);
-        for (auto id : _lightIdentifierMap)
+        for (const auto& id : _lightIdentifierMap)
         {
             NodeDefPtr nodeDef = doc->getNodeDef(id.first);
             if (nodeDef)

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -200,7 +200,7 @@ void Mesh::splitByUdims()
     }
 
     _partitions.clear();
-    for (auto pair : udimMap)
+    for (const auto& pair : udimMap)
     {
         addPartition(pair.second);
     }

--- a/source/MaterialXRender/Mesh.h
+++ b/source/MaterialXRender/Mesh.h
@@ -252,7 +252,7 @@ class Mesh
     /// @return Reference to a mesh stream if found
     MeshStreamPtr getStream(const string& name) const
     {
-        for (auto stream : _streams)
+        for (const auto& stream : _streams)
         {
             if (stream->getName() == name)
             {
@@ -268,7 +268,7 @@ class Mesh
     /// @return Reference to a mesh stream if found
     MeshStreamPtr getStream(const string& type, unsigned int index) const
     {
-        for (auto stream : _streams)
+        for (const auto& stream : _streams)
         {
             if (stream->getType() == type &&
                 stream->getIndex() == index)

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -118,6 +118,14 @@ unsigned int getUIProperties(ValueElementPtr nodeDefElement, UIProperties& uiPro
             propertyCount++;
         }
     }
+
+    const string& uiAdvancedString = nodeDefElement->getAttribute(ValueElement::UI_ADVANCED_ATTRIBUTE);
+    uiProperties.uiAdvanced = (uiAdvancedString == "true");
+    if(!uiAdvancedString.empty())
+    {
+        propertyCount++;
+    }
+
     return propertyCount;
 }
 

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -182,7 +182,7 @@ void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocume
 void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
                           const string& pathSeparator, UIPropertyGroup& groups, UIPropertyGroup& unnamedGroups)
 {
-    for (auto uniform : block.getVariableOrder())
+    for (const auto& uniform : block.getVariableOrder())
     {
         if (!uniform->getPath().empty() && uniform->getValue())
         {

--- a/source/MaterialXRender/Util.h
+++ b/source/MaterialXRender/Util.h
@@ -54,6 +54,9 @@ namespace MaterialX
 
         /// UI maximum value
         ValuePtr uiMax;
+
+        /// UI advanced element
+        bool uiAdvanced;
     };
 
     /// Get the UI properties for a given nodedef element.

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -120,7 +120,7 @@ unsigned int GlslProgram::build()
 
     unsigned int stagesBuilt = 0;
     unsigned int desiredStages = 0;
-    for (auto it : _stages)
+    for (const auto& it : _stages)
     {
         if (it.second.length())
             desiredStages++;
@@ -283,7 +283,7 @@ void GlslProgram::bindInputs(ViewHandlerPtr viewHandler,
 
     // Bind based on inputs found
     bindViewInformation(viewHandler);
-    for (auto mesh : geometryHandler->getMeshes())
+    for (const auto& mesh : geometryHandler->getMeshes())
     {
         bindStreams(mesh);
     }
@@ -328,7 +328,7 @@ void GlslProgram::bindAttribute(const GlslProgram::InputMap& inputs, MeshPtr mes
 
     const size_t FLOAT_SIZE = sizeof(float);
 
-    for (auto input : inputs)
+    for (const auto& input : inputs)
     {
         int location = input.second->location;
         unsigned int index = input.second->value ? input.second->value->asA<int>() : 0;
@@ -459,7 +459,7 @@ void GlslProgram::bindStreams(MeshPtr mesh)
     // Bind any named attribute information
     const GlslProgram::InputMap& uniformList = getUniformsList();
     findInputs(HW::GEOMATTR + "_", uniformList, foundList, false);
-    for (auto Input : foundList)
+    for (const auto& Input : foundList)
     {
         // Only handle float1-4 types for now
         switch (Input.second->gltype)
@@ -509,7 +509,7 @@ void GlslProgram::unbindGeometry()
         glDeleteBuffers(1, &_indexBuffer);
         _indexBuffer = GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
     }
-    for (auto attributeBufferId : _attributeBufferIds)
+    for (const auto& attributeBufferId : _attributeBufferIds)
     {
         unsigned int bufferId = attributeBufferId.second;
         if (bufferId > 0)
@@ -587,7 +587,7 @@ void GlslProgram::bindTextures(ImageHandlerPtr imageHandler)
     // Bind textures based on uniforms found in the program
     const GlslProgram::InputMap& uniformList = getUniformsList();
     const std::string IMAGE_SEPARATOR("_");
-    for (auto uniform : uniformList)
+    for (const auto& uniform : uniformList)
     {
         GLenum uniformType = uniform.second->gltype;
         GLint uniformLocation = uniform.second->location;
@@ -697,7 +697,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
         { HW::ENV_IRRADIANCE, lightHandler->getLightEnvIrradiancePath() }
     };
 
-    for (auto ibl : iblList)
+    for (const auto& ibl : iblList)
     {
         auto iblUniform = uniformList.find(ibl.first);
         GlslProgram::InputPtr inputPtr = iblUniform != uniformList.end() ? iblUniform->second : nullptr;
@@ -731,7 +731,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
     const std::unordered_map<string, unsigned int>& ids = lightHandler->getLightIdentifierMap();
 
     size_t index = 0;
-    for (auto light : lightList)
+    for (const auto& light : lightList)
     {
         auto nodeDef = light->getNodeDef();
         if (!nodeDef)
@@ -763,7 +763,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
         }
 
         // Set all inputs
-        for (auto lightInput : light->getInputs())
+        for (const auto& lightInput : light->getInputs())
         {
             // Make sure we have a value to set
             if (lightInput->hasValue())
@@ -777,7 +777,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
         }
 
         // Set all parameters. Note that upstream connections are not currently handled.
-        for (auto param : light->getParameters())
+        for (const auto& param : light->getParameters())
         {
             // Make sure we have a value to set
             if (param->hasValue())
@@ -1464,7 +1464,7 @@ void GlslProgram::findInputs(const std::string& variable,
 void GlslProgram::printUniforms(std::ostream& outputStream)
 {
     updateUniformsList();
-    for (auto input : _uniformList)
+    for (const auto& input : _uniformList)
     {
         unsigned int gltype = input.second->gltype;
         int location = input.second->location;
@@ -1491,7 +1491,7 @@ void GlslProgram::printUniforms(std::ostream& outputStream)
 void GlslProgram::printAttributes(std::ostream& outputStream)
 {
     updateAttributesList();
-    for (auto input : _attributeList)
+    for (const auto& input : _attributeList)
     {
         unsigned int gltype = input.second->gltype;
         int location = input.second->location;

--- a/source/MaterialXRenderGlsl/GlslValidator.cpp
+++ b/source/MaterialXRenderGlsl/GlslValidator.cpp
@@ -306,7 +306,7 @@ void GlslValidator::validateCreation(const StageMap& stages)
         throw ExceptionShaderValidationError(errorType, errors);
     }
 
-    for (auto it : stages)
+    for (const auto& it : stages)
     {
         _program->addStage(it.first, it.second);
     }
@@ -423,7 +423,7 @@ void GlslValidator::validateRender()
                 _program->bindInputs(_viewHandler, _geometryHandler, _imageHandler, _lightHandler);
 
                 // Draw all the partitions of all the meshes in the handler
-                for (auto mesh : _geometryHandler->getMeshes())
+                for (const auto& mesh : _geometryHandler->getMeshes())
                 {
                     for (size_t i = 0; i < mesh->getPartitionCount(); i++)
                     {

--- a/source/MaterialXRenderOsl/OslValidator.cpp
+++ b/source/MaterialXRenderOsl/OslValidator.cpp
@@ -120,12 +120,12 @@ void OslValidator::renderOSL(const FilePath& dirPath, const string& shaderName, 
     replacementMap[OUTPUT_SHADER_INPUT_STRING] = OUTPUT_SHADER_INPUT_VALUE_STRING;
     replacementMap[INPUT_SHADER_TYPE_STRING] = shaderName;
     string overrideString;
-    for (auto param : _oslShaderParameterOverrides)
+    for (const auto& param : _oslShaderParameterOverrides)
     {
         overrideString.append(param);
     }
     string envOverrideString;
-    for (auto param : _envOslShaderParameterOverrides)
+    for (const auto& param : _envOslShaderParameterOverrides)
     {
         envOverrideString.append(param);
     }
@@ -253,7 +253,7 @@ void OslValidator::shadeOSL(const FilePath& dirPath, const string& shaderName, c
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
         errors.push_back("Shader failed to render:");
-        for (auto resultLine : results)
+        for (const auto& resultLine : results)
         {
             errors.push_back(resultLine);
         }

--- a/source/MaterialXTest/GenGlsl.cpp
+++ b/source/MaterialXTest/GenGlsl.cpp
@@ -12,6 +12,7 @@
 
 #include <MaterialXFormat/File.h>
 
+#include <MaterialXGenShader/Util.h>
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 #include <MaterialXGenGlsl/GlslSyntax.h>
 
@@ -100,7 +101,7 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
     mx::DocumentPtr doc = mx::createDocument();
 
     mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    GenShaderUtil::loadLibraries({ "stdlib", "pbrlib", "lights" }, searchPath, doc);
+    loadLibraries({ "stdlib", "pbrlib", "lights" }, searchPath, doc);
 
     mx::NodeDefPtr pointLightShader = doc->getNodeDef("ND_point_light");
     mx::NodeDefPtr spotLightShader = doc->getNodeDef("ND_spot_light");

--- a/source/MaterialXTest/GenGlsl.h
+++ b/source/MaterialXTest/GenGlsl.h
@@ -6,6 +6,7 @@
 #ifndef GENGLSL_H
 #define GENGLSL_H
 
+#include <MaterialXGenShader/Util.h>
 #include <MaterialXTest/GenShaderUtil.h>
 
 namespace mx = MaterialX;
@@ -32,8 +33,8 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
         ParentClass::setupDependentLibraries();
 
         mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/Utilities/Lights");
-        GenShaderUtil::loadLibrary(lightDir / mx::FilePath("lightcompoundtest.mtlx"), _dependLib);
-        GenShaderUtil::loadLibrary(lightDir / mx::FilePath("light_rig.mtlx"), _dependLib);
+        loadLibrary(lightDir / mx::FilePath("lightcompoundtest.mtlx"), _dependLib);
+        loadLibrary(lightDir / mx::FilePath("light_rig.mtlx"), _dependLib);
     }
 
   protected:

--- a/source/MaterialXTest/GenShader.cpp
+++ b/source/MaterialXTest/GenShader.cpp
@@ -29,10 +29,6 @@
 #include <MaterialXGenOsl/OslShaderGenerator.h>
 #endif
 
-#if defined (MATERIALX_BUILD_CONTRIB)
-#include <MaterialXContrib/OGSXMLFragmentWrapper.h>
-#endif
-
 namespace mx = MaterialX;
 
 //
@@ -61,7 +57,7 @@ TEST_CASE("GenShader: Valid Libraries", "[genshader]")
     mx::DocumentPtr doc = mx::createDocument();
 
     mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    GenShaderUtil::loadLibraries({ "stdlib", "pbrlib" }, searchPath, doc);
+    loadLibraries({ "stdlib", "pbrlib" }, searchPath, doc);
 
     std::string validationErrors;
     bool valid = doc->validate(&validationErrors);
@@ -116,7 +112,7 @@ TEST_CASE("GenShader: OSL Reference Implementation Check", "[genshader]")
     mx::DocumentPtr doc = mx::createDocument();
 
     mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    GenShaderUtil::loadLibraries({ "stdlib" }, searchPath, doc);
+    loadLibraries({ "stdlib" }, searchPath, doc);
 
     // Set source code search path
     mx::FileSearchPath sourceCodeSearchPath;
@@ -137,7 +133,7 @@ TEST_CASE("GenShader: OSL Reference Implementation Check", "[genshader]")
     std::vector<mx::ImplementationPtr> impls = doc->getImplementations();
     implDumpStream << "Existing implementations: " << std::to_string(impls.size()) << std::endl;
     implDumpStream << "-----------------------------------------------------------------------" << std::endl;
-    for (auto impl : impls)
+    for (const auto& impl : impls)
     {
         if (language == impl->getLanguage() && impl->getTarget().empty())
         {

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -24,18 +24,6 @@ namespace mx = MaterialX;
 
 namespace GenShaderUtil
 {
-//
-// Load in a library. Sets the URI before import
-//
-void loadLibrary(const mx::FilePath& file, mx::DocumentPtr doc);
-
-//
-// Loads all the MTLX files below a given library path
-//
-void loadLibraries(const mx::StringVec& libraryNames,
-                    const mx::FilePath& searchPath,
-                    mx::DocumentPtr doc,
-                    const mx::StringSet* excludeFiles = nullptr);
     
 //
 // Get source content, source path and resolved paths for
@@ -139,6 +127,12 @@ class TestSuiteOptions
 
     // Transforms UVs of loaded geometry
     MaterialX::Matrix44 transformUVs;
+
+    // Additional library paths
+    mx::FileSearchPath externalLibraryPaths;
+
+    // Additional testPaths paths
+    mx::FileSearchPath externalTestPaths;
 };
 
 // Utility class to handle testing of shader generators.
@@ -194,8 +188,8 @@ class ShaderGeneratorTester
     virtual void registerLights(mx::DocumentPtr doc, const std::vector<mx::NodePtr>& lights, mx::GenContext& context);
 
     // Generate source code for a given element and check that code was produced.
-    bool generateCode(mx::GenContext& context, const std::string& shaderName, mx::TypedElementPtr element,
-                        std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
+    virtual bool generateCode(mx::GenContext& context, const std::string& shaderName, mx::TypedElementPtr element,
+                              std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
 
     // Run test for source code generation
     void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath);

--- a/source/MaterialXTest/Render.cpp
+++ b/source/MaterialXTest/Render.cpp
@@ -102,7 +102,7 @@ TEST_CASE("Render: Geometry Handler Load", "[rendercore]")
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             geomHandlerLog << e.what() << " " << error << std::endl;
         }
@@ -203,7 +203,7 @@ TEST_CASE("Render: Image Handler Load", "[rendercore]")
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             imageHandlerLog << e.what() << " " << error << std::endl;
         }

--- a/source/MaterialXTest/RenderGlsl.cpp
+++ b/source/MaterialXTest/RenderGlsl.cpp
@@ -41,8 +41,8 @@ class GlslShaderRenderTester : public RenderUtil::ShaderRenderTester
     }
 
   protected:
-    void loadLibraries(mx::DocumentPtr document,
-                       GenShaderUtil::TestSuiteOptions& options) override;
+    void loadAdditionalLibraries(mx::DocumentPtr document,
+                                 GenShaderUtil::TestSuiteOptions& options) override;
 
     void registerLights(mx::DocumentPtr document, const GenShaderUtil::TestSuiteOptions &options, 
                         mx::GenContext& context) override;
@@ -69,13 +69,13 @@ class GlslShaderRenderTester : public RenderUtil::ShaderRenderTester
 // are loaded in. If no files are specifed in the input options, a sample
 // compound light type and a set of lights in a "light rig" are loaded in to a given
 // document.
-void GlslShaderRenderTester::loadLibraries(mx::DocumentPtr document,
-                                           GenShaderUtil::TestSuiteOptions& options)
+void GlslShaderRenderTester::loadAdditionalLibraries(mx::DocumentPtr document,
+                                                     GenShaderUtil::TestSuiteOptions& options)
 {
     mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/Utilities/Lights");
-    for (auto lightFile : options.lightFiles)
+    for (const auto& lightFile : options.lightFiles)
     {
-        GenShaderUtil::loadLibrary(lightDir / mx::FilePath(lightFile), document);
+        loadLibrary(lightDir / mx::FilePath(lightFile), document);
     }
 }
 
@@ -116,7 +116,7 @@ void GlslShaderRenderTester::createValidator(std::ostream& log)
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             log << e.what() << " " << error << std::endl;
         }
@@ -415,7 +415,7 @@ bool GlslShaderRenderTester::runValidator(const std::string& shaderName,
                     log << "* Uniform UI Properties:" << std::endl;
                     const std::string& target = shadergen.getTarget();
                     const MaterialX::GlslProgram::InputMap& uniforms = program->getUniformsList();
-                    for (auto uniform : uniforms)
+                    for (const auto& uniform : uniforms)
                     {
                         const std::string& path = uniform.second->path;
                         if (path.empty())
@@ -483,7 +483,7 @@ bool GlslShaderRenderTester::runValidator(const std::string& shaderName,
                 file << shader->getSourceCode(mx::Stage::PIXEL);
                 file.close();
 
-                for (auto error : e.errorLog())
+                for (const auto& error : e.errorLog())
                 {
                     log << e.what() << " " << error << std::endl;
                 }

--- a/source/MaterialXTest/RenderOsl.cpp
+++ b/source/MaterialXTest/RenderOsl.cpp
@@ -3,6 +3,7 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
+#include <MaterialXGenShader/Util.h>
 #include <MaterialXGenOsl/OslShaderGenerator.h>
 #include <MaterialXRenderOsl/OslValidator.h>
 
@@ -73,7 +74,7 @@ void OslShaderRenderTester::createValidator(std::ostream& log)
 
             const std::string OSL_EXTENSION("osl");
             mx::FilePathVec files = shaderPath.getFilesInDirectory(OSL_EXTENSION);
-            for (auto file : files)
+            for (const auto& file : files)
             {
                 mx::FilePath filePath = shaderPath / file;
                 _validator->compileOSL(filePath.asString());
@@ -85,7 +86,7 @@ void OslShaderRenderTester::createValidator(std::ostream& log)
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             log << e.what() << " " << error << std::endl;
         }
@@ -126,7 +127,7 @@ bool OslShaderRenderTester::runValidator(const std::string& shaderName,
     {
         log << "------------ Run OSL validation with element: " << element->getNamePath() << "-------------------" << std::endl;
 
-        for (auto options : optionsList)
+        for (const auto& options : optionsList)
         {
             profileTimes.elementsTested++;
 
@@ -287,7 +288,7 @@ bool OslShaderRenderTester::runValidator(const std::string& shaderName,
                 file << shader->getSourceCode();
                 file.close();
 
-                for (auto error : e.errorLog())
+                for (const auto& error : e.errorLog())
                 {
                     log << e.what() << " " << error << std::endl;
                 }

--- a/source/MaterialXTest/RenderUtil.h
+++ b/source/MaterialXTest/RenderUtil.h
@@ -179,8 +179,8 @@ class ShaderRenderTester
     }
 
     // Load any additional libraries requird by the generator
-    virtual void loadLibraries(mx::DocumentPtr /*dependLib*/,
-                               GenShaderUtil::TestSuiteOptions& /*options*/) {};
+    virtual void loadAdditionalLibraries(mx::DocumentPtr /*dependLib*/,
+                                         GenShaderUtil::TestSuiteOptions& /*options*/) {};
 
     //
     // Code generation methods

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -748,6 +748,7 @@ void PropertyEditor::updateContents(Viewer* viewer)
         return;
     }
 
+    const bool showAdvancedItems = viewer->showAdvancedProperties();
     bool addedItems = false;
     const MaterialX::VariableBlock* publicUniforms = material->getPublicUniforms();
     if (publicUniforms)
@@ -766,6 +767,10 @@ void PropertyEditor::updateContents(Viewer* viewer)
             const std::string& folder = it->first;
             const mx::UIPropertyItem& item = it->second;
 
+            if(item.ui.uiAdvanced && !showAdvancedItems)
+            {
+                continue;
+            }
             // Find out if the uniform is editable. Some
             // inputs may be optimized out during compilation.
             if (material->findUniform(item.variable->getPath()))
@@ -781,6 +786,10 @@ void PropertyEditor::updateContents(Viewer* viewer)
         for (auto it2 = unnamedGroups.begin(); it2 != unnamedGroups.end(); ++it2)
         {
             const mx::UIPropertyItem& item = it2->second;
+            if (item.ui.uiAdvanced && !showAdvancedItems)
+            {
+                continue;
+            }
             if (material->findUniform(item.variable->getPath()))
             {
                 addItemToForm(item, addedLabel ? mx::EMPTY_STRING : otherString, _container, viewer, editable);

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -694,7 +694,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                                 mx::StringSet extensions;
                                 handler->supportedExtensions(extensions);
                                 std::vector<std::pair<std::string, std::string>> filetypes;
-                                for (auto extension : extensions)
+                                for (const auto& extension : extensions)
                                 {
                                     filetypes.push_back(std::make_pair(extension, extension));
                                 }

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* const argv[])
     { 
         mx::FilePath("libraries")
     };
-    for (auto libraryPath : libraryPaths)
+    for (const auto& libraryPath : libraryPaths)
     {
         mx::FilePath fullPath(currentPath / libraryPath);
         if (!fullPath.exists())

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -303,7 +303,7 @@ void Material::bindViewInformation(const mx::Matrix44& world, const mx::Matrix44
 
 void Material::unbindImages(mx::GLTextureHandlerPtr imageHandler)
 {
-    for (auto filePath : _boundImages)
+    for (const auto& filePath : _boundImages)
     {
         imageHandler->unbindImage(filePath);
     }
@@ -318,16 +318,9 @@ void Material::bindImages(mx::GLTextureHandlerPtr imageHandler, const mx::FileSe
 
     _boundImages.clear();
 
-    const std::string IMAGE_SEPARATOR("_");
-    const std::string UADDRESS_MODE_POST_FIX("_uaddressmode");
-    const std::string VADDRESS_MODE_POST_FIX("_vaddressmode");
-    const std::string FILTER_TYPE_POST_FIX("_filtertype");
-    const std::string DEFAULT_COLOR_POST_FIX("_default");
-    const int INVALID_MAPPED_INT_VALUE = -1; // Any value < 0 is not considered to be invalid
-
     const mx::VariableBlock* publicUniforms = getPublicUniforms();
     mx::Color4 fallbackColor(0, 0, 0, 1);
-    for (auto uniform : publicUniforms->getVariableOrder())
+    for (const auto& uniform : publicUniforms->getVariableOrder())
     {
         if (uniform->getType() != MaterialX::Type::FILENAME)
         {
@@ -342,43 +335,7 @@ void Material::bindImages(mx::GLTextureHandlerPtr imageHandler, const mx::FileSe
 
         // Extract out sampling properties
         mx::ImageSamplingProperties samplingProperties;
-
-        // Get the additional texture parameters based on image uniform name
-        // excluding the trailing "_file" postfix string
-        std::string root = uniformName;
-        size_t pos = root.find_last_of(IMAGE_SEPARATOR);
-        if (pos != std::string::npos)
-        {
-            root = root.substr(0, pos);
-        }
-
-        const std::string uaddressmodeStr = root + UADDRESS_MODE_POST_FIX;
-        const mx::ShaderPort* port = publicUniforms->find(uaddressmodeStr);
-        mx::ValuePtr intValue = port ? port->getValue() : nullptr;
-        samplingProperties.uaddressMode = mx::ImageSamplingProperties::AddressMode(intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE);
-
-        const std::string vaddressmodeStr = root + VADDRESS_MODE_POST_FIX;
-        port = publicUniforms->find(vaddressmodeStr);
-        intValue = port ? port->getValue() : nullptr;
-        samplingProperties.vaddressMode = mx::ImageSamplingProperties::AddressMode(intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE);
-
-        const std::string filtertypeStr = root + FILTER_TYPE_POST_FIX;
-        port = publicUniforms->find(filtertypeStr);
-        intValue = port ? port->getValue() : nullptr;
-        samplingProperties.filterType = mx::ImageSamplingProperties::FilterType(intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE);
-
-        const std::string defaultColorStr = root + DEFAULT_COLOR_POST_FIX;
-        port = publicUniforms->find(defaultColorStr);
-        mx::ValuePtr colorValue = port ? port->getValue() : nullptr;
-        mx::Color4 defaultColor;
-        if (colorValue)
-        {
-            mx::mapValueToColor(colorValue, defaultColor);
-            samplingProperties.defaultColor[0] = defaultColor[0];
-            samplingProperties.defaultColor[1] = defaultColor[1];
-            samplingProperties.defaultColor[2] = defaultColor[2];
-            samplingProperties.defaultColor[3] = defaultColor[3];
-        }
+        samplingProperties.setProperties(uniformName, *publicUniforms);
 
         mx::ImageDesc desc;
         mx::FilePath resolvedFilename = bindImage(filename, uniformName, imageHandler, desc, samplingProperties, udim, &fallbackColor);
@@ -404,7 +361,7 @@ mx::FilePath Material::bindImage(const mx::FilePath& filePath, const std::string
     if (!udim.empty())
     {
         const mx::StringVec udimSet{ udim };
-        mx::FilePathVec udimPaths = imageHandler->getUdimPaths(filePath, udimSet);
+        mx::FilePathVec udimPaths = mx::getUdimPaths(filePath, udimSet);
         if (!udimPaths.empty())
         {
             resolvedFilename = udimPaths[0];
@@ -511,7 +468,7 @@ void Material::bindLights(mx::LightHandlerPtr lightHandler, mx::GLTextureHandler
     };
     const std::string udim;
     mx::Color4 fallbackColor(0, 0, 0, 1);
-    for (auto pair : lightTextures)
+    for (const auto& pair : lightTextures)
     {
         if (_glShader->uniform(pair.first, false) != -1)
         {
@@ -572,7 +529,7 @@ void Material::bindLights(mx::LightHandlerPtr lightHandler, mx::GLTextureHandler
         }
 
         // Set all inputs
-        for (auto input : light->getInputs())
+        for (const auto& input : light->getInputs())
         {
             // Make sure we have a value to set
             if (input->hasValue())

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -197,6 +197,7 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
     _specularEnvironmentMethod(specularEnvironmentMethod),
     _envSamples(DEFAULT_ENV_SAMPLES),
     _drawEnvironment(false),
+    _showAdvancedProperties(false),
     _captureFrame(false),
     _drawUVGeometry(false),
     _uvScale(2.0f, 2.0f, 1.0f),
@@ -601,6 +602,16 @@ void Viewer::createAdvancedSettings(Widget* parent)
             _envSamples = MIN_ENV_SAMPLES * (int) std::pow(4, index);
         });
     }
+
+    new ng::Label(advancedPopup, "Property Editor Options");
+
+    ng::CheckBox* showAdvancedProperties = new ng::CheckBox(advancedPopup, "Show advanced attributes");
+    showAdvancedProperties->setChecked(_showAdvancedProperties);
+    showAdvancedProperties->setCallback([this](bool enable)
+    {
+        _showAdvancedProperties = enable;
+        updatePropertyEditor();
+    });
 }
 
 void Viewer::updateGeometrySelections()

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -390,7 +390,7 @@ void Viewer::setupLights(mx::DocumentPtr doc)
             // Create a list of unique nodedefs and ids for them
             std::unordered_map<std::string, unsigned int> identifiers;
             _lightHandler->mapNodeDefToIdentiers(lights, identifiers);
-            for (auto id : identifiers)
+            for (const auto& id : identifiers)
             {
                 mx::NodeDefPtr nodeDef = doc->getNodeDef(id.first);
                 if (nodeDef)
@@ -671,7 +671,7 @@ void Viewer::updateGeometrySelections()
 void Viewer::updateMaterialSelections()
 {
     std::vector<std::string> items;
-    for (auto material : _materials)
+    for (const auto& material : _materials)
     {
         mx::ElementPtr displayElem = material->getElement();
         if (displayElem->isA<mx::ShaderRef>())
@@ -783,7 +783,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         mx::ValuePtr udimSetValue = doc->getGeomAttrValue("udimset");
 
         // Create new materials.
-        for (auto renderablePath : renderablePaths)
+        for (const auto& renderablePath : renderablePaths)
         {
             mx::ElementPtr elem = doc->getDescendant(renderablePath);
             mx::TypedElementPtr typedElem = elem ? elem->asA<mx::TypedElement>() : nullptr;
@@ -1038,7 +1038,7 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         if (!extensions.empty())
         {
             std::vector<std::pair<std::string, std::string>> filetypes;
-            for (auto extension : extensions)
+            for (const auto& extension : extensions)
             {
                 filetypes.push_back(std::make_pair(extension, extension));
             }
@@ -1120,7 +1120,7 @@ void Viewer::drawScene3D()
 
     // Opaque pass
     glDisable(GL_BLEND);
-    for (auto assignment : _materialAssignments)
+    for (const auto& assignment : _materialAssignments)
     {
         mx::MeshPartitionPtr geom = assignment.first;
         MaterialPtr material = assignment.second;
@@ -1142,7 +1142,7 @@ void Viewer::drawScene3D()
     // Transparent pass
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    for (auto assignment : _materialAssignments)
+    for (const auto& assignment : _materialAssignments)
     {
         mx::MeshPartitionPtr geom = assignment.first;
         MaterialPtr material = assignment.second;
@@ -1166,7 +1166,7 @@ void Viewer::drawScene3D()
     {
         glEnable(GL_BLEND);
         glBlendFunc(GL_DST_COLOR, GL_ZERO);
-        for (auto assignment : _materialAssignments)
+        for (const auto& assignment : _materialAssignments)
         {
             mx::MeshPartitionPtr geom = assignment.first;
             MaterialPtr material = assignment.second;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -78,13 +78,18 @@ mx::DocumentPtr loadLibraries(const mx::StringVec& libraryFolders, const mx::Fil
         mx::FilePath path = searchPath.find(libraryFolder);
         mx::FilePathVec filenames = path.getFilesInDirectory("mtlx");
 
+        mx::CopyOptions copyOptions;
+        copyOptions.skipConflictingElements = true;
+
+        mx::XmlReadOptions readOptions;
+        readOptions.skipConflictingElements = true;
         for (const std::string& filename : filenames)
         {
             mx::FilePath file = path / filename;
             mx::DocumentPtr libDoc = mx::createDocument();
-            mx::readFromXmlFile(libDoc, file);
+            mx::readFromXmlFile(libDoc, file, mx::EMPTY_STRING, &readOptions);
             libDoc->setSourceUri(file);
-            doc->importLibrary(libDoc);
+            doc->importLibrary(libDoc, &copyOptions);
         }
     }
     return doc;
@@ -357,9 +362,14 @@ void Viewer::setupLights(mx::DocumentPtr doc)
     {
         try
         {
-            mx::readFromXmlFile(lightDoc, path.asString());
+            mx::XmlReadOptions readOptions;
+            readOptions.skipConflictingElements = true;
+            mx::readFromXmlFile(lightDoc, path.asString(), mx::EMPTY_STRING, &readOptions);
             lightDoc->setSourceUri(path);
-            doc->importLibrary(lightDoc);
+
+            mx::CopyOptions copyOptions;
+            copyOptions.skipConflictingElements = true;
+            doc->importLibrary(lightDoc, &copyOptions);
         }
         catch (std::exception& e)
         {
@@ -726,6 +736,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
 {
     // Set up read options.
     mx::XmlReadOptions readOptions;
+    readOptions.skipConflictingElements = true;
     readOptions.readXIncludeFunction = [](mx::DocumentPtr doc, const std::string& filename,
                                           const std::string& searchPath, const mx::XmlReadOptions* options)
     {
@@ -764,7 +775,8 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         mx::readFromXmlFile(doc, filename, _searchPath.asString(), &readOptions);
 
         // Import libraries.
-        mx::CopyOptions copyOptions;
+        mx::CopyOptions copyOptions; 
+        copyOptions.skipConflictingElements = true;
         doc->importLibrary(libraries, &copyOptions);
 
         // Add lighting 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -76,6 +76,11 @@ class Viewer : public ng::Screen
         return _imageHandler;
     }
 
+    bool showAdvancedProperties() const
+    {
+        return _showAdvancedProperties;
+    }
+
   private:
     void drawScene3D();
     void drawScene2D();
@@ -186,6 +191,9 @@ class Viewer : public ng::Screen
     int _envSamples;
     bool _drawEnvironment;
     mx::Matrix44 _envMatrix;
+
+    // Property options
+    bool _showAdvancedProperties;
 
     // Image save
     bool _captureFrame;


### PR DESCRIPTION
General:
- Fixes for auto non-const usage in iterators

ShaderGen:
- Sanitize all generated identifiers during code generation. 
- UDIM transform support (for tiled atlases) + UDIM computation utilities
- Fix utility for transparency detection to test for bindinputs which set for nodedef inputs which are marked as interfaces (vs assuming any interface is tranparent).

File Management:
- Library path read / include cleanup.
- Add additional skips for read/import since read can have includes, and includes can still conflict.

Test:
- Add external library path and test root options to unit test framework (_options.mtlx)

UI:
- Add in `uiadvanced` option support for Property Editor in viewer.