### PR TITLE
Improvements to FilePath

### DIFF
--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -17,9 +17,9 @@
 #include <dirent.h>
 #endif
 
+#include <array>
 #include <cctype>
 #include <cerrno>
-#include <climits>
 #include <cstring>
 
 namespace MaterialX
@@ -235,19 +235,19 @@ void FilePath::createDirectory()
 FilePath FilePath::getCurrentPath()
 {
 #if defined(_WIN32)
-    char buf[MAX_PATH];
-    if (!GetCurrentDirectory(MAX_PATH, buf))
+    std::array<char, MAX_PATH> buf;
+    if (!GetCurrentDirectory(MAX_PATH, buf.data()))
     {
         throw Exception("Error in getCurrentPath: " + std::to_string(GetLastError()));
     }
-    return FilePath(buf);
+    return FilePath(buf.data());
 #else
-    char buf[PATH_MAX];
-    if (getcwd(buf, PATH_MAX) == NULL)
+    std::array<char, PATH_MAX> buf;
+    if (getcwd(buf.data(), PATH_MAX) == NULL)
     {
         throw Exception("Error in getCurrentPath: " + string(strerror(errno)));
     }
-    return FilePath(buf);
+    return FilePath(buf.data());
 #endif
 }
 

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -72,7 +72,7 @@ class FilePath
     /// Construct a path from a C-style string.
     FilePath(const char* str)
     {
-        assign(string(str));
+        assign(str ? string(str) : EMPTY_STRING);
     }
 
     /// Convert a path to a standard string.
@@ -101,7 +101,7 @@ class FilePath
 
     /// Return the base name of the given path, with leading directory
     /// information removed.
-    string getBaseName() const
+    const string& getBaseName() const
     {
         if (isEmpty())
         {
@@ -125,7 +125,7 @@ class FilePath
     /// Return the file extension of the given path.
     string getExtension() const
     {
-        string baseName = getBaseName();
+        const string& baseName = getBaseName();
         size_t i = baseName.rfind('.');
         return i != string::npos ? baseName.substr(i + 1) : EMPTY_STRING;
     }

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -132,13 +132,11 @@ void xmlDocumentFromFile(xml_document& xmlDoc, FilePath filename, FileSearchPath
         {
             throw ExceptionFileMissing("Failed to open file for reading: " + filename.asString());
         }
-        else
-        {
-            string desc = result.description();
-            string offset = std::to_string(result.offset);
-            throw ExceptionParseError("XML parse error in file: " + filename.asString() +
-                                      " (" + desc + " at character " + offset + ")");
-        }
+
+        string desc = result.description();
+        string offset = std::to_string(result.offset);
+        throw ExceptionParseError("XML parse error in file: " + filename.asString() +
+                                  " (" + desc + " at character " + offset + ")");
     }
 }
 

--- a/source/MaterialXRender/StbImageLoader.cpp
+++ b/source/MaterialXRender/StbImageLoader.cpp
@@ -4,9 +4,9 @@
 //
 
 #if defined(_WIN32)
-    #pragma warning( push )
-    #pragma warning( disable: 4100)
-    #pragma warning( disable: 4505)
+    #pragma warning(push)
+    #pragma warning(disable: 4100)
+    #pragma warning(disable: 4505)
 #endif
 
 // Make the functions static to avoid multiple definitions if other libraries
@@ -20,7 +20,7 @@
 #include <MaterialXRender/External/StbImage/stb_image.h>
 
 #if defined(_WIN32)
-    #pragma warning( pop )
+    #pragma warning(pop)
 #endif
 
 #include <MaterialXRender/StbImageLoader.h>
@@ -52,7 +52,7 @@ bool StbImageLoader::saveImage(const FilePath& filePath,
 
     const string filePathName = filePath.asString();
 
-    string extension = (filePathName.substr(filePathName.find_last_of(".") + 1));
+    string extension = filePath.getExtension();
     if (!isFloat)
     {
         if (extension == PNG_EXTENSION)
@@ -104,7 +104,7 @@ bool StbImageLoader::loadImage(const FilePath& filePath, ImageDesc &imageDesc,
     const string fileName = filePath.asString();
 
     // If HDR, switch to float reader
-    string extension = (fileName.substr(fileName.find_last_of(".") + 1));
+    string extension = filePath.getExtension();
     if (extension == HDR_EXTENSION)
     {
         // Early out if base type is unsupported


### PR DESCRIPTION
- Handle null inputs in FilePath construction from a C-style string.
- Return a const string reference in FilePath::getBaseName for efficiency.
- Use std::array in FilePath::getCurrentPath for consistency.
- Use FilePath::getExtension in MaterialXRender for consistency.