### PR TITLE
Improvements to FilePath and FileSearchPath

### DIFF
--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -25,8 +25,7 @@
 namespace MaterialX
 {
 
-const string VALID_SEPARATORS_WINDOWS = "/\\";
-const string VALID_SEPARATORS_POSIX = "/";
+const string VALID_SEPARATORS = "/\\";
 
 const char PREFERRED_SEPARATOR_WINDOWS = '\\';
 const char PREFERRED_SEPARATOR_POSIX = '/';
@@ -42,13 +41,17 @@ const string MATERIALX_SEARCH_PATH_ENV_VAR = "MATERIALX_SEARCH_PATH";
 // FilePath methods
 //
 
-void FilePath::assign(const string& str, Format format)
+void FilePath::assign(const string& str)
 {
     _type = TypeRelative;
-    if (format == FormatWindows)
+    _vec = splitString(str, VALID_SEPARATORS);
+    if (!str.empty())
     {
-        _vec = splitString(str, VALID_SEPARATORS_WINDOWS);
-        if (str.size() >= 2)
+        if (str[0] == PREFERRED_SEPARATOR_POSIX)
+        {
+            _type = TypeAbsolute;
+        }
+        else if (str.size() >= 2)
         {
             if (std::isalpha(str[0]) && str[1] == ':')
             {
@@ -60,15 +63,6 @@ void FilePath::assign(const string& str, Format format)
             }
         }
     }
-    else
-    {
-        _vec = splitString(str, VALID_SEPARATORS_POSIX);
-        if (!str.empty() && str[0] == PREFERRED_SEPARATOR_POSIX)
-        {
-            _type = TypeAbsolute;
-        }
-    }
-    _format = format;
 }
 
 string FilePath::asString(Format format) const
@@ -109,10 +103,6 @@ FilePath FilePath::operator/(const FilePath& rhs) const
     {
         throw Exception("Appended path must be relative.");
     }
-    if (_format != rhs._format)
-    {
-        throw Exception("Appended path must have the same format.");
-    }
 
     FilePath combined(*this);
     for (const string& str : rhs._vec)
@@ -120,14 +110,6 @@ FilePath FilePath::operator/(const FilePath& rhs) const
         combined._vec.push_back(str);
     }
     return combined;
-}
-
-void FilePath::pop()
-{
-    if (!isEmpty())
-    {
-        _vec.pop_back();
-    }
 }
 
 bool FilePath::exists() const

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -13,6 +13,8 @@
 
 #include <MaterialXCore/Document.h>
 
+#include <MaterialXFormat/File.h>
+
 namespace MaterialX
 {
 
@@ -22,7 +24,7 @@ extern const string MTLX_EXTENSION;
 
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.
-using XmlReadFunction = std::function<void(DocumentPtr, string, string, const XmlReadOptions*)>;
+using XmlReadFunction = std::function<void(DocumentPtr, const FilePath&, const FileSearchPath&, const XmlReadOptions*)>;
 
 /// @class XmlReadOptions
 /// A set of options for controlling the behavior of XML read functions.
@@ -97,18 +99,20 @@ void readFromXmlStream(DocumentPtr doc, std::istream& stream, const XmlReadOptio
 
 /// Read a Document as XML from the given filename.
 /// @param doc The Document into which data is read.
-/// @param filename The filename from which data is read.
-/// @param searchPath A semicolon-separated sequence of file paths, which will
-///    be applied in order when searching for the given file and its includes.
-///    Defaults to the empty string.
+/// @param filename The filename from which data is read.  This argument can
+///    be supplied either as a FilePath or a standard string.
+/// @param searchPath An optional sequence of file paths that will be applied
+///    in order when searching for the given file and its includes.  This
+///    argument can be supplied either as a FileSearchPath, or as a standard
+///    string with paths separated by the PATH_SEPARATOR character.
 /// @param readOptions An optional pointer to an XmlReadOptions object.
-///    If provided, then the given options will affect the behavior of the
-///    read function.  Defaults to a null pointer.
+///    If provided, then the given options will affect the behavior of the read
+///    function.  Defaults to a null pointer.
 /// @throws ExceptionParseError if the document cannot be parsed.
 /// @throws ExceptionFileMissing if the file cannot be opened.
 void readFromXmlFile(DocumentPtr doc,
-                     const string& filename,
-                     const string& searchPath = EMPTY_STRING,
+                     const FilePath& filename,
+                     const FileSearchPath& searchPath = FileSearchPath(),
                      const XmlReadOptions* readOptions = nullptr);
 
 /// Read a Document as XML from the given string.
@@ -134,11 +138,12 @@ void writeToXmlStream(DocumentPtr doc, std::ostream& stream, const XmlWriteOptio
 
 /// Write a Document as XML to the given filename.
 /// @param doc The Document to be written.
-/// @param filename The filename to which data is written
+/// @param filename The filename to which data is written.  This argument can
+///    be supplied either as a FilePath or a standard string.
 /// @param writeOptions An optional pointer to an XmlWriteOptions object.
 ///    If provided, then the given options will affect the behavior of the
 ///    write function.  Defaults to a null pointer.
-void writeToXmlFile(DocumentPtr doc, const string& filename, const XmlWriteOptions* writeOptions = nullptr);
+void writeToXmlFile(DocumentPtr doc, const FilePath& filename, const XmlWriteOptions* writeOptions = nullptr);
 
 /// Write a Document as XML to a new string, returned by value.
 /// @param doc The Document to be written.
@@ -156,7 +161,7 @@ string writeToXmlString(DocumentPtr doc, const XmlWriteOptions* writeOptions = n
 /// element to hold the reference filename.
 /// @param doc The Document to be modified.
 /// @param filename The filename of the XInclude reference to be added.
-void prependXInclude(DocumentPtr doc, const string& filename);
+void prependXInclude(DocumentPtr doc, const FilePath& filename);
 
 /// @}
 

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -60,9 +60,9 @@ void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, c
                 const FilePath filePath = dir / file;
                 try
                 {
-                    FileSearchPath readSearchPath(searchPath.asString());
+                    FileSearchPath readSearchPath(searchPath);
                     readSearchPath.append(dir);
-                    readFromXmlFile(doc, filePath, readSearchPath.asString());
+                    readFromXmlFile(doc, filePath, readSearchPath);
                     documents.push_back(doc);
                     documentsPaths.push_back(filePath.asString());
                 }
@@ -80,7 +80,7 @@ void loadLibrary(const FilePath& file, DocumentPtr doc)
     DocumentPtr libDoc = createDocument();
     XmlReadOptions readOptions;
     readOptions.skipConflictingElements = true;
-    readFromXmlFile(libDoc, file, EMPTY_STRING, &readOptions);
+    readFromXmlFile(libDoc, file, FileSearchPath(), &readOptions);
     CopyOptions copyOptions;
     copyOptions.skipConflictingElements = true;
     doc->importLibrary(libDoc, &copyOptions);

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -103,10 +103,8 @@ class ImageSamplingProperties
     void setProperties(const string& fileNameUniform,
                        const VariableBlock& uniformBlock);
 
-    /// Address mode options. Matches enumerations
-    /// allowed for <image> address modes, except
-    /// UNSPECIFIED which indicates no explicit mode was
-    /// defined.
+    /// Address mode options. Matches enumerations allowed for image address
+    /// modes, except UNSPECIFIED which indicates no explicit mode was defined.
     enum class AddressMode : int
     { 
         UNSPECIFIED = -1,
@@ -121,10 +119,8 @@ class ImageSamplingProperties
     /// Address mode in V
     AddressMode vaddressMode = AddressMode::UNSPECIFIED;
 
-    /// Filter type options. Matches enumerations
-    /// allowed for <image> filter types, except
-    /// UNSPECIFIED which indicates no explicit type was
-    /// defined.
+    /// Filter type options. Matches enumerations allowed for image filter
+    /// types, except UNSPECIFIED which indicates no explicit type was defined.
     enum class FilterType : int
     {
         UNSPECIFIED = -1,
@@ -136,8 +132,8 @@ class ImageSamplingProperties
     /// Filter type
     FilterType filterType = FilterType::UNSPECIFIED;
 
-    /// Default color. Corresponds to the "default"
-    /// value on the <image> node definition.
+    /// Default color. Corresponds to the "default" value on the image
+    /// node definition.
     Color4 defaultColor = { 0.0f, 0.0f, 0.0f, 1.0f };
 };
 

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -54,7 +54,7 @@ class GLTextureHandler : public ImageHandler
     /// Bind an image. This method will bind the texture to an active texture
     /// unit as defined by the corresponding image description. The method
     /// will fail if there are not enough available image units to bind to.
-    /// @param identifier Identifier for image description to bind.
+    /// @param filePath File path of image description to bind.
     /// @param samplingProperties Sampling properties for the image
     /// @return true if succeded to bind
     bool bindImage(const FilePath& filePath, const ImageSamplingProperties& samplingProperties) override;

--- a/source/MaterialXTest/File.cpp
+++ b/source/MaterialXTest/File.cpp
@@ -24,8 +24,7 @@ TEST_CASE("Syntactic operations", "[file]")
 
     for (const InputPair& pair : inputPairs)
     {
-        mx::FilePath path;
-        path.assign(pair.first, pair.second);
+        mx::FilePath path(pair.first);
         REQUIRE(path.asString(pair.second) == pair.first);
     }
 }
@@ -49,20 +48,19 @@ TEST_CASE("File system operations", "[file]")
 
 TEST_CASE("File search path operations", "[file]")
 {
-    std::string searchPath = "libraries/stdlib" + 
-                             mx::PATH_LIST_SEPARATOR + 
-                             "resources/Materials/Examples/Syntax";
+    mx::FileSearchPath searchPath = "libraries/stdlib" + 
+                                    mx::PATH_LIST_SEPARATOR + 
+                                    "resources/Materials/Examples/Syntax";
 
-    mx::StringVec filenames =
+    mx::FilePathVec filenames =
     {
         "stdlib_defs.mtlx",
         "MaterialBasic.mtlx",
         "PaintMaterials.mtlx",
     };
 
-    for (const std::string& filename : filenames)
+    for (const mx::FilePath& filename : filenames)
     {
-        mx::FilePath path(filename);
-        REQUIRE(mx::FileSearchPath(searchPath, mx::PATH_LIST_SEPARATOR).find(path).exists());
+        REQUIRE(searchPath.find(filename).exists());
     }
 }

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -137,9 +137,9 @@ TEST_CASE("Node", "[node]")
 
 TEST_CASE("Flatten", "[nodegraph]")
 {
-    std::string searchPath = "resources/Materials/Examples/Syntax" +
-                             mx::PATH_LIST_SEPARATOR +
-                             "libraries/stdlib";
+    mx::FileSearchPath searchPath = "resources/Materials/Examples/Syntax" +
+                                    mx::PATH_LIST_SEPARATOR +
+                                    "libraries/stdlib";
 
     // Read the example file.
     mx::DocumentPtr doc = mx::createDocument();

--- a/source/MaterialXTest/RenderOsl.cpp
+++ b/source/MaterialXTest/RenderOsl.cpp
@@ -73,11 +73,9 @@ void OslShaderRenderTester::createValidator(std::ostream& log)
             _validator->setOslOutputFilePath(shaderPath);
 
             const std::string OSL_EXTENSION("osl");
-            mx::FilePathVec files = shaderPath.getFilesInDirectory(OSL_EXTENSION);
-            for (const auto& file : files)
+            for (const mx::FilePath& filename : shaderPath.getFilesInDirectory(OSL_EXTENSION))
             {
-                mx::FilePath filePath = shaderPath / file;
-                _validator->compileOSL(filePath.asString());
+                _validator->compileOSL(shaderPath / filename);
             }
 
             // Set the search path for these compiled shaders.

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -234,35 +234,33 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                 continue;
             }
 
-            const mx::FilePath filePath = mx::FilePath(dir) / mx::FilePath(file);
-            const std::string filename = filePath;
-
+            const mx::FilePath filename = mx::FilePath(dir) / mx::FilePath(file);
             mx::DocumentPtr doc = mx::createDocument();
             try
             {
-                mx::FileSearchPath readSearchPath(searchPath.asString());
+                mx::FileSearchPath readSearchPath(searchPath);
                 readSearchPath.append(dir);
-                mx::readFromXmlFile(doc, filename, readSearchPath.asString());
+                mx::readFromXmlFile(doc, filename, readSearchPath);
             }
             catch (mx::Exception& e)
             {
-                docValidLog << "Failed to load in file: " << filename << ". Error: " << e.what() << std::endl;
-                WARN("Failed to load in file: " + filename + "See: " + docValidLogFilename + " for details.");                    
+                docValidLog << "Failed to load in file: " << filename.asString() << ". Error: " << e.what() << std::endl;
+                WARN("Failed to load in file: " + filename.asString() + "See: " + docValidLogFilename + " for details.");                    
             }
 
             doc->importLibrary(dependLib, &copyOptions);
             ioTimer.endTimer();
 
             validateTimer.startTimer();
-            std::cout << "- Validating MTLX file: " << filename << std::endl;
-            log << "MTLX Filename: " << filename << std::endl;
+            std::cout << "- Validating MTLX file: " << filename.asString() << std::endl;
+            log << "MTLX Filename: " << filename.asString() << std::endl;
 
             // Validate the test document
             std::string validationErrors;
             bool validDoc = doc->validate(&validationErrors);
             if (!validDoc)
             {
-                docValidLog << filename << std::endl;
+                docValidLog << filename.asString() << std::endl;
                 docValidLog << validationErrors << std::endl;
             }
             validateTimer.endTimer();

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -15,13 +15,13 @@ TEST_CASE("Load content", "[xmlio]")
 {
     mx::FilePath libraryPath("libraries/stdlib");
     mx::FilePath examplesPath("resources/Materials/Examples/Syntax");
-    std::string searchPath = libraryPath.asString() +
-                             mx::PATH_LIST_SEPARATOR +
-                             examplesPath.asString();
+    mx::FileSearchPath searchPath = libraryPath.asString() +
+                                    mx::PATH_LIST_SEPARATOR +
+                                    examplesPath.asString();
 
     // Read the standard library.
     std::vector<mx::DocumentPtr> libs;
-    for (std::string filename : libraryPath.getFilesInDirectory(mx::MTLX_EXTENSION))
+    for (const mx::FilePath& filename : libraryPath.getFilesInDirectory(mx::MTLX_EXTENSION))
     {
         mx::DocumentPtr lib = mx::createDocument();
         mx::readFromXmlFile(lib, filename, searchPath);
@@ -29,7 +29,7 @@ TEST_CASE("Load content", "[xmlio]")
     }
 
     // Read and validate each example document.
-    for (std::string filename : examplesPath.getFilesInDirectory(mx::MTLX_EXTENSION))
+    for (const mx::FilePath& filename : examplesPath.getFilesInDirectory(mx::MTLX_EXTENSION))
     {
         mx::DocumentPtr doc = mx::createDocument();
         mx::readFromXmlFile(doc, filename, searchPath);
@@ -41,7 +41,7 @@ TEST_CASE("Load content", "[xmlio]")
         bool docValid = doc->validate(&message);
         if (!docValid)
         {
-            WARN("[" + filename + "] " + message);
+            WARN("[" + filename.asString() + "] " + message);
         }
         REQUIRE(docValid);
 
@@ -174,7 +174,7 @@ TEST_CASE("Load content", "[xmlio]")
     REQUIRE(*flatDoc != *doc);
 
     // Read document using environment search path.
-    mx::setEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR, searchPath);
+    mx::setEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR, searchPath.asString());
     mx::DocumentPtr envDoc = mx::createDocument();
     mx::readFromXmlFile(envDoc, filename);
     REQUIRE(*envDoc == *doc);

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -28,8 +28,8 @@ int main(int argc, char* const argv[])
         tokens.push_back(std::string(argv[i]));
     }
 
-    mx::StringVec libraryFolders = { "libraries/stdlib", "libraries/pbrlib", "libraries/stdlib/genglsl", "libraries/pbrlib/genglsl", 
-                                     "libraries/bxdf", "libraries/lights", "libraries/lights/genglsl" };
+    mx::FilePathVec libraryFolders = { "libraries/stdlib", "libraries/pbrlib", "libraries/stdlib/genglsl", "libraries/pbrlib/genglsl", 
+                                       "libraries/bxdf", "libraries/lights", "libraries/lights/genglsl" };
     mx::FileSearchPath searchPath;
     std::string meshFilename = "resources/Geometry/shaderball.obj";
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx";
@@ -108,8 +108,7 @@ int main(int argc, char* const argv[])
 
     // Search current directory and parent directory if not found.
     mx::FilePath currentPath(mx::FilePath::getCurrentPath());
-    mx::FilePath parentCurrentPath(currentPath);
-    parentCurrentPath.pop();
+    mx::FilePath parentCurrentPath = currentPath.getParentPath();
     std::vector<mx::FilePath> libraryPaths =
     { 
         mx::FilePath("libraries")

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -13,7 +13,7 @@ namespace ng = nanogui;
 class Viewer : public ng::Screen
 {
   public:
-    Viewer(const mx::StringVec& libraryFolders,
+    Viewer(const mx::FilePathVec& libraryFolders,
            const mx::FileSearchPath& searchPath,
            const std::string& meshFilename,
            const std::string& materialFilename,
@@ -137,7 +137,7 @@ class Viewer : public ng::Screen
     ng::Vector2i _translationStart;
 
     // Document management
-    mx::StringVec _libraryFolders;
+    mx::FilePathVec _libraryFolders;
     mx::FileSearchPath _searchPath;
     mx::DocumentPtr _stdLib;
     mx::FilePath _materialFilename;

--- a/source/PyMaterialX/PyMaterialXFormat/PyFile.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyFile.cpp
@@ -25,18 +25,40 @@ void bindPyFile(py::module& mod)
         .export_values();
 
     py::class_<mx::FilePath>(mod, "FilePath")
-        .def_static("getCurrentPath", &mx::FilePath::getCurrentPath)
         .def(py::init<>())
         .def(py::init<const std::string&>())
         .def(py::self == py::self)
         .def(py::self != py::self)
         .def(py::self / py::self)
-        .def("assign", &mx::FilePath::assign)
-        .def("asString", &mx::FilePath::asString)
+        .def("asString", &mx::FilePath::asString,
+             py::arg("format") = mx::FilePath::Format::FormatNative)
         .def("isEmpty", &mx::FilePath::isEmpty)
         .def("isAbsolute", &mx::FilePath::isAbsolute)
         .def("getBaseName", &mx::FilePath::getBaseName)
-        .def("exists", &mx::FilePath::exists);
+        .def("getParentPath", &mx::FilePath::getParentPath)
+        .def("getExtension", &mx::FilePath::getExtension)
+        .def("exists", &mx::FilePath::exists)
+        .def("isDirectory", &mx::FilePath::isDirectory)
+        .def("getFilesInDirectory", &mx::FilePath::getFilesInDirectory)
+        .def("getSubDirectories", &mx::FilePath::getSubDirectories)
+        .def("createDirectory", &mx::FilePath::createDirectory)
+        .def_static("getCurrentPath", &mx::FilePath::getCurrentPath);
+
+    py::class_<mx::FileSearchPath>(mod, "FileSearchPath")
+        .def(py::init<>())
+        .def(py::init<const std::string&, const std::string&>(),
+             py::arg("searchPath"), py::arg("sep") = mx::PATH_LIST_SEPARATOR)
+        .def("asString", &mx::FileSearchPath::asString,
+             py::arg("sep") = mx::PATH_LIST_SEPARATOR)
+        .def("append", static_cast<void (mx::FileSearchPath::*)(const mx::FilePath&)>(&mx::FileSearchPath::append))
+        .def("append", static_cast<void (mx::FileSearchPath::*)(const mx::FileSearchPath&)>(&mx::FileSearchPath::append))
+        .def("prepend", &mx::FileSearchPath::prepend)
+        .def("size", &mx::FileSearchPath::size)
+        .def("isEmpty", &mx::FileSearchPath::isEmpty)
+        .def("find", &mx::FileSearchPath::find);
+
+    py::implicitly_convertible<std::string, mx::FilePath>();
+    py::implicitly_convertible<std::string, mx::FileSearchPath>();
 
     mod.attr("PATH_LIST_SEPARATOR") = mx::PATH_LIST_SEPARATOR;
     mod.attr("MATERIALX_SEARCH_PATH_ENV_VAR") = mx::MATERIALX_SEARCH_PATH_ENV_VAR;

--- a/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
@@ -7,13 +7,13 @@
 
 namespace py = pybind11;
 
-void bindPyXmlIo(py::module& mod);
 void bindPyFile(py::module& mod);
+void bindPyXmlIo(py::module& mod);
 
 PYBIND11_MODULE(PyMaterialXFormat, mod)
 {
     mod.doc() = "Module containing Python bindings for the MaterialXFormat library";
 
-    bindPyXmlIo(mod);
     bindPyFile(mod);
+    bindPyXmlIo(mod);
 }

--- a/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
@@ -24,7 +24,7 @@ void bindPyXmlIo(py::module& mod)
         .def_readwrite("elementPredicate", &mx::XmlWriteOptions::elementPredicate);
 
     mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
-        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::EMPTY_STRING, py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
+        py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::FileSearchPath(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("readFromXmlString", &mx::readFromXmlString,
         py::arg("doc"), py::arg("str"), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("writeToXmlFile", mx::writeToXmlFile,


### PR DESCRIPTION
- Make FilePath construction independent of the current platform, allowing FilePath to be used with stored strings.
- Add support for iteration over FileSearchPath objects.
- Update the interface of readFromXmlFile and writeToXmlFile to leverage FilePath and FileSearchPath.
- Extend Python bindings for FilePath and FileSearchPath.