### PR TITLE
Fix for OSL implementation of mx_roughness_dual.

### DIFF
--- a/libraries/pbrlib/genosl/mx_roughness_dual.osl
+++ b/libraries/pbrlib/genosl/mx_roughness_dual.osl
@@ -1,9 +1,5 @@
 void mx_roughness_dual(vector2 roughness, output vector2 result)
 {
-    if (roughness.y < 0.0)
-    {
-        roughness.y = roughness.x;
-    }
     result.x = clamp(roughness.x * roughness.x, M_FLOAT_EPS, 1.0);
     if (roughness.y < 0.0)
     {

--- a/libraries/pbrlib/genosl/mx_roughness_dual.osl
+++ b/libraries/pbrlib/genosl/mx_roughness_dual.osl
@@ -5,5 +5,12 @@ void mx_roughness_dual(vector2 roughness, output vector2 result)
         roughness.y = roughness.x;
     }
     result.x = clamp(roughness.x * roughness.x, M_FLOAT_EPS, 1.0);
-    result.y = clamp(roughness.y * roughness.y, M_FLOAT_EPS, 1.0);
+    if (roughness.y < 0.0)
+    {
+        result.y = result.x;
+    }
+    else
+    {
+        result.y = clamp(roughness.y * roughness.y, M_FLOAT_EPS, 1.0);
+    }
 }


### PR DESCRIPTION
Fix for OSL implementation of mx_roughness_dual. Avoid error if the function attempts to overwrite the input parameter reference when that parameter is a shader input.