### PR TITLE
Additional improvements to texture baking

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -729,29 +729,6 @@ void tokenSubstitution(const StringMap& substitutions, string& source)
     source = buffer;
 }
 
-FilePathVec getUdimPaths(const FilePath& filePath, const StringVec& udimIdentifiers)
-{
-    FilePathVec resolvedFilePaths;
-    if (udimIdentifiers.empty())
-    {
-        return resolvedFilePaths;
-    }
-
-    for (const string& udimIdentifier : udimIdentifiers)
-    {
-        if (udimIdentifier.empty())
-        {
-            continue;
-        }
-
-        StringMap map;
-        map[UDIM_TOKEN] = udimIdentifier;
-        resolvedFilePaths.push_back(FilePath(replaceSubstrings(filePath.asString(), map)));
-    }
-
-    return resolvedFilePaths;
-}
-
 vector<Vector2> getUdimCoordinates(const StringVec& udimIdentifiers)
 {
     vector<Vector2> udimCoordinates;

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -94,14 +94,6 @@ ValueElementPtr findNodeDefChild(const string& path, DocumentPtr doc, const stri
 /// by the corresponding string in the substitution map, if the token exists in the map.
 void tokenSubstitution(const StringMap& substitutions, string& source);
 
-/// Perform UDIM token replace using an input file path and a list of token
-/// replacements (UDIM identifiers). A new path will be created for
-/// each identifier.
-/// @param filePath File path with UDIM token
-/// @param udimIdentifiers List of UDIM identifiers
-/// @returns List of file paths
-FilePathVec getUdimPaths(const FilePath& filePath, const StringVec& udimIdentifiers);
-
 /// Compute the UDIM coordinates for a set of UDIM identifiers
 /// @return List of UDIM coordinates
 vector<Vector2> getUdimCoordinates(const StringVec& udimIdentifiers);

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -11,6 +11,7 @@
 
 #include <MaterialXFormat/File.h>
 
+#include <MaterialXCore/Element.h>
 #include <MaterialXCore/Types.h>
 
 #include <cmath>
@@ -144,8 +145,7 @@ using ImageDescCache = std::unordered_map<string, ImageDesc>;
 using ImageLoaderPtr = std::shared_ptr<class ImageLoader>;
 
 /// @class ImageLoader
-/// Abstract class representing an disk image loader
-///
+/// Abstract base class for file-system image loaders
 class ImageLoader
 {
   public:
@@ -207,35 +207,28 @@ using ImageHandlerPtr = std::shared_ptr<class ImageHandler>;
 using ImageLoaderMap = std::multimap<string, ImageLoaderPtr>;
 
 /// @class ImageHandler
-/// A image handler class. Keeps track of images which are loaded
-/// from disk via supplied ImageLoader. Derive classes are responsible
-/// for determinine how to perform the logic for "binding" of these resources
+/// Base image handler class. Keeps track of images which are loaded from
+/// disk via supplied ImageLoader. Derived classes are responsible for
+/// determinining how to perform the logic for "binding" of these resources
 /// for a given target (such as a given shading language).
-///
 class ImageHandler
 {
   public:
-    /// Constructor. Assume at least one loader must be supplied.
-    explicit ImageHandler(ImageLoaderPtr imageLoader);
-
-    /// Static instance create function
     static ImageHandlerPtr create(ImageLoaderPtr imageLoader)
     {
-        return std::make_shared<ImageHandler>(imageLoader);
+        return ImageHandlerPtr(new ImageHandler(imageLoader));
     }
 
-    /// Add additional image loaders. Useful to handle different file
-    /// extensions
-    /// @param loader Loader to add to list of available loaders.
-    void addLoader(ImageLoaderPtr loader);
-
-    /// Default destructor
     virtual ~ImageHandler()
     {
         clearImageCache();
-    };
+    }
 
-    /// Get a list of extensions supported by the handler
+    /// Add another image loader to the handler, which will be invoked if
+    /// existing loaders cannot load a given image.
+    void addLoader(ImageLoaderPtr loader);
+
+    /// Get a list of extensions supported by the handler.
     void supportedExtensions(StringSet& extensions);
 
     /// Save image to disk. This method must be implemented by derived classes.
@@ -300,51 +293,61 @@ class ImageHandler
         return _searchPath;
     }
 
+    /// Set the filename resolver for images.
+    void setFilenameResolver(StringResolverPtr resolver)
+    {
+        _resolver = resolver;
+    }
+
+    /// Return the filename resolver for images.
+    StringResolverPtr getFilenameResolver() const
+    {
+        return _resolver;
+    }
+
     /// Resolve a path to a file using the registered search paths.
     FilePath findFile(const FilePath& filePath);
 
-    /// Returns the bound texture location for a given resource
+    /// Return the bound texture location for a given resource.
     virtual int getBoundTextureLocation(unsigned int)
     {
         return -1;
     }
 
   protected:
-    /// Cache an image for reuse.
-    /// @param filePath File path of image to cache.
-    /// @param imageDesc Image description to cache.
+    // Protected constructor.
+    ImageHandler(ImageLoaderPtr imageLoader);
+
+    // Cache an image for reuse.
     void cacheImage(const string& filePath, const ImageDesc& imageDesc);
 
-    /// Remove image description from the cache.
-    /// @param filePath File path of image to remove.
+    // Remove image description from the cache.
     void uncacheImage(const string& filePath);
 
-    /// Get an image description in the image cache if it exists
-    /// @param filePath File path of image to find in the cache.
-    /// @return A null ptr is returned if not found.
+    // Return the cached image description, if found; otherwise
+    // return a null pointer.
     const ImageDesc* getCachedImage(const string& filePath);
 
-    /// Return a reference to the image cache
+    // Return a reference to the image cache
     ImageDescCache& getImageCache()
     {
         return _imageCache;
     }
 
-    /// Delete an image
-    /// @param imageDesc Image description indicate which image to delete.
-    /// Derived classes should override this method to clean up any related resources
-    /// an image is deleted from the handler.
+    // Delete an image. Derived classes should override this method to clean
+    // up any related resources when an image is deleted from the handler.
     virtual void deleteImage(ImageDesc& imageDesc);
 
-    /// Return image description restrictions. By default nullptr is
-    /// returned meaning no restrictions. Derived classes can override
-    /// this to add restrictions specific to that handler.
+    // Return image description restrictions. By default nullptr is
+    // returned meaning no restrictions. Derived classes can override
+    // this to add restrictions specific to that handler.
     virtual const ImageDescRestrictions* getRestrictions() const { return nullptr; }
 
   protected:
     ImageLoaderMap _imageLoaders;
     ImageDescCache _imageCache;
     FileSearchPath _searchPath;
+    StringResolverPtr _resolver;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -43,8 +43,7 @@ bool GLTextureHandler::acquireImage(const FilePath& filePath,
         glewInit();
     }
 
-    // Check to see if we have already loaded in the texture.
-    // If so, reuse the existing texture id
+    // Return a cached image if available.
     const ImageDesc* cachedDesc = getCachedImage(filePath);
     if (cachedDesc)
     {

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -13,6 +13,7 @@
 
 namespace MaterialX
 {
+
 /// Shared pointer to an OpenGL texture handler
 using GLTextureHandlerPtr = std::shared_ptr<class GLTextureHandler>;
 
@@ -21,18 +22,12 @@ using GLTextureHandlerPtr = std::shared_ptr<class GLTextureHandler>;
 class GLTextureHandler : public ImageHandler
 {
   public:
-    /// Static instance create function
     static GLTextureHandlerPtr create(ImageLoaderPtr imageLoader)
     {
-        return std::make_shared<GLTextureHandler>(imageLoader);
+        return GLTextureHandlerPtr(new GLTextureHandler(imageLoader));
     }
 
-    /// Default constructor
-    GLTextureHandler(ImageLoaderPtr imageLoader);
-
-    /// Default destructor
-    virtual ~GLTextureHandler() {}
-
+    virtual ~GLTextureHandler() { }
 
     /// Acquire an image from the cache or file system.  If the image is not
     /// found in the cache, then each image loader will be applied in turn.
@@ -73,31 +68,35 @@ class GLTextureHandler : public ImageHandler
     int getBoundTextureLocation(unsigned int resourceId) override;
 
   protected:
-    /// Unbind an image.
+    // Protected constructor
+    GLTextureHandler(ImageLoaderPtr imageLoader);
+
+    // Unbind an image.
     bool unbindImage(const ImageDesc& imageDesc);
 
-    /// Delete an image
-    /// @param imageDesc Image description indicate which image to delete.
-    /// Any OpenGL texture resource and as well as any CPU side reosurce memory will be deleted.
+    // Delete an image. Any OpenGL texture resource and as well as any CPU-side
+    // resource memory will be deleted.
     void deleteImage(MaterialX::ImageDesc& imageDesc) override;
 
-    /// Return restrictions specific to this handler
+    // Return restrictions specific to this handler
     const ImageDescRestrictions* getRestrictions() const override
     {
         return &_restrictions;
     }
 
-    /// Returns the first free texture location that can be bound to.
+    // Return the first free texture location that can be bound to.
     int getNextAvailableTextureLocation();
 
-    /// Maximum number of available image units
+  protected:
+    // Maximum number of available image units
     int _maxImageUnits;
 
-    /// Support restrictions
+    // Support restrictions
     ImageDescRestrictions _restrictions;
 
     std::vector<unsigned int> _boundTextureLocations;
 };
 
 } // namespace MaterialX
+
 #endif

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -259,9 +259,9 @@ bool GlslProgram::bind()
 }
 
 void GlslProgram::bindInputs(ViewHandlerPtr viewHandler,
-                            GeometryHandlerPtr geometryHandler,
-                            ImageHandlerPtr imageHandler,
-                            LightHandlerPtr lightHandler)
+                             GeometryHandlerPtr geometryHandler,
+                             ImageHandlerPtr imageHandler,
+                             LightHandlerPtr lightHandler)
 {
     // Bind the program to use
     if (!bind())
@@ -530,10 +530,19 @@ bool GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation, con
                               const ImageSamplingProperties& samplingProperties, ImageDesc& desc)
 {
     bool textureBound = false;
-    FilePath resolvedFilePath = imageHandler->getSearchPath().find(filePath);
+
     if (uniformLocation >= 0 &&
         uniformType >= GL_SAMPLER_1D && uniformType <= GL_SAMPLER_CUBE)
     {
+        // Resolve the input filepath.
+        FilePath resolvedFilePath = filePath;
+        if (imageHandler->getFilenameResolver())
+        {
+            resolvedFilePath = imageHandler->getFilenameResolver()->resolve(resolvedFilePath, FILENAME_TYPE_STRING);
+        }
+        resolvedFilePath = imageHandler->getSearchPath().find(resolvedFilePath);
+
+        // Acquire the image.
         if (imageHandler->acquireImage(resolvedFilePath, desc, generateMipMaps, &(samplingProperties.defaultColor)))
         {
             textureBound = imageHandler->bindImage(resolvedFilePath, samplingProperties);

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -373,7 +373,6 @@ void GlslRenderer::renderTextureSpace(bool encodeSrgb)
 
     _program->unbind();
     _program->unbindInputs(_imageHandler);
-    _program->unbindTextures(_imageHandler);
 }
 
 void GlslRenderer::validateInputs()

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -19,35 +19,45 @@ namespace MaterialX
 /// A shared pointer to a TextureBaker
 using TextureBakerPtr = shared_ptr<class TextureBaker>;
 
-class TextureBaker
+class TextureBaker : public GlslRenderer
 {
   public:
-    TextureBaker(unsigned int res = 1024);
-    ~TextureBaker() { }
-
-    static TextureBakerPtr create()
+    static TextureBakerPtr create(unsigned int res = 1024)
     {
-        return std::make_shared<TextureBaker>();
+        return TextureBakerPtr(new TextureBaker(res));
+    }
+
+    /// Set the file extension for baked textures.
+    void setExtension(const string& extension)
+    {
+        _extension = extension;
+    }
+
+    /// Return the file extension for baked textures.
+    const string& getExtension()
+    {
+        return _extension;
     }
 
     /// Bake textures for all graph inputs of the given shader reference.
-    void bakeShaderInputs(ShaderRefPtr shaderRef, const FileSearchPath& searchPath, GenContext& context, const FilePath& outputFolder);
+    void bakeShaderInputs(ShaderRefPtr shaderRef, GenContext& context, const FilePath& outputFolder);
 
     /// Bake a texture for the given graph output.
     void bakeGraphOutput(OutputPtr output, GenContext& context, const FilePath& outputFolder);
 
-    /// Write out a document with baked images.
+    /// Write out the baked material document.
     void writeBakedDocument(ShaderRefPtr shaderRef, const FilePath& filename);
 
   protected:
-    void setSearchPath(const FileSearchPath searchPath) { _searchPath = searchPath; }
-    FileSearchPath getSearchPath() { return _searchPath; }
+    TextureBaker(unsigned int res);
+
+    // Generate a texture filename for the given graph output.
+    FilePath generateTextureFilename(OutputPtr output);
 
   protected:
-    GlslRendererPtr _renderer;
     ShaderGeneratorPtr _generator;
-    FileSearchPath _searchPath;
-    string _fileSuffix;
+    string _udim;
+    string _extension;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -134,17 +134,14 @@ class Material
     void bindViewInformation(const mx::Matrix44& world, const mx::Matrix44& view, const mx::Matrix44& proj);
 
     /// Bind all images for this material.
-    void bindImages(mx::GLTextureHandlerPtr imageHandler,
-                    const mx::FileSearchPath& searchPath,
-                    const std::string& udim);
+    void bindImages(mx::GLTextureHandlerPtr imageHandler, const mx::FileSearchPath& searchPath);
 
     /// Unbbind all images for this material.
     void unbindImages(mx::GLTextureHandlerPtr imageHandler);
 
     /// Bind a single image.
     mx::FilePath bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::GLTextureHandlerPtr imageHandler,
-                           mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, const std::string& udim = mx::EMPTY_STRING,
-                           mx::Color4* fallbackColor = nullptr);
+                           mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, mx::Color4* fallbackColor = nullptr);
 
     /// Bind lights to shader.
     void bindLights(mx::LightHandlerPtr lightHandler, mx::GLTextureHandlerPtr imageHandler, const mx::FileSearchPath& imagePath, 


### PR DESCRIPTION
- Add support for UDIM-based materials.
- Subclass TextureBaker from GlslRenderer for simplicity.
- Move baked filename logic into TextureBaker::generateTextureFilename.
- Clarify related interfaces and documentation in MaterialXRender and MaterialXRenderGlsl.