### PR TITLE
Add "Save" option to Viewer

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -190,6 +190,19 @@ void Document::importLibrary(const ConstDocumentPtr& library, const CopyOptions*
     }
 }
 
+StringSet Document::getReferencedSourceUris() const
+{
+    StringSet sourceUris;
+    for (ElementPtr elem : traverseTree())
+    {
+        if (elem->hasSourceUri())
+        {
+            sourceUris.insert(elem->getSourceUri());
+        }
+    }
+    return sourceUris;
+}
+
 std::pair<int, int> Document::getVersionIntegers() const
 {
     if (!hasVersionString())

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -65,6 +65,9 @@ class Document : public GraphElement
     ///    import function.  Defaults to a null pointer.
     void importLibrary(const ConstDocumentPtr& library, const CopyOptions* copyOptions = nullptr);
 
+    /// Get a list of source URI's referenced by the document
+    StringSet getReferencedSourceUris() const;
+
     /// @}
     /// @name NodeGraph Elements
     /// @{

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -93,6 +93,10 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
             {
                 uiProperties.enumerationValues.push_back(Value::createValue(enumerationValues));
             }
+            if(uiProperties.enumeration.size() != uiProperties.enumerationValues.size())
+            {
+                throw std::runtime_error("Every enum must have a value!");
+            }
             propertyCount++;
         }
     }

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -93,7 +93,7 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
             {
                 uiProperties.enumerationValues.push_back(Value::createValue(enumerationValues));
             }
-            if(uiProperties.enumeration.size() != uiProperties.enumerationValues.size())
+            if (uiProperties.enumeration.size() != uiProperties.enumerationValues.size())
             {
                 throw std::runtime_error("Every enum must have a value!");
             }
@@ -125,7 +125,7 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
 
     const string& uiAdvancedString = nodeDefElement->getAttribute(ValueElement::UI_ADVANCED_ATTRIBUTE);
     uiProperties.uiAdvanced = (uiAdvancedString == "true");
-    if(!uiAdvancedString.empty())
+    if (!uiAdvancedString.empty())
     {
         propertyCount++;
     }

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -86,12 +86,11 @@ void ShaderRenderTester::loadDependentLibraries(GenShaderUtil::TestSuiteOptions 
     mx::loadLibraries(libraries, searchPath, dependLib, nullptr);
     for (size_t i = 0; i < options.externalLibraryPaths.size(); i++)
     {
-        const mx::FilePath& extraPath = options.externalLibraryPaths[i];
-        mx::FilePathVec libraryFiles  = extraPath.getFilesInDirectory("mtlx");
-        for (size_t l = 0; l < libraryFiles.size(); l++)
+        const mx::FilePath& libraryPath = options.externalLibraryPaths[i];
+        for (const mx::FilePath& libraryFile : libraryPath.getFilesInDirectory("mtlx"))
         {
-            std::cout << "Extra library path: " << (extraPath / libraryFiles[l]).asString() << std::endl;
-            mx::loadLibrary((extraPath / libraryFiles[l]), dependLib);
+            std::cout << "Extra library path: " << (libraryPath / libraryFile).asString() << std::endl;
+            mx::loadLibrary((libraryPath / libraryFile), dependLib);
         }
     }
 

--- a/source/MaterialXTest/RenderUtil.h
+++ b/source/MaterialXTest/RenderUtil.h
@@ -178,6 +178,10 @@ class ShaderRenderTester
         _skipFiles.insert("default_viewer_lights.mtlx");
     }
 
+    // Load dependencies
+    void loadDependentLibraries(GenShaderUtil::TestSuiteOptions options, mx::FilePath searchPath,
+                             mx::DocumentPtr& dependLib);
+
     // Load any additional libraries requird by the generator
     virtual void loadAdditionalLibraries(mx::DocumentPtr /*dependLib*/,
                                          GenShaderUtil::TestSuiteOptions& /*options*/) {};

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -81,11 +81,11 @@ class MyColorPicker : public ng::ColorPicker
 //
 
 PropertyEditor::PropertyEditor() :
-    _visible(false),
     _container(nullptr),
     _formWindow(nullptr),
     _gridLayout2(nullptr),
     _gridLayout3(nullptr),
+    _visible(false),
     _fileDialogsForImages(true)
 {
 }
@@ -647,7 +647,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             ng::Widget* twoColumns = new ng::Widget(container);
             twoColumns->setLayout(_gridLayout2);
 
-            if (item.variable->getType() == MaterialX::Type::FILENAME)
+            if (item.variable->getType() == mx::Type::FILENAME)
             {
                 new ng::Label(twoColumns, label);
                 ng::Button* buttonVar = new ng::Button(twoColumns, mx::FilePath(v).getBaseName());
@@ -659,7 +659,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                     mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
                     if (uniform)
                     {
-                        if (uniform->getType() == MaterialX::Type::FILENAME)
+                        if (uniform->getType() == mx::Type::FILENAME)
                         {
                             const mx::GLTextureHandlerPtr handler = viewer->getImageHandler();
                             if (handler)
@@ -709,13 +709,7 @@ void PropertyEditor::updateContents(Viewer* viewer)
     create(*viewer);
 
     MaterialPtr material = viewer->getSelectedMaterial();
-    mx::TypedElementPtr materialElement = material ? material->getElement() : nullptr;
-    if (!materialElement)
-    {
-        return;
-    }
-
-    mx::DocumentPtr doc = material->getDocument();
+    mx::DocumentPtr doc = material ? material->getDocument() : nullptr;
     if (!doc)
     {
         return;
@@ -723,13 +717,13 @@ void PropertyEditor::updateContents(Viewer* viewer)
 
     const bool showAdvancedItems = viewer->showAdvancedProperties();
     bool addedItems = false;
-    const MaterialX::VariableBlock* publicUniforms = material->getPublicUniforms();
+    const mx::VariableBlock* publicUniforms = material->getPublicUniforms();
     if (publicUniforms)
     {
         mx::UIPropertyGroup groups;
         mx::UIPropertyGroup unnamedGroups;
         const std::string pathSeparator(":");
-        mx::createUIPropertyGroups(*publicUniforms, doc, materialElement,
+        mx::createUIPropertyGroups(*publicUniforms, doc, material->getElement(),
                                     pathSeparator, groups, unnamedGroups); 
 
         std::string previousFolder;

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -218,18 +218,18 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         auto indexInEnumeration = [&value, &enumValues, &enumeration]()
         {
             size_t index = 0;
-            for(auto& enumValue: enumValues)
+            for (auto& enumValue: enumValues)
             {
-                if(value->getValueString() == enumValue->getValueString())
+                if (value->getValueString() == enumValue->getValueString())
                 {
                     return index;
                 }
                 index++;
             }
             index = 0;
-            for(auto& enumName: enumeration)
+            for (auto& enumName: enumeration)
             {
-                if(value->getValueString() == enumName)
+                if (value->getValueString() == enumName)
                 {
                     return index;
                 }
@@ -255,11 +255,11 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             comboBox->setCallback([path, viewer, enumeration, enumValues](int index)
             {
                 MaterialPtr material = viewer->getSelectedMaterial();
-                if(index >= 0 && static_cast<size_t>(index) < enumValues.size())
+                if (index >= 0 && static_cast<size_t>(index) < enumValues.size())
                 {
                     material->setUniformInt(path, enumValues[index]->asA<int>());
                 }
-                else if(index >= 0 && static_cast<size_t>(index) < enumeration.size())
+                else if (index >= 0 && static_cast<size_t>(index) < enumeration.size())
                 {
                     material->setUniformEnum(path, index, enumeration[index]);
                 }
@@ -308,7 +308,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         boolVar->setCallback([path, viewer](bool v)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            if(material)
+            if (material)
             {
                 material->setUniformFloat(path, v);
             }
@@ -334,7 +334,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         colorVar->setFinalCallback([path, viewer, colorVar](const ng::Color &c)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            if(material)
+            if (material)
             {
                 ng::Vector2f v;
                 v.x() = c.r();
@@ -734,7 +734,7 @@ void PropertyEditor::updateContents(Viewer* viewer)
             const std::string& folder = it->first;
             const mx::UIPropertyItem& item = it->second;
 
-            if(item.ui.uiAdvanced && !showAdvancedItems)
+            if (item.ui.uiAdvanced && !showAdvancedItems)
             {
                 continue;
             }

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -81,11 +81,11 @@ class MyColorPicker : public ng::ColorPicker
 //
 
 PropertyEditor::PropertyEditor() :
+    _visible(false),
     _container(nullptr),
     _formWindow(nullptr),
     _gridLayout2(nullptr),
     _gridLayout3(nullptr),
-    _visible(false),
     _fileDialogsForImages(true)
 {
 }
@@ -166,22 +166,18 @@ ng::FloatBox<float>* PropertyEditor::makeFloatWidget(ng::Widget* container, cons
     {
         floatVar->setValue(value);
         MaterialPtr material = viewer->getSelectedMaterial();
-        mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-        if (uniform)
+        if (material)
         {
-            material->getShader()->bind();
-            material->getShader()->setUniform(uniform->getVariable(), value);
+            material->setUniformFloat(path, value);            
         }
     });
     floatVar->setCallback([slider, path, viewer](float value)
     {
         slider->setValue(value);
         MaterialPtr material = viewer->getSelectedMaterial();
-        mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-        if (uniform)
+        if (material)
         {
-            material->getShader()->bind();
-            material->getShader()->setUniform(uniform->getVariable(), value);
+            material->setUniformFloat(path, value);
         }
     });
 
@@ -218,13 +214,34 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
     // Integer input. Can map to a combo box if an enumeration
     if (value->isA<int>())
     {
-        int v = value->asA<int>();
+        const size_t INVALID_INDEX = std::numeric_limits<size_t>::max();
+        auto indexInEnumeration = [&value, &enumValues, &enumeration]()
+        {
+            size_t index = 0;
+            for(auto& enumValue: enumValues)
+            {
+                if(value->getValueString() == enumValue->getValueString())
+                {
+                    return index;
+                }
+                index++;
+            }
+            index = 0;
+            for(auto& enumName: enumeration)
+            {
+                if(value->getValueString() == enumName)
+                {
+                    return index;
+                }
+                index++;
+            }
+            return std::numeric_limits<size_t>::max(); // INVALID_INDEX;
+        };
 
         // Create a combo box. The items are the enumerations in order.
-        if (v < (int) enumeration.size())
+        const size_t valueIndex = indexInEnumeration();
+        if (INVALID_INDEX != valueIndex)
         {
-            std::string enumValue = enumeration[v];
-
             ng::Widget* twoColumns = new ng::Widget(container);
             twoColumns->setLayout(_gridLayout2);
 
@@ -232,24 +249,19 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             ng::ComboBox* comboBox = new ng::ComboBox(twoColumns, {""});
             comboBox->setEnabled(editable);
             comboBox->setItems(enumeration);
-            comboBox->setSelectedIndex(v);
+            comboBox->setSelectedIndex(static_cast<int>(valueIndex));
             comboBox->setFixedSize(ng::Vector2i(100, 20));
             comboBox->setFontSize(15);
-            comboBox->setCallback([path, viewer, enumValues](int v)
+            comboBox->setCallback([path, viewer, enumeration, enumValues](int index)
             {
                 MaterialPtr material = viewer->getSelectedMaterial();
-                mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-                if (uniform)
+                if(index >= 0 && static_cast<size_t>(index) < enumValues.size())
                 {
-                    material->getShader()->bind();
-                    if (v < (int) enumValues.size())
-                    {
-                        material->getShader()->setUniform(uniform->getVariable(), enumValues[v]->asA<int>());
-                    }
-                    else
-                    {
-                        material->getShader()->setUniform(uniform->getVariable(), v);
-                    }
+                    material->setUniformInt(path, enumValues[index]->asA<int>());
+                }
+                else if(index >= 0 && static_cast<size_t>(index) < enumeration.size())
+                {
+                    material->setUniformEnum(path, index, enumeration[index]);
                 }
             });
         }
@@ -268,12 +280,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                 MaterialPtr material = viewer->getSelectedMaterial();
                 if (material)
                 {
-                    mx::ShaderPort* uniform = material->findUniform(path);
-                    if (uniform)
-                    {
-                        material->getShader()->bind();
-                        material->getShader()->setUniform(uniform->getVariable(), v);
-                    }
+                    material->setUniformInt(path, v);
                 }
             });
         }
@@ -301,11 +308,9 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         boolVar->setCallback([path, viewer](bool v)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if(material)
             {
-                material->getShader()->bind();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformFloat(path, v);
             }
         });
     }
@@ -329,14 +334,12 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         colorVar->setFinalCallback([path, viewer, colorVar](const ng::Color &c)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if(material)
             {
-                material->getShader()->bind();
                 ng::Vector2f v;
                 v.x() = c.r();
                 v.y() = c.g();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec2(path, v);
                 ng::Color c2 = c;
                 c2.b() = 0.0f;
                 c2.w() = 1.0f;
@@ -378,10 +381,8 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             comboBox->setCallback([path, enumValues, viewer](int index)
             {
                 MaterialPtr material = viewer->getSelectedMaterial();
-                mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-                if (uniform)
+                if (material)
                 {
-                    material->getShader()->bind();
                     if (index < (int) enumValues.size())
                     {
                         mx::Color3 c = enumValues[index]->asA<mx::Color3>();
@@ -389,7 +390,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                         v.x() = c[0];
                         v.y() = c[1];
                         v.z() = c[2];
-                        material->getShader()->setUniform(uniform->getVariable(), v);
+                        material->setUniformVec3(path, v);
                     }
                 }
             });
@@ -410,16 +411,11 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             colorVar->setFinalCallback([path, viewer](const ng::Color &c)
             {
                 MaterialPtr material = viewer->getSelectedMaterial();
-                mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-                if (uniform)
-                {
-                    material->getShader()->bind();
-                    ng::Vector3f v;
-                    v.x() = c.r();
-                    v.y() = c.g();
-                    v.z() = c.b();
-                    material->getShader()->setUniform(uniform->getVariable(), v);
-                }
+                ng::Vector3f v;
+                v[0] = c.r();
+                v[1] = c.g();
+                v[2] = c.b();
+                material->setUniformVec3(path, v);
             });
         }
     }
@@ -443,16 +439,14 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         colorVar->setFinalCallback([path, viewer](const ng::Color &c)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
-                material->getShader()->bind();
                 ng::Vector4f v;
                 v.x() = c.r();
                 v.y() = c.g();
                 v.z() = c.b();
                 v.w() = c.w();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec4(path, v);
             }
         });
     }
@@ -475,28 +469,25 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         v1->setCallback([v2, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
-                material->getShader()->bind();
                 ng::Vector2f v;
                 v.x() = f;
                 v.y() = v2->value();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec2(path, v);
             }
         });
         v1->setSpinnable(editable);
         v2->setCallback([v1, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
                 material->getShader()->bind();
                 ng::Vector2f v;
                 v.x() = v1->value();
                 v.y() = f;
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec2(path, v);
             }
         });
         v2->setSpinnable(editable);
@@ -525,45 +516,41 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         v1->setCallback([v2, v3, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
                 material->getShader()->bind();
                 ng::Vector3f v;
                 v.x() = f;
                 v.y() = v2->value();
                 v.z() = v3->value();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec3(path, v);
             }
         });
         v1->setSpinnable(editable);
         v2->setCallback([v1, v3, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
                 material->getShader()->bind();
                 ng::Vector3f v;
                 v.x() = v1->value();
                 v.y() = f;
                 v.z() = v3->value();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec3(path, v);
             }
         });
         v2->setSpinnable(editable);
         v3->setCallback([v1, v2, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
-                material->getShader()->bind();
                 ng::Vector3f v;
                 v.x() = v1->value();
                 v.y() = v2->value();
                 v.z() = f;
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec3(path, v);
             }
         });
         v3->setSpinnable(editable);
@@ -596,64 +583,56 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         v1->setCallback([v2, v3, v4, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
-                material->getShader()->bind();
                 ng::Vector4f v;
                 v.x() = f;
                 v.y() = v2->value();
                 v.z() = v3->value();
                 v.w() = v4->value();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec4(path, v);
             }
         });
         v1->setSpinnable(editable);
         v2->setCallback([v1, v3, v4, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
-                material->getShader()->bind();
                 ng::Vector4f v;
                 v.x() = v1->value();
                 v.y() = f;
                 v.z() = v3->value();
                 v.w() = v4->value();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec4(path, v);
             }
         });
         v2->setSpinnable(editable);
         v3->setCallback([v1, v2, v4, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
-                material->getShader()->bind();
                 ng::Vector4f v;
                 v.x() = v1->value();
                 v.y() = v2->value();
                 v.z() = f;
                 v.w() = v4->value();
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec4(path, v);
             }
         });
         v3->setSpinnable(editable);
         v4->setCallback([v1, v2, v3, path, viewer](float f)
         {
             MaterialPtr material = viewer->getSelectedMaterial();
-            mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
-            if (uniform)
+            if (material)
             {
-                material->getShader()->bind();
                 ng::Vector4f v;
                 v.x() = v1->value();
                 v.y() = v2->value();
                 v.z() = v3->value();
                 v.w() = f;
-                material->getShader()->setUniform(uniform->getVariable(), v);
+                material->setUniformVec4(path, v);
             }
         });
         v4->setSpinnable(editable);
@@ -668,7 +647,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             ng::Widget* twoColumns = new ng::Widget(container);
             twoColumns->setLayout(_gridLayout2);
 
-            if (item.variable->getType() == mx::Type::FILENAME)
+            if (item.variable->getType() == MaterialX::Type::FILENAME)
             {
                 new ng::Label(twoColumns, label);
                 ng::Button* buttonVar = new ng::Button(twoColumns, mx::FilePath(v).getBaseName());
@@ -680,7 +659,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                     mx::ShaderPort* uniform = material ? material->findUniform(path) : nullptr;
                     if (uniform)
                     {
-                        if (uniform->getType() == mx::Type::FILENAME)
+                        if (uniform->getType() == MaterialX::Type::FILENAME)
                         {
                             const mx::GLTextureHandlerPtr handler = viewer->getImageHandler();
                             if (handler)
@@ -730,7 +709,13 @@ void PropertyEditor::updateContents(Viewer* viewer)
     create(*viewer);
 
     MaterialPtr material = viewer->getSelectedMaterial();
-    mx::DocumentPtr doc = material ? material->getDocument() : nullptr;
+    mx::TypedElementPtr materialElement = material ? material->getElement() : nullptr;
+    if (!materialElement)
+    {
+        return;
+    }
+
+    mx::DocumentPtr doc = material->getDocument();
     if (!doc)
     {
         return;
@@ -738,13 +723,13 @@ void PropertyEditor::updateContents(Viewer* viewer)
 
     const bool showAdvancedItems = viewer->showAdvancedProperties();
     bool addedItems = false;
-    const mx::VariableBlock* publicUniforms = material->getPublicUniforms();
+    const MaterialX::VariableBlock* publicUniforms = material->getPublicUniforms();
     if (publicUniforms)
     {
         mx::UIPropertyGroup groups;
         mx::UIPropertyGroup unnamedGroups;
         const std::string pathSeparator(":");
-        mx::createUIPropertyGroups(*publicUniforms, doc, material->getElement(),
+        mx::createUIPropertyGroups(*publicUniforms, doc, materialElement,
                                     pathSeparator, groups, unnamedGroups); 
 
         std::string previousFolder;

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -612,7 +612,7 @@ mx::ShaderPort* Material::findUniform(const std::string& path) const
 
 void Material::changeUniformElement(mx::ShaderPort* uniform, const std::string& value)
 {
-    if (nullptr == uniform)
+    if (!uniform)
     {
         throw std::runtime_error("Null ShaderPort");
     }

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -609,3 +609,97 @@ mx::ShaderPort* Material::findUniform(const std::string& path) const
     }
     return port;
 }
+
+void Material::changeUniformElement(mx::ShaderPort* uniform, const std::string& value)
+{
+    if (nullptr == uniform)
+    {
+        throw std::runtime_error("Null ShaderPort");
+    }
+    uniform->setValue(mx::Value::createValueFromStrings(value, uniform->getType()->getName()));
+    mx::ElementPtr element = _doc->getDescendant(uniform->getPath());
+    if (element)
+    {
+        mx::ValueElementPtr valueElement = element->asA<MaterialX::ValueElement>();
+        if (valueElement)
+        {
+            valueElement->setValueString(value);
+        }
+    }
+}
+
+void Material::setUniformInt(const std::string& path, int value)
+{
+    mx::ShaderPort* uniform = findUniform(path);
+    if (uniform)
+    {
+        getShader()->bind();
+        getShader()->setUniform(uniform->getVariable(), value);
+        std::stringstream intValue;
+        intValue << value;
+        changeUniformElement(uniform, intValue.str());
+    }
+}
+
+void Material::setUniformFloat(const std::string& path, float value)
+{
+    mx::ShaderPort* uniform = findUniform(path);
+    if (uniform)
+    {
+        getShader()->bind();
+        getShader()->setUniform(uniform->getVariable(), value);
+        std::stringstream floatValue;
+        floatValue << value;
+        changeUniformElement(uniform, floatValue.str());
+    }
+}
+
+void Material::setUniformVec2(const std::string& path, const ng::Vector2f& value)
+{
+    mx::ShaderPort* uniform = findUniform(path);
+    if (uniform)
+    {
+        getShader()->bind();
+        getShader()->setUniform(uniform->getVariable(), value);
+        std::stringstream vec2Value;
+        vec2Value << value[0] << mx::ARRAY_VALID_SEPARATORS << value[1];
+        changeUniformElement(uniform, vec2Value.str());
+    }
+}
+
+void Material::setUniformVec3(const std::string& path, const ng::Vector3f& value)
+{
+    mx::ShaderPort* uniform = findUniform(path);
+    if (uniform)
+    {        
+        getShader()->bind();
+        getShader()->setUniform(uniform->getVariable(), value);
+        std::stringstream vec3Value;
+        vec3Value << value[0] << mx::ARRAY_VALID_SEPARATORS << value[1] << mx::ARRAY_VALID_SEPARATORS << value[2];
+        changeUniformElement(uniform, vec3Value.str());
+    }    
+}
+
+void Material::setUniformVec4(const std::string& path, const ng::Vector4f& value)
+{
+    mx::ShaderPort* uniform = findUniform(path);
+    if (uniform)
+    {
+        getShader()->bind();
+        getShader()->setUniform(uniform->getVariable(), value);
+        std::stringstream vec4Value;        
+        vec4Value << value[0] << mx::ARRAY_VALID_SEPARATORS << value[1] << mx::ARRAY_VALID_SEPARATORS << value[2] << mx::ARRAY_VALID_SEPARATORS << value[3];
+        changeUniformElement(uniform, vec4Value.str());
+    }
+}
+
+void Material::setUniformEnum(const std::string& path, int index, const std::string& value)
+{
+    mx::ShaderPort* uniform = findUniform(path);
+    if (uniform)
+    {
+        getShader()->bind();
+        getShader()->setUniform(uniform->getVariable(), index);
+        changeUniformElement(uniform, value);
+    }
+}

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -322,7 +322,7 @@ void Material::bindImages(mx::GLTextureHandlerPtr imageHandler, const mx::FileSe
     mx::Color4 fallbackColor(0, 0, 0, 1);
     for (const auto& uniform : publicUniforms->getVariableOrder())
     {
-        if (uniform->getType() != MaterialX::Type::FILENAME)
+        if (uniform->getType() != mx::Type::FILENAME)
         {
             continue;
         }
@@ -620,7 +620,7 @@ void Material::changeUniformElement(mx::ShaderPort* uniform, const std::string& 
     mx::ElementPtr element = _doc->getDescendant(uniform->getPath());
     if (element)
     {
-        mx::ValueElementPtr valueElement = element->asA<MaterialX::ValueElement>();
+        mx::ValueElementPtr valueElement = element->asA<mx::ValueElement>();
         if (valueElement)
         {
             valueElement->setValueString(value);

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -167,22 +167,22 @@ class Material
     /// Change the uniform value inside the shader and the associated element in the MaterialX document.
     void changeUniformElement(mx::ShaderPort* uniform, const std::string& value);
 
-    /// Set the value for an element with a given path.
+    /// Set the value for an integer element with a given path.
     void setUniformInt(const std::string& path, int value);
 
-    /// Set the value for an element with a given path.
+    /// Set the value for a float element with a given path.
     void setUniformFloat(const std::string& path, float value);
 
-    /// Set the value for an element with a given path.
+    /// Set the value for a vector2 element with a given path.
     void setUniformVec2(const std::string& path, const ng::Vector2f& value);
 
-    /// Set the value for an element with a given path.
+    /// Set the value for a vector3 element with a given path.
     void setUniformVec3(const std::string& path, const ng::Vector3f& value);
 
-    /// Set the value for an element with a given path.
+    /// Set the value for a vector4 element with a given path.
     void setUniformVec4(const std::string& path, const ng::Vector4f& value);
 
-    /// Set the value for an element with a given path.
+    /// Set the value for an enumerated element with a given path.
     void setUniformEnum(const std::string& path, int index, const std::string& value);
 
   protected:

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -164,6 +164,27 @@ class Material
     /// Find a public uniform from its MaterialX path.
     mx::ShaderPort* findUniform(const std::string& path) const;
 
+    /// Change the uniform value inside the shader and the associated element in the MaterialX document.
+    void changeUniformElement(mx::ShaderPort* uniform, const std::string& value);
+
+    /// Set the value for an element with a given path.
+    void setUniformInt(const std::string& path, int value);
+
+    /// Set the value for an element with a given path.
+    void setUniformFloat(const std::string& path, float value);
+
+    /// Set the value for an element with a given path.
+    void setUniformVec2(const std::string& path, const ng::Vector2f& value);
+
+    /// Set the value for an element with a given path.
+    void setUniformVec3(const std::string& path, const ng::Vector3f& value);
+
+    /// Set the value for an element with a given path.
+    void setUniformVec4(const std::string& path, const ng::Vector4f& value);
+
+    /// Set the value for an element with a given path.
+    void setUniformEnum(const std::string& path, int index, const std::string& value);
+
   protected:
     void bindUniform(const std::string& name, mx::ConstValuePtr value);
     void updateUniformsList();

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -544,7 +544,7 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
             mx::XmlWriteOptions writeOptions;
             writeOptions.writeXIncludeEnable = true;
             writeOptions.elementPredicate = skipXincludes;
-            MaterialX::writeToXmlFile(doc, filename, &writeOptions);
+            mx::writeToXmlFile(doc, filename, &writeOptions);
         }
 
         // Update material file name

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -532,8 +532,18 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
         if (!filename.empty() && !_materials.empty())
         {
             mx::DocumentPtr doc = _materials.front()->getDocument();
+            // Add element predicate to prune out writing elements from included files
+            auto skipXincludes = [this](mx::ConstElementPtr elem)
+            {
+                if (elem->hasSourceUri())
+                {
+                    return (std::find(_xincludeFiles.begin(), _xincludeFiles.end(), elem->getSourceUri()) == _xincludeFiles.end());
+                }
+                return true;
+            };
             mx::XmlWriteOptions writeOptions;
-            writeOptions.ignoredXIncludes = _xincludeFiles;
+            writeOptions.writeXIncludeEnable = true;
+            writeOptions.elementPredicate = skipXincludes;
             MaterialX::writeToXmlFile(doc, filename, &writeOptions);
         }
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -107,6 +107,8 @@ class Viewer : public ng::Screen
 
     void createLoadMeshInterface(Widget* parent, const std::string& label);
     void createLoadMaterialsInterface(Widget* parent, const std::string& label);
+    void createSaveMaterialsInterface(Widget* parent, const std::string& label);
+    void createPropertyEditorInterface(Widget* parent, const std::string& label);
     void createAdvancedSettings(Widget* parent);
 
     mx::MeshStreamPtr createUvPositionStream(mx::MeshPtr mesh, 
@@ -139,6 +141,7 @@ class Viewer : public ng::Screen
     mx::DocumentPtr _stdLib;
     mx::FilePath _materialFilename;
     DocumentModifiers _modifiers;
+    mx::StringVec _xincludeFiles;
 
     // Lighting information
     std::string _lightFileName;

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -141,7 +141,7 @@ class Viewer : public ng::Screen
     mx::DocumentPtr _stdLib;
     mx::FilePath _materialFilename;
     DocumentModifiers _modifiers;
-    mx::StringVec _xincludeFiles;
+    mx::StringSet _xincludeFiles;
 
     // Lighting information
     std::string _lightFileName;

--- a/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
@@ -17,8 +17,9 @@ void bindPyDocument(py::module& mod)
     py::class_<mx::Document, mx::DocumentPtr, mx::GraphElement>(mod, "Document")
         .def("initialize", &mx::Document::initialize)
         .def("copy", &mx::Document::copy)
-        .def("importLibrary", &mx::Document::importLibrary, 
+        .def("importLibrary", &mx::Document::importLibrary,
             py::arg("library"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
+        .def("getReferencedSourceUris", &mx::Document::getReferencedSourceUris)
         .def("addNodeGraph", &mx::Document::addNodeGraph,
             py::arg("name") = mx::EMPTY_STRING)
         .def("getNodeGraph", &mx::Document::getNodeGraph)


### PR DESCRIPTION
- Explicitly library load will keep track of the list of libraries loaded.
- Property editor now updates both the shader uniform (for immediate shader feedback without recompiling) as well as the associated document element.
- New "Save" UI menu item. 
- Save uses an element predicate to prune out any elements which belong to libraries which are explicitly loaded.
- Add unit test for sourceUri and hence xinclude pruning (as if all elements of a given include are pruned out then no xinclude will be written into the document).
