### PR TITLE
Add Python bindings for array types

### DIFF
--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -65,7 +65,7 @@ Element.removeChildOfType = _removeChildOfType
 
 def _setValue(self, value, typeString = ''):
     "Set the typed value of an element."
-    method = getattr(self.__class__, "_setValue" + typeToName(value.__class__))
+    method = getattr(self.__class__, "_setValue" + getTypeString(value))
     method(self, value, typeString)
 
 def _getValue(self):
@@ -98,7 +98,7 @@ ValueElement.getDefaultValue = _getDefaultValue
 def _setParameterValue(self, name, value, typeString = ''):
     """Set the typed value of a parameter by its name, creating a child element
        to hold the parameter if needed."""
-    method = getattr(self.__class__, "_setParameterValue" + typeToName(value.__class__))
+    method = getattr(self.__class__, "_setParameterValue" + getTypeString(value))
     return method(self, name, value, typeString)
 
 def _getParameterValue(self, name, target = ''):
@@ -118,7 +118,7 @@ def _getParameterValueString(self, name):
 def _setInputValue(self, name, value, typeString = ''):
     """Set the typed value of an input by its name, creating a child element
        to hold the input if needed."""
-    method = getattr(self.__class__, "_setInputValue" + typeToName(value.__class__))
+    method = getattr(self.__class__, "_setInputValue" + getTypeString(value))
     return method(self, name, value, typeString)
 
 def _getInputValue(self, name, target = ''):
@@ -169,7 +169,7 @@ def _addOverride(self, name):
 def _setOverrideValue(self, name, value, typeString = ''):
     """Set the value of an override by its name, creating a child element
        to hold the override if needed."""
-    method = getattr(self.__class__, "_setOverrideValue" + typeToName(value.__class__))
+    method = getattr(self.__class__, "_setOverrideValue" + getTypeString(value))
     return method(self, name, value, typeString)
 
 def _addShaderRef(self, name = '', node = ''):
@@ -212,7 +212,7 @@ ShaderRef.getReferencedShaderDef = _getReferencedShaderDef
 def _setPropertyValue(self, name, value, typeString = ''):
     """Set the typed value of a property by its name, creating a child element
        to hold the property if needed."""
-    method = getattr(self.__class__, "_setPropertyValue" + typeToName(value.__class__))
+    method = getattr(self.__class__, "_setPropertyValue" + getTypeString(value))
     return method(self, name, value, typeString)
 
 def _getPropertyValue(self, name, target = ''):
@@ -236,7 +236,7 @@ def _addGeomAttr(self, name):
 def _setGeomAttrValue(self, name, value, typeString = ''):
     """Set the value of a geomattr by its name, creating a child element
        to hold the geomattr if needed."""
-    method = getattr(self.__class__, "_setGeomAttrValue" + typeToName(value.__class__))
+    method = getattr(self.__class__, "_setGeomAttrValue" + getTypeString(value))
     return method(self, name, value, typeString)
 
 GeomInfo.addGeomAttr = _addGeomAttr
@@ -266,18 +266,24 @@ Document.generateRequireString = _generateRequireString
 # Value
 #
 
-def _objectToString(value):
-    "(Deprecated) Convert a value of MaterialX type to a string."
-    warnings.warn("This function is deprecated; call valueToString instead.", DeprecationWarning, stacklevel = 2)
-    return valueToString(value)
+def _typeToName(t):
+    "(Deprecated) Return the MaterialX type string associated with the given Python type."
+    warnings.warn("This function is deprecated; call MaterialX.getTypeString instead.", DeprecationWarning, stacklevel = 2)
+    return getTypeString(t())
 
-def _stringToObject(string, t):
-    "(Deprecated) Convert a string to a value of MaterialX type."
-    warnings.warn("This function is deprecated; call stringToValue instead.", DeprecationWarning, stacklevel = 2)
-    return stringToValue(string, t)
+def _valueToString(value):
+    "(Deprecated) Convert a Python value to its correponding MaterialX value string."
+    warnings.warn("This function is deprecated; call MaterialX.getValueString instead.", DeprecationWarning, stacklevel = 2)
+    return getValueString(value)
 
-objectToString = _objectToString
-stringToObject = _stringToObject
+def _stringToValue(string, t):
+    "(Deprecated) Convert a MaterialX value string and Python type to the corresponding Python value."
+    warnings.warn("This function is deprecated; call MaterialX.createValueFromStrings instead.", DeprecationWarning, stacklevel = 2)
+    return createValueFromStrings(string, getTypeString(t()))
+
+typeToName = _typeToName
+valueToString = _valueToString
+stringToValue = _stringToValue
 
 
 #

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -18,7 +18,11 @@ _testValues = (1,
                mx.Vector4(1.0, 2.0, 3.0, 4.0),
                mx.Matrix33(0.0),
                mx.Matrix44(1.0),
-               'value')
+               'value',
+               [1, 2, 3],
+               [False, True, False],
+               [1.0, 2.0, 3.0],
+               ['one', 'two', 'three'])
 
 _fileDir = os.path.dirname(os.path.abspath(__file__))
 _libraryDir = os.path.join(_fileDir, '../../libraries/stdlib/')
@@ -43,15 +47,11 @@ _epsilon = 1e-4
 class TestMaterialX(unittest.TestCase):
     def test_DataTypes(self):
         for value in _testValues:
-            # Convert between values and strings.
-            string = mx.valueToString(value)
-            newValue = mx.stringToValue(string, type(value))
+            valueString = mx.getValueString(value)
+            typeString = mx.getTypeString(value)
+            newValue = mx.createValueFromStrings(valueString, typeString)
             self.assertTrue(newValue == value)
-
-            # Convert between types and strings.
-            string = mx.typeToName(type(value))
-            newType = mx.nameToType(string)
-            self.assertTrue(newType == type(value))
+            self.assertTrue(mx.getTypeString(newValue) == typeString)
 
     def test_Vectors(self):
         v1 = mx.Vector3(1, 2, 3)

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -279,10 +279,6 @@ template <class T> class ValueRegistry
 // Template instantiations
 //
 
-using IntVec = vector<int>;
-using BoolVec = vector<bool>;
-using FloatVec = vector<float>;
-
 #define INSTANTIATE_TYPE(T, name)                       \
 template <> const string TypedValue<T>::TYPE = name;    \
 template bool Value::isA<T>() const;                    \

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -17,6 +17,13 @@
 namespace MaterialX
 {
 
+/// A vector of integers.
+using IntVec = vector<int>;
+/// A vector of booleans.
+using BoolVec = vector<bool>;
+/// A vector of floats.
+using FloatVec = vector<float>;
+
 class Value;
 
 /// A shared pointer to a Value
@@ -185,7 +192,7 @@ template <class T> class TypedValue : public Value
 class ScopedFloatFormatting
 {
   public:
-    ScopedFloatFormatting(Value::FloatFormat format, int precision = 6);
+    explicit ScopedFloatFormatting(Value::FloatFormat format, int precision = 6);
     ~ScopedFloatFormatting();
 
   private:

--- a/source/MaterialXTest/Value.cpp
+++ b/source/MaterialXTest/Value.cpp
@@ -106,14 +106,14 @@ TEST_CASE("Typed values", "[value]")
                    std::string("second_value"));
 
     // Array types
-    testTypedValue(std::vector<int>{1, 2, 3},
-                   std::vector<int>{4, 5, 6});
-    testTypedValue(std::vector<bool>{false, false, false},
-                   std::vector<bool>{true, true, true});
-    testTypedValue(std::vector<float>{1.0f, 2.0f, 3.0f},
-                   std::vector<float>{4.0f, 5.0f, 6.0f});
-    testTypedValue(std::vector<std::string>{"one", "two", "three"},
-                   std::vector<std::string>{"four", "five", "six"});
+    testTypedValue(mx::IntVec{1, 2, 3},
+                   mx::IntVec{4, 5, 6});
+    testTypedValue(mx::BoolVec{false, false, false},
+                   mx::BoolVec{true, true, true});
+    testTypedValue(mx::FloatVec{1.0f, 2.0f, 3.0f},
+                   mx::FloatVec{4.0f, 5.0f, 6.0f});
+    testTypedValue(mx::StringVec{"one", "two", "three"},
+                   mx::StringVec{"four", "five", "six"});
 
     // Alias types
     testTypedValue<long>(1l, 2l);

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -170,7 +170,11 @@ void bindPyElement(py::module& mod)
         BIND_VALUE_ELEMENT_FUNC_INSTANCE(vector4, mx::Vector4)
         BIND_VALUE_ELEMENT_FUNC_INSTANCE(matrix33, mx::Matrix33)
         BIND_VALUE_ELEMENT_FUNC_INSTANCE(matrix44, mx::Matrix44)
-        BIND_VALUE_ELEMENT_FUNC_INSTANCE(string, std::string);
+        BIND_VALUE_ELEMENT_FUNC_INSTANCE(string, std::string)
+        BIND_VALUE_ELEMENT_FUNC_INSTANCE(integerarray, mx::IntVec)
+        BIND_VALUE_ELEMENT_FUNC_INSTANCE(booleanarray, mx::BoolVec)
+        BIND_VALUE_ELEMENT_FUNC_INSTANCE(floatarray, mx::FloatVec)
+        BIND_VALUE_ELEMENT_FUNC_INSTANCE(stringarray, mx::StringVec);
 
     py::class_<mx::Token, mx::TokenPtr, mx::ValueElement>(mod, "Token")
         .def_readonly_static("CATEGORY", &mx::Token::CATEGORY);

--- a/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
@@ -48,6 +48,10 @@ void bindPyGeom(py::module& mod)
         BIND_GEOMINFO_FUNC_INSTANCE(matrix33, mx::Matrix33)
         BIND_GEOMINFO_FUNC_INSTANCE(matrix44, mx::Matrix44)
         BIND_GEOMINFO_FUNC_INSTANCE(string, std::string)
+        BIND_GEOMINFO_FUNC_INSTANCE(integerarray, mx::IntVec)
+        BIND_GEOMINFO_FUNC_INSTANCE(booleanarray, mx::BoolVec)
+        BIND_GEOMINFO_FUNC_INSTANCE(floatarray, mx::FloatVec)
+        BIND_GEOMINFO_FUNC_INSTANCE(stringarray, mx::StringVec)
         .def_readonly_static("CATEGORY", &mx::GeomInfo::CATEGORY);
 
     py::class_<mx::GeomAttr, mx::GeomAttrPtr, mx::ValueElement>(mod, "GeomAttr")

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -96,5 +96,9 @@ void bindPyInterface(py::module& mod)
         BIND_INTERFACE_TYPE_INSTANCE(matrix33, mx::Matrix33)
         BIND_INTERFACE_TYPE_INSTANCE(matrix44, mx::Matrix44)
         BIND_INTERFACE_TYPE_INSTANCE(string, std::string)
+        BIND_INTERFACE_TYPE_INSTANCE(integerarray, mx::IntVec)
+        BIND_INTERFACE_TYPE_INSTANCE(booleanarray, mx::BoolVec)
+        BIND_INTERFACE_TYPE_INSTANCE(floatarray, mx::FloatVec)
+        BIND_INTERFACE_TYPE_INSTANCE(stringarray, mx::StringVec)
         .def_readonly_static("NODE_DEF_ATTRIBUTE", &mx::InterfaceElement::NODE_DEF_ATTRIBUTE);
 }

--- a/source/PyMaterialX/PyMaterialXCore/PyProperty.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyProperty.cpp
@@ -49,6 +49,10 @@ void bindPyProperty(py::module& mod)
         BIND_PROPERTYSET_TYPE_INSTANCE(matrix33, mx::Matrix33)
         BIND_PROPERTYSET_TYPE_INSTANCE(matrix44, mx::Matrix44)
         BIND_PROPERTYSET_TYPE_INSTANCE(string, std::string)
+        BIND_PROPERTYSET_TYPE_INSTANCE(integerarray, mx::IntVec)
+        BIND_PROPERTYSET_TYPE_INSTANCE(booleanarray, mx::BoolVec)
+        BIND_PROPERTYSET_TYPE_INSTANCE(floatarray, mx::FloatVec)
+        BIND_PROPERTYSET_TYPE_INSTANCE(stringarray, mx::StringVec)
         .def_readonly_static("CATEGORY", &mx::Property::CATEGORY);
 
     py::class_<mx::PropertySetAssign, mx::PropertySetAssignPtr, mx::GeomElement>(mod, "PropertySetAssign")

--- a/source/PyMaterialX/PyMaterialXCore/PyValue.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyValue.cpp
@@ -36,4 +36,8 @@ void bindPyValue(py::module& mod)
     BIND_TYPE_INSTANCE(matrix33, mx::Matrix33)
     BIND_TYPE_INSTANCE(matrix44, mx::Matrix44)
     BIND_TYPE_INSTANCE(string, std::string)
+    BIND_TYPE_INSTANCE(integerarray, mx::IntVec)
+    BIND_TYPE_INSTANCE(booleanarray, mx::BoolVec)
+    BIND_TYPE_INSTANCE(floatarray, mx::FloatVec)
+    BIND_TYPE_INSTANCE(stringarray, mx::StringVec)
 }


### PR DESCRIPTION
- Add Python bindings for array types in value accessors.
- Add Python functions getTypeString, getValueString, and createValueFromStrings.
- Deprecate Python functions typeToName, valueToString, and stringToValue.
- Remove deprecated Python functions objectToString and stringToObject.