### PR TITLE
Improvements to image handling

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -452,7 +452,7 @@ StringResolverPtr Element::createStringResolver(const string& geom,
                                                 const string& target,
                                                 const string& type) const
 {
-    StringResolverPtr resolver = std::make_shared<StringResolver>();
+    StringResolverPtr resolver = StringResolver::create();
 
     // Compute file and geom prefixes as this scope.
     resolver->setFilePrefix(getActiveFilePrefix());

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1185,7 +1185,12 @@ class GenericElement : public Element
 class StringResolver
 {
   public:
-    StringResolver() { }
+    /// Create a new string resolver.
+    static StringResolverPtr create()
+    {
+        return StringResolverPtr(new StringResolver());
+    }
+
     virtual ~StringResolver() { }
 
     /// @name File Prefix
@@ -1274,6 +1279,9 @@ class StringResolver
     }
 
     /// @}
+
+  protected:
+    StringResolver() { }
 
   protected:
     string _filePrefix;

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -129,8 +129,7 @@ bool ImageHandler::acquireImage(const FilePath& filePath, ImageDesc& imageDesc, 
     return false;
 }
 
-bool ImageHandler::createColorImage(const Color4& color,
-                                    ImageDesc& desc)
+bool ImageHandler::createColorImage(const Color4& color, ImageDesc& desc)
 {
     unsigned int bufferSize = desc.width * desc.height * desc.channelCount;
     if (bufferSize < 1)
@@ -160,12 +159,12 @@ bool ImageHandler::createColorImage(const Color4& color,
     return true;
 }
 
-bool ImageHandler::bindImage(const FilePath& /*filePath*/, const ImageSamplingProperties& /*samplingProperties*/)
+bool ImageHandler::bindImage(const ImageDesc&, const ImageSamplingProperties&)
 {
     return false;
 }
 
-bool ImageHandler::unbindImage(const FilePath& /*filePath*/)
+bool ImageHandler::unbindImage(const ImageDesc&)
 {
     return false;
 }
@@ -178,23 +177,24 @@ void ImageHandler::cacheImage(const string& filePath, const ImageDesc& desc)
     }
 }
 
-void ImageHandler::uncacheImage(const string& filePath)
-{
-    _imageCache.erase(filePath);
-}
-
-const ImageDesc* ImageHandler::getCachedImage(const string& filePath)
+const ImageDesc* ImageHandler::getCachedImage(const FilePath& filePath)
 {
     if (_imageCache.count(filePath))
     {
         return &(_imageCache[filePath]);
     }
+    if (!filePath.isAbsolute())
+    {
+        for (const FilePath& path : _searchPath)
+        {
+            FilePath combined = path / filePath;
+            if (_imageCache.count(combined))
+            {
+                return &(_imageCache[combined]);
+            }
+        }
+    }
     return nullptr;
-}
-
-FilePath ImageHandler::findFile(const FilePath& filePath)
-{
-    return _searchPath.find(filePath);
 }
 
 void ImageHandler::deleteImage(ImageDesc& imageDesc)

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -22,25 +22,15 @@ using GLTextureHandlerPtr = std::shared_ptr<class GLTextureHandler>;
 class GLTextureHandler : public ImageHandler
 {
   public:
-    static GLTextureHandlerPtr create(ImageLoaderPtr imageLoader)
+    static ImageHandlerPtr create(ImageLoaderPtr imageLoader)
     {
-        return GLTextureHandlerPtr(new GLTextureHandler(imageLoader));
+        return ImageHandlerPtr(new GLTextureHandler(imageLoader));
     }
 
     virtual ~GLTextureHandler() { }
 
     /// Acquire an image from the cache or file system.  If the image is not
     /// found in the cache, then each image loader will be applied in turn.
-    /// @param filePath File path of the image.
-    /// @param imageDesc On success, this image descriptor will be filled out
-    ///    and assigned ownership of a resource buffer.
-    /// @param generateMipMaps Generate mip maps if supported.
-    /// @param fallbackColor Optional uniform color of a fallback texture
-    ///    to create when the image cannot be loaded from the file system.
-    ///    By default, no fallback texture is created.
-    /// @return True if the image was successfully found in the cache or
-    ///    file system.  Returns false if this call generated a fallback
-    ///    texture.
     bool acquireImage(const FilePath& filePath,
                       ImageDesc& imageDesc,
                       bool generateMipMaps,
@@ -49,14 +39,10 @@ class GLTextureHandler : public ImageHandler
     /// Bind an image. This method will bind the texture to an active texture
     /// unit as defined by the corresponding image description. The method
     /// will fail if there are not enough available image units to bind to.
-    /// @param filePath File path of image description to bind.
-    /// @param samplingProperties Sampling properties for the image
-    /// @return true if succeded to bind
-    bool bindImage(const FilePath& filePath, const ImageSamplingProperties& samplingProperties) override;
+    bool bindImage(const ImageDesc& desc, const ImageSamplingProperties& samplingProperties) override;
 
     /// Unbind an image. 
-    /// @param filePath File path to image description to unbind
-    virtual bool unbindImage(const FilePath& filePath) override;
+    virtual bool unbindImage(const ImageDesc& desc) override;
 
     /// Utility to map an address mode enumeration to an OpenGL address mode
     static int mapAddressModeToGL(ImageSamplingProperties::AddressMode addressModeEnum);
@@ -71,12 +57,9 @@ class GLTextureHandler : public ImageHandler
     // Protected constructor
     GLTextureHandler(ImageLoaderPtr imageLoader);
 
-    // Unbind an image.
-    bool unbindImage(const ImageDesc& imageDesc);
-
     // Delete an image. Any OpenGL texture resource and as well as any CPU-side
     // resource memory will be deleted.
-    void deleteImage(MaterialX::ImageDesc& imageDesc) override;
+    void deleteImage(ImageDesc& imageDesc) override;
 
     // Return restrictions specific to this handler
     const ImageDescRestrictions* getRestrictions() const override

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -42,7 +42,7 @@ class GLTextureHandler : public ImageHandler
     bool bindImage(const ImageDesc& desc, const ImageSamplingProperties& samplingProperties) override;
 
     /// Unbind an image. 
-    virtual bool unbindImage(const ImageDesc& desc) override;
+    bool unbindImage(const ImageDesc& desc) override;
 
     /// Utility to map an address mode enumeration to an OpenGL address mode
     static int mapAddressModeToGL(ImageSamplingProperties::AddressMode addressModeEnum);

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -534,18 +534,10 @@ bool GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation, con
     if (uniformLocation >= 0 &&
         uniformType >= GL_SAMPLER_1D && uniformType <= GL_SAMPLER_CUBE)
     {
-        // Resolve the input filepath.
-        FilePath resolvedFilePath = filePath;
-        if (imageHandler->getFilenameResolver())
-        {
-            resolvedFilePath = imageHandler->getFilenameResolver()->resolve(resolvedFilePath, FILENAME_TYPE_STRING);
-        }
-        resolvedFilePath = imageHandler->getSearchPath().find(resolvedFilePath);
-
         // Acquire the image.
-        if (imageHandler->acquireImage(resolvedFilePath, desc, generateMipMaps, &(samplingProperties.defaultColor)))
+        if (imageHandler->acquireImage(filePath, desc, generateMipMaps, &(samplingProperties.defaultColor)))
         {
-            textureBound = imageHandler->bindImage(resolvedFilePath, samplingProperties);
+            textureBound = imageHandler->bindImage(desc, samplingProperties);
             if (textureBound)
             {
                 int textureLocation = imageHandler->getBoundTextureLocation(desc.resourceId);

--- a/source/MaterialXTest/RenderGlsl.cpp
+++ b/source/MaterialXTest/RenderGlsl.cpp
@@ -106,7 +106,7 @@ void GlslShaderRenderTester::createRenderer(std::ostream& log)
 
         // Set image handler on renderer
         mx::StbImageLoaderPtr stbLoader = mx::StbImageLoader::create();
-        mx::GLTextureHandlerPtr imageHandler = mx::GLTextureHandler::create(stbLoader);
+        mx::ImageHandlerPtr imageHandler = mx::GLTextureHandler::create(stbLoader);
         _renderer->setImageHandler(imageHandler);
 
         // Set light handler.

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -661,7 +661,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                     {
                         if (uniform->getType() == mx::Type::FILENAME)
                         {
-                            mx::GLTextureHandlerPtr handler = viewer->getImageHandler();
+                            mx::ImageHandlerPtr handler = viewer->getImageHandler();
                             if (handler)
                             {
                                 mx::StringSet extensions;

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -9,8 +9,8 @@
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 #include <MaterialXGenShader/HwShaderGenerator.h>
+#include <MaterialXRender/ImageHandler.h>
 #include <MaterialXRender/LightHandler.h>
-#include <MaterialXRenderGlsl/GLTextureHandler.h>
 
 #include <nanogui/common.h>
 #include <nanogui/glutil.h>
@@ -134,17 +134,17 @@ class Material
     void bindViewInformation(const mx::Matrix44& world, const mx::Matrix44& view, const mx::Matrix44& proj);
 
     /// Bind all images for this material.
-    void bindImages(mx::GLTextureHandlerPtr imageHandler, const mx::FileSearchPath& searchPath);
+    void bindImages(mx::ImageHandlerPtr imageHandler, const mx::FileSearchPath& searchPath);
 
     /// Unbbind all images for this material.
-    void unbindImages(mx::GLTextureHandlerPtr imageHandler);
+    void unbindImages(mx::ImageHandlerPtr imageHandler);
 
     /// Bind a single image.
-    mx::FilePath bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::GLTextureHandlerPtr imageHandler,
-                           mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, mx::Color4* fallbackColor = nullptr);
+    bool bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
+                   mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, mx::Color4* fallbackColor = nullptr);
 
     /// Bind lights to shader.
-    void bindLights(mx::LightHandlerPtr lightHandler, mx::GLTextureHandlerPtr imageHandler, const mx::FileSearchPath& imagePath, 
+    void bindLights(mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr imageHandler, const mx::FileSearchPath& imagePath, 
                     bool directLighting, bool indirectLighting, mx::HwSpecularEnvironmentMethod specularEnvironmentMethod, int envSamples);
 
     /// Bind the given mesh to this material.
@@ -198,7 +198,7 @@ class Material
     bool _hasTransparency;
     mx::StringSet _uniformVariable;
 
-    std::vector<mx::FilePath> _boundImages;
+    std::vector<mx::ImageDesc> _boundImages;
 };
 
 #endif // MATERIALXVIEW_MATERIAL_H

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1,5 +1,6 @@
 #include <MaterialXView/Viewer.h>
 
+#include <MaterialXRenderGlsl/GLTextureHandler.h>
 #include <MaterialXRenderGlsl/TextureBaker.h>
 
 #include <MaterialXRender/OiioImageLoader.h>
@@ -538,7 +539,7 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
                 imageHandler->setSearchPath(searchPath);
                 if (!material->getUdim().empty())
                 {
-                    mx::StringResolverPtr resolver = std::make_shared<mx::StringResolver>();
+                    mx::StringResolverPtr resolver = mx::StringResolver::create();
                     resolver->setUdimString(material->getUdim());
                     imageHandler->setFilenameResolver(resolver);
                 }

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -71,7 +71,7 @@ class Viewer : public ng::Screen
         return _searchPath;
     }
 
-    mx::GLTextureHandlerPtr getImageHandler() const
+    mx::ImageHandlerPtr getImageHandler() const
     {
         return _imageHandler;
     }
@@ -172,7 +172,7 @@ class Viewer : public ng::Screen
 
     // Resource handlers
     mx::GeometryHandlerPtr _geometryHandler;
-    mx::GLTextureHandlerPtr _imageHandler;
+    mx::ImageHandlerPtr _imageHandler;
     mx::LightHandlerPtr _lightHandler;
 
     // Supporting materials and geometry.

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -88,13 +88,13 @@ class PyImageHandler : public mx::ImageHandler
         );
     }
 
-    bool bindImage(const mx::FilePath& filePath, const mx::ImageSamplingProperties& samplingProperties) override
+    bool bindImage(const mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties) override
     {
         PYBIND11_OVERLOAD(
             bool,
             mx::ImageHandler,
             bindImage,
-            filePath,
+            desc,
             samplingProperties
         );
     }


### PR DESCRIPTION
- Move responsibility for image path resolution from client code to GLTextureHandler::acquireImage.
- Remove duplicate cache lookups in GLTextureHandler::bindImage and GLTextureHandler::unbindImage.
- Add a static create method for StringResolver.