### PR TITLE
Harmonize usage of registerSourceCodeSearchPath

### DIFF
--- a/python/MaterialXTest/genshader.py
+++ b/python/MaterialXTest/genshader.py
@@ -74,9 +74,9 @@ class TestGenShader(unittest.TestCase):
         shadergen = OslShaderGenerator.create()
         context = GenContext(shadergen)
         # Add path to find all source code snippets
-        context.registerSourceCodeSearchPath(mx.FilePath(searchPath))
+        context.registerSourceCodeSearchPath(searchPath)
         # Add path to find OSL include files
-        context.registerSourceCodeSearchPath(mx.FilePath(os.path.join(searchPath, "stdlib/osl")))
+        context.registerSourceCodeSearchPath(os.path.join(searchPath, "stdlib/osl"))
 
         # Test complete mode
         context.getOptions().shaderInterfaceType = int(ShaderInterfaceType.SHADER_INTERFACE_COMPLETE);

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -90,12 +90,6 @@ class GenContext
     }
 
     /// Add to the search path used for finding source code.
-    void registerSourceCodeSearchPath(const string& path)
-    {
-        _sourceCodeSearchPath.append(FilePath(path));
-    }
-
-    /// Add to the search path used for finding source code.
     void registerSourceCodeSearchPath(const FilePath& path)
     {
         _sourceCodeSearchPath.append(path);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1073,10 +1073,7 @@ void Viewer::loadStandardLibraries()
     _stdLib = loadLibraries(_libraryFolders, _searchPath);
     mx::DefaultColorManagementSystemPtr cms = mx::DefaultColorManagementSystem::create(_genContext.getShaderGenerator().getLanguage());
     cms->loadLibrary(_stdLib);
-    for (const mx::FilePath& filePath : _searchPath)
-    {
-        _genContext.registerSourceCodeSearchPath(filePath);
-    }
+    _genContext.registerSourceCodeSearchPath(_searchPath);
     _genContext.getShaderGenerator().setColorManagementSystem(cms);
 }
 

--- a/source/PyMaterialX/PyMaterialXGenShader/PyGenContext.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyGenContext.cpp
@@ -17,7 +17,6 @@ void bindPyGenContext(py::module& mod)
         .def(py::init<mx::ShaderGeneratorPtr>())
         .def("getShaderGenerator", &mx::GenContext::getShaderGenerator)
         .def("getOptions", static_cast<mx::GenOptions& (mx::GenContext::*)()>(&mx::GenContext::getOptions), py::return_value_policy::reference)
-        .def("registerSourceCodeSearchPath", static_cast<void (mx::GenContext::*)(const std::string&)>(&mx::GenContext::registerSourceCodeSearchPath))
         .def("registerSourceCodeSearchPath", static_cast<void (mx::GenContext::*)(const mx::FilePath&)>(&mx::GenContext::registerSourceCodeSearchPath))
         .def("registerSourceCodeSearchPath", static_cast<void (mx::GenContext::*)(const mx::FileSearchPath&)>(&mx::GenContext::registerSourceCodeSearchPath))
         .def("resolveSourceFile", &mx::GenContext::resolveSourceFile);


### PR DESCRIPTION
Use the FilePath and FileSearchPath variants of registerSourceCodeSearchPath consistently across the library, allowing string arguments to automatically convert to a FilePath where needed.