### PR TITLE
Always-on-top checkbox added in the viewer Advanced settings (for WIN32)

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -849,45 +849,6 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         mx::DocumentPtr doc = mx::createDocument();
         mx::readFromXmlFile(doc, filename, _searchPath, &readOptions);
 
-
-        std::cout << "\n---------\n";
-
-        // Traverse the document tree (explicit iterator).
-        int nodeCount = 0;
-        size_t lastElementDepth = 0;
-        for (mx::TreeIterator it = doc->traverseTree().begin(); it != mx::TreeIterator::end(); ++it)
-        {
-            mx::ElementPtr elem = it.getElement();
-
-            std::string indent = "";
-            for (int i = 0; i < it.getElementDepth(); i++)
-                indent += "    ";
-
-            if (it.getElementDepth() == lastElementDepth-1)
-                std::cout << indent << "    },\n";
-
-            if (it.getElementDepth() <= lastElementDepth)
-                std::cout << indent << "},\n";
-
-            lastElementDepth = it.getElementDepth();
-
-            std::cout << indent << "\"" << elem->getCategory() << "\" : { \n";
-            std::cout << indent << "    \"name\"\t  :   \"" << elem->getName() << "\", \n";
-
-            auto atts = elem->getAttributeNames();
-            for (auto att : atts)
-                std::cout << indent << "    \"" << att << "\"\t  :   \"" << elem->getAttribute(att) << "\",\n";
-
-            if (elem->isA<mx::Node>())
-            {
-                nodeCount++;
-            }
-        }
-
-
-
-
-
         // Import libraries.
         mx::CopyOptions copyOptions; 
         copyOptions.skipConflictingElements = true;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -331,9 +331,6 @@ Viewer::Viewer(const mx::FilePathVec& libraryFolders,
         }
     }
 
-    glfwWindowHint(GLFW_FLOATING, GL_TRUE);
-
-
     // Initialize camera
     initCamera();
     setResizeCallback([this](ng::Vector2i size)

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -194,6 +194,10 @@ class Viewer : public ng::Screen
     mx::HwSpecularEnvironmentMethod _specularEnvironmentMethod;
     int _envSamples;
     bool _drawEnvironment;
+#ifdef _WIN32
+    bool _topmost;
+    HWND _hwnd;
+#endif
     mx::Matrix44 _envMatrix;
 
     // Property options


### PR DESCRIPTION
This adds a checkbox to keep the viewer on top for Windows. Got for comparative testing on top of a DCC, your viewer doesn't get dropped behind the DCC all the time....