### PR TITLE
Add support for value construction from string literals

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1037,6 +1037,12 @@ class ValueElement : public TypedElement
         setValueString(toValueString(value));
     }
 
+    /// Set the typed value of an element from a string literal.
+    void setValue(const char* value, const string& type = EMPTY_STRING)
+    {
+        setValue(string(value), type);
+    }
+
     /// Return true if the element possesses a typed value.
     bool hasValue() const
     {

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -183,6 +183,11 @@ template <class T> string toValueString(const T& data)
     return value;
 }
 
+string toValueString(const char* data)
+{
+    return toValueString(string(data));
+}
+
 template <class T> T fromValueString(const string& value)
 {
     T data;

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -49,6 +49,12 @@ class Value
         return std::make_shared< TypedValue<T> >(data);
     }
 
+    // Create a new value from a string literal.
+    static ValuePtr createValue(const char* data)
+    {
+        return createValue(string(data));
+    }
+
     /// Create a new value instance from value and type strings.
     /// @return A shared pointer to a typed value, or an empty shared pointer
     ///    if the conversion to the given data type cannot be performed.

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -144,10 +144,6 @@ bool GLTextureHandler::acquireImage(const FilePath& filePath,
             glBindTexture(GL_TEXTURE_2D, imageDesc.resourceId);
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, imageDesc.width, imageDesc.height, 0,
                 GL_RGBA, GL_FLOAT, imageDesc.resourceBuffer);
-            if (generateMipMaps)
-            {
-                glGenerateMipmap(GL_TEXTURE_2D);
-            }
             glBindTexture(GL_TEXTURE_2D, 0);
         }
         imageDesc.freeResourceBuffer();

--- a/source/MaterialXTest/Geom.cpp
+++ b/source/MaterialXTest/Geom.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Geom elements", "[geom]")
     nodeGraph->setFilePrefix("folder/");
     REQUIRE_THROWS_AS(doc->addNodeGraph(nodeGraph->getName()), mx::Exception&);
     mx::NodePtr image = nodeGraph->addNode("image");
-    image->setParameterValue("file", std::string("<asset><id>_diffuse_<UDIM>.tif"), mx::FILENAME_TYPE_STRING);
+    image->setParameterValue("file", "<asset><id>_diffuse_<UDIM>.tif", mx::FILENAME_TYPE_STRING);
 
     // Test filename string substitutions.
     mx::ParameterPtr fileParam = image->getParameter("file");

--- a/source/MaterialXTest/Material.cpp
+++ b/source/MaterialXTest/Material.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Material", "[material]")
     mx::InputPtr diffColor = simpleSrf->setInputValue("diffColor", mx::Color3(1.0f));
     mx::InputPtr specColor = simpleSrf->setInputValue("specColor", mx::Color3(0.0f));
     mx::ParameterPtr roughness = simpleSrf->setParameterValue("roughness", 0.25f);
-    mx::TokenPtr texId = simpleSrf->setTokenValue("texId", std::string("01"));
+    mx::TokenPtr texId = simpleSrf->setTokenValue("texId", "01");
     REQUIRE(simpleSrf->getInputValue("diffColor")->asA<mx::Color3>() == mx::Color3(1.0f));
     REQUIRE(simpleSrf->getInputValue("specColor")->asA<mx::Color3>() == mx::Color3(0.0f));
     REQUIRE(simpleSrf->getParameterValue("roughness")->asA<float>() == 0.25f);
@@ -68,7 +68,7 @@ TEST_CASE("Material", "[material]")
 
     // Bind a shader token to a value.
     mx::BindTokenPtr bindToken = refAnisoSrf->addBindToken("texId");
-    bindToken->setValue(std::string("02"));
+    bindToken->setValue("02");
     REQUIRE(texId->getBoundValue(material)->asA<std::string>() == "02");
     REQUIRE(texId->getDefaultValue()->asA<std::string>() == "01");
     mx::StringResolverPtr resolver = doc->createStringResolver(mx::UNIVERSAL_GEOM_NAME, material);

--- a/source/MaterialXTest/Value.cpp
+++ b/source/MaterialXTest/Value.cpp
@@ -50,8 +50,7 @@ TEST_CASE("Value strings", "[value]")
     REQUIRE(mx::toValueString(mx::Color3(1.0f)) == "1, 1, 1");
     REQUIRE(mx::toValueString(std::string("text")) == "text");
 
-    // Convert from data values to value strings
-    // using the various float formattings.
+    // Convert from floats to value strings with custom formatting.
     {
         mx::ScopedFloatFormatting fmt(mx::Value::FloatFormatFixed, 3);
         REQUIRE(mx::toValueString(0.1234f) == "0.123");
@@ -115,6 +114,11 @@ TEST_CASE("Typed values", "[value]")
                    std::vector<float>{4.0f, 5.0f, 6.0f});
     testTypedValue(std::vector<std::string>{"one", "two", "three"},
                    std::vector<std::string>{"four", "five", "six"});
+
+    // String literals
+    mx::ValuePtr value = mx::Value::createValue("text");
+    REQUIRE(value->isA<std::string>());
+    REQUIRE(value->asA<std::string>() == "text");
 
     // Alias types
     testTypedValue<long>(1l, 2l);


### PR DESCRIPTION
Previously, it was only possible to construct a string Value from a std::string, and this changelist adds support for their construction from C string literals.