### PR TITLE
Documentation improvements

### DIFF
--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -68,7 +68,6 @@ class Document : public GraphElement
     /// Get a list of source URI's referenced by the document
     StringSet getReferencedSourceUris() const;
 
-    /// @}
     /// @name NodeGraph Elements
     /// @{
 

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -894,8 +894,8 @@ class TypedElement : public Element
     using TypeDefPtr = shared_ptr<class TypeDef>;
 
   public:
-    /// @}
     /// @name Type String
+    /// @{
 
     /// Set the element's type string.
     void setType(const string& type)

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -49,7 +49,6 @@ class Look : public Element
     }
     virtual ~Look() { }
 
-    /// @}
     /// @name MaterialAssign Elements
     /// @{
 

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -254,7 +254,6 @@ class BindInput : public ValueElement
     }
     virtual ~BindInput() { }
 
-    /// @}
     /// @name NodeGraph String
     /// @{
 

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -49,7 +49,6 @@ class Node : public InterfaceElement
     }
     virtual ~Node() { }
 
-    /// @}
     /// @name Connections
     /// @{
 

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -57,7 +57,6 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
     explicit VectorN(const vector<float>& vec) { std::copy(vec.begin(), vec.end(), _arr.begin()); }
     explicit VectorN(const S* begin, const S* end) { std::copy(begin, end, _arr.begin()); }
 
-    /// @}
     /// @name Equality Operators
     /// @{
 
@@ -333,7 +332,6 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
     explicit MatrixN(S s) { std::fill_n(&_arr[0][0], N * N, s); }
     explicit MatrixN(const S* begin, const S* end) { std::copy(begin, end, &_arr[0][0]); }
 
-    /// @}
     /// @name Equality Operators
     /// @{
 
@@ -343,8 +341,8 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
     /// Return true if the given vector differs from this one.
     bool operator!=(const M& rhs) const { return _arr != rhs._arr; }
 
-    /// Return true if the given matrix is equivalent to another
-    /// matrix within a given floating point tolerance
+    /// Return true if the given matrix is equivalent to this one
+    /// within a given floating point tolerance.
     bool isEquivalent(const M& rhs, S tolerance) const
     {
         for (size_t i = 0; i < N; i++)

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -71,7 +71,6 @@ class Value
     /// Create a deep copy of the value.
     virtual ValuePtr copy() const = 0;
 
-    /// @}
     /// @name Data Accessors
     /// @{
 

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -51,14 +51,6 @@ class ImageDesc
     /// Preset image type identifiers
     static ImageType IMAGETYPE_2D;
 
-    /// Deallocator to free resource buffer memory. If not defined then malloc() is
-    /// assumed to have been used to allocate the buffer and corresponding free() is
-    /// used to deallocate.
-    ImageBufferDeallocator resourceBufferDeallocator = [](void *buffer)
-    {
-        free(buffer);
-    };
-
     /// Compute the number of mip map levels based on size of the image
     void computeMipCount()
     {
@@ -79,6 +71,11 @@ class ImageDesc
 
     // CPU buffer. May be empty.
     void* resourceBuffer = nullptr;
+
+    // Deallocator to free resource buffer memory. If not defined then malloc() is
+    // assumed to have been used to allocate the buffer and corresponding free() is
+    // used to deallocate.
+    ImageBufferDeallocator resourceBufferDeallocator = nullptr;
 
     // Hardware target dependent resource identifier. May be undefined.
     unsigned int resourceId = 0;
@@ -259,20 +256,19 @@ class ImageHandler
                               const Color4* fallbackColor = nullptr);
 
     /// Utility to create a solid color color image
-    /// @param color Color to set
-    /// @param imageDesc Description of image updated during load.
-    /// @return if creation succeeded
+    /// @param color Uniform color of the image to create
+    /// @param imageDesc On success, the newly created image description
+    /// @return True if the image was successfully created
     virtual bool createColorImage(const Color4& color, ImageDesc& imageDesc);
 
     /// Bind an image. Derived classes should implement this method to handle logical binding of
     /// an image resource. The default implementation performs no action.
-    /// @param filePath File path of image description to bind.
+    /// @param desc The image description to bind
     /// @param samplingProperties Sampling properties for the image
-    /// @return true if succeded to bind
     virtual bool bindImage(const ImageDesc& desc, const ImageSamplingProperties& samplingProperties);
 
     /// Unbind an image. The default implementation performs no action.
-    /// @param filePath File path to image description to unbind
+    /// @param desc The image description to unbind
     virtual bool unbindImage(const ImageDesc& desc);
 
     /// Clear the contents of the image cache.

--- a/source/MaterialXRender/ViewHandler.h
+++ b/source/MaterialXRender/ViewHandler.h
@@ -77,7 +77,6 @@ class ViewHandler
         return _worldMatrix;
     }
 
-    /// @}
     /// @name General utilities
     /// @{
 

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -19,6 +19,8 @@ namespace MaterialX
 /// A shared pointer to a TextureBaker
 using TextureBakerPtr = shared_ptr<class TextureBaker>;
 
+/// @class TextureBaker
+/// A helper class for baking procedural material content to textures.
 class TextureBaker : public GlslRenderer
 {
   public:


### PR DESCRIPTION
- Update descriptions in Doxygen comments.
- Fix mismatched groups in Doxygen comments.
- Use nullptr as the default value for ImageDesc::resourceBufferDeallocator, since this has the same behavior as an explicit call to free().