### PR TITLE
Value construction from C-style strings

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1037,6 +1037,12 @@ class ValueElement : public TypedElement
         setValueString(toValueString(value));
     }
 
+    /// Set the typed value of an element from a C-style string.
+    void setValue(const char* value, const string& type = EMPTY_STRING)
+    {
+        setValue(value ? string(value) : EMPTY_STRING, type);
+    }
+
     /// Return true if the element possesses a typed value.
     bool hasValue() const
     {

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -12,6 +12,7 @@
 #include <MaterialXCore/Library.h>
 
 #include <MaterialXCore/Types.h>
+#include <MaterialXCore/Util.h>
 
 namespace MaterialX
 {
@@ -47,6 +48,12 @@ class Value
     template<class T> static ValuePtr createValue(const T& data)
     {
         return std::make_shared< TypedValue<T> >(data);
+    }
+
+    // Create a new value from a C-style string.
+    static ValuePtr createValue(const char* data)
+    {
+        return createValue(data ? string(data) : EMPTY_STRING);
     }
 
     /// Create a new value instance from value and type strings.

--- a/source/MaterialXTest/Geom.cpp
+++ b/source/MaterialXTest/Geom.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Geom elements", "[geom]")
     nodeGraph->setFilePrefix("folder/");
     REQUIRE_THROWS_AS(doc->addNodeGraph(nodeGraph->getName()), mx::Exception&);
     mx::NodePtr image = nodeGraph->addNode("image");
-    image->setParameterValue("file", std::string("<asset><id>_diffuse_<UDIM>.tif"), mx::FILENAME_TYPE_STRING);
+    image->setParameterValue("file", "<asset><id>_diffuse_<UDIM>.tif", mx::FILENAME_TYPE_STRING);
 
     // Test filename string substitutions.
     mx::ParameterPtr fileParam = image->getParameter("file");

--- a/source/MaterialXTest/Material.cpp
+++ b/source/MaterialXTest/Material.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Material", "[material]")
     mx::InputPtr diffColor = simpleSrf->setInputValue("diffColor", mx::Color3(1.0f));
     mx::InputPtr specColor = simpleSrf->setInputValue("specColor", mx::Color3(0.0f));
     mx::ParameterPtr roughness = simpleSrf->setParameterValue("roughness", 0.25f);
-    mx::TokenPtr texId = simpleSrf->setTokenValue("texId", std::string("01"));
+    mx::TokenPtr texId = simpleSrf->setTokenValue("texId", "01");
     REQUIRE(simpleSrf->getInputValue("diffColor")->asA<mx::Color3>() == mx::Color3(1.0f));
     REQUIRE(simpleSrf->getInputValue("specColor")->asA<mx::Color3>() == mx::Color3(0.0f));
     REQUIRE(simpleSrf->getParameterValue("roughness")->asA<float>() == 0.25f);
@@ -68,7 +68,7 @@ TEST_CASE("Material", "[material]")
 
     // Bind a shader token to a value.
     mx::BindTokenPtr bindToken = refAnisoSrf->addBindToken("texId");
-    bindToken->setValue(std::string("02"));
+    bindToken->setValue("02");
     REQUIRE(texId->getBoundValue(material)->asA<std::string>() == "02");
     REQUIRE(texId->getDefaultValue()->asA<std::string>() == "01");
     mx::StringResolverPtr resolver = doc->createStringResolver(mx::UNIVERSAL_GEOM_NAME, material);

--- a/source/MaterialXTest/Value.cpp
+++ b/source/MaterialXTest/Value.cpp
@@ -50,8 +50,7 @@ TEST_CASE("Value strings", "[value]")
     REQUIRE(mx::toValueString(mx::Color3(1.0f)) == "1, 1, 1");
     REQUIRE(mx::toValueString(std::string("text")) == "text");
 
-    // Convert from data values to value strings
-    // using the various float formattings.
+    // Convert from floats to value strings with custom formatting.
     {
         mx::ScopedFloatFormatting fmt(mx::Value::FloatFormatFixed, 3);
         REQUIRE(mx::toValueString(0.1234f) == "0.123");
@@ -119,4 +118,9 @@ TEST_CASE("Typed values", "[value]")
     // Alias types
     testTypedValue<long>(1l, 2l);
     testTypedValue<double>(1.0, 2.0);
+
+    // Construct a string value from a string literal
+    mx::ValuePtr value = mx::Value::createValue("text");
+    REQUIRE(value->isA<std::string>());
+    REQUIRE(value->asA<std::string>() == "text");
 }


### PR DESCRIPTION
This changelist adds support for value construction from C-style strings and string literals.  Previously, it was only possible to construct a value of string type from a standard string.