### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXGenShader/Nodes/SwitchNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SwitchNode.cpp
@@ -48,16 +48,13 @@ void SwitchNode::emitFunctionCall(const ShaderNode& node, GenContext& context, S
             {
                 shadergen.emitString("else ", stage);
             }
-            if (branch < 5)
-            {
-                // 'which' can be float, integer or boolean, 
-                // so always convert to float to make sure the comparison is valid
-                shadergen.emitString("if (float(", stage); 
-                shadergen.emitInput(which, context, stage);
-                shadergen.emitString(") < ", stage);
-                shadergen.emitValue(float(branch + 1), stage);
-                shadergen.emitString(")", stage);
-            }
+            // Convert to float to insure a valid comparison, since the 'which'
+            // input may be float, integer or boolean.
+            shadergen.emitString("if (float(", stage); 
+            shadergen.emitInput(which, context, stage);
+            shadergen.emitString(") < ", stage);
+            shadergen.emitValue(float(branch + 1), stage);
+            shadergen.emitString(")", stage);
             shadergen.emitLineEnd(stage, false);
 
             shadergen.emitScopeBegin(stage);

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -250,11 +250,15 @@ void ShaderGraph::addDefaultGeomNode(ShaderInput* input, const GeomPropDef& geom
 
 void ShaderGraph::addColorTransformNode(ShaderInput* input, const ColorSpaceTransform& transform, GenContext& context)
 {
-    ColorManagementSystemPtr colorManagementSystem = context.getShaderGenerator().getColorManagementSystem();
-    if (!input->isBindInput() && (!colorManagementSystem || input->getConnection()))
+    // Ignore connected node inputs, which don't support colorspace attributes.
+    if (!input->isBindInput() && input->getConnection())
     {
-        // Ignore unbound inputs with connections as they are not 
-        // allowed to have colorspaces specified.
+        return;
+    }
+
+    ColorManagementSystemPtr colorManagementSystem = context.getShaderGenerator().getColorManagementSystem();
+    if (!colorManagementSystem)
+    {
         return;
     }
     const string colorTransformNodeName = input->getFullName() + "_cm";
@@ -318,8 +322,14 @@ void ShaderGraph::addColorTransformNode(ShaderOutput* output, const ColorSpaceTr
 
 void ShaderGraph::addUnitTransformNode(ShaderInput* input, const UnitTransform& transform, GenContext& context)
 {
+    // Ignore connected node inputs, which don't support unit attributes.
+    if (!input->isBindInput() && input->getConnection())
+    {
+        return;
+    }
+
     UnitSystemPtr unitSystem = context.getShaderGenerator().getUnitSystem();
-    if (!input->isBindInput() && (!unitSystem || input->getConnection()))
+    if (!unitSystem)
     {
         return;
     }

--- a/source/MaterialXGenShader/UnitConverter.cpp
+++ b/source/MaterialXGenShader/UnitConverter.cpp
@@ -76,7 +76,7 @@ float LinearUnitConverter::convert(float input, const string& inputUnit, const s
     return input * conversionRatio(inputUnit, outputUnit);
 }
 
-Vector2 LinearUnitConverter::convert(Vector2 input, const string& inputUnit, const string& outputUnit) const
+Vector2 LinearUnitConverter::convert(const Vector2& input, const string& inputUnit, const string& outputUnit) const
 {
     if (inputUnit == outputUnit)
     {
@@ -86,7 +86,7 @@ Vector2 LinearUnitConverter::convert(Vector2 input, const string& inputUnit, con
     return input * conversionRatio(inputUnit, outputUnit);
 }
 
-Vector3 LinearUnitConverter::convert(Vector3 input, const string& inputUnit, const string& outputUnit) const
+Vector3 LinearUnitConverter::convert(const Vector3& input, const string& inputUnit, const string& outputUnit) const
 {
     if (inputUnit == outputUnit)
     {
@@ -96,7 +96,7 @@ Vector3 LinearUnitConverter::convert(Vector3 input, const string& inputUnit, con
     return input * conversionRatio(inputUnit, outputUnit);
 }
 
-Vector4 LinearUnitConverter::convert(Vector4 input, const string& inputUnit, const string& outputUnit) const
+Vector4 LinearUnitConverter::convert(const Vector4& input, const string& inputUnit, const string& outputUnit) const
 {
     if (inputUnit == outputUnit)
     {

--- a/source/MaterialXGenShader/UnitConverter.h
+++ b/source/MaterialXGenShader/UnitConverter.h
@@ -63,19 +63,19 @@ class UnitConverter
     /// @param input Input value to convert
     /// @param inputUnit Unit of input value
     /// @param outputUnit Unit for output value
-    virtual Vector2 convert(Vector2 input, const string& inputUnit, const string& outputUnit) const = 0;
+    virtual Vector2 convert(const Vector2& input, const string& inputUnit, const string& outputUnit) const = 0;
 
     /// Convert a given value in a given unit to a desired unit
     /// @param input Input value to convert
     /// @param inputUnit Unit of input value
     /// @param outputUnit Unit for output value
-    virtual Vector3 convert(Vector3 input, const string& inputUnit, const string& outputUnit) const = 0;
+    virtual Vector3 convert(const Vector3& input, const string& inputUnit, const string& outputUnit) const = 0;
 
     /// Convert a given value in a given unit to a desired unit
     /// @param input Input value to convert
     /// @param inputUnit Unit of input value
     /// @param outputUnit Unit for output value
-    virtual Vector4 convert(Vector4 input, const string& inputUnit, const string& outputUnit) const = 0;
+    virtual Vector4 convert(const Vector4& input, const string& inputUnit, const string& outputUnit) const = 0;
 };
 
 /// @class LinearUnitConverter
@@ -119,19 +119,19 @@ class LinearUnitConverter : public UnitConverter
     /// @param input Input value to convert
     /// @param inputUnit Unit of input value
     /// @param outputUnit Unit for output value
-    Vector2 convert(Vector2 input, const string& inputUnit, const string& outputUnit) const override;
+    Vector2 convert(const Vector2& input, const string& inputUnit, const string& outputUnit) const override;
 
     /// Convert a given value in a given unit to a desired unit
     /// @param input Input value to convert
     /// @param inputUnit Unit of input value
     /// @param outputUnit Unit for output value
-    Vector3 convert(Vector3 input, const string& inputUnit, const string& outputUnit) const override;
+    Vector3 convert(const Vector3& input, const string& inputUnit, const string& outputUnit) const override;
 
     /// Convert a given value in a given unit to a desired unit
     /// @param input Input value to convert
     /// @param inputUnit Unit of input value
     /// @param outputUnit Unit for output value
-    Vector4 convert(Vector4 input, const string& inputUnit, const string& outputUnit) const override;
+    Vector4 convert(const Vector4& input, const string& inputUnit, const string& outputUnit) const override;
 
     /// @}
     /// @name Shader Mapping

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -13,6 +13,12 @@
 namespace MaterialX
 {
 
+const string IMAGE_PROPERTY_SEPARATOR("_");
+const string UADDRESS_MODE_SUFFIX(IMAGE_PROPERTY_SEPARATOR + "uaddressmode");
+const string VADDRESS_MODE_SUFFIX(IMAGE_PROPERTY_SEPARATOR + "vaddressmode");
+const string FILTER_TYPE_SUFFIX(IMAGE_PROPERTY_SEPARATOR + "filtertype");
+const string DEFAULT_COLOR_SUFFIX(IMAGE_PROPERTY_SEPARATOR + "default");
+
 string ImageDesc::BASETYPE_UINT8 = "UINT8";
 string ImageDesc::BASETYPE_HALF = "HALF";
 string ImageDesc::BASETYPE_FLOAT = "FLOAT";
@@ -214,38 +220,33 @@ void ImageHandler::clearImageCache()
 void ImageSamplingProperties::setProperties(const string& fileNameUniform,
                                             const VariableBlock& uniformBlock)
 {
-    const string IMAGE_SEPARATOR("_");
-    const string UADDRESS_MODE_POST_FIX("_uaddressmode");
-    const string VADDRESS_MODE_POST_FIX("_vaddressmode");
-    const string FILTER_TYPE_POST_FIX("_filtertype");
-    const string DEFAULT_COLOR_POST_FIX("_default");
     const int INVALID_MAPPED_INT_VALUE = -1; // Any value < 0 is not considered to be invalid
 
     // Get the additional texture parameters based on image uniform name
     // excluding the trailing "_file" postfix string
     string root = fileNameUniform;
-    size_t pos = root.find_last_of(IMAGE_SEPARATOR);
+    size_t pos = root.find_last_of(IMAGE_PROPERTY_SEPARATOR);
     if (pos != string::npos)
     {
         root = root.substr(0, pos);
     }
 
-    const string uaddressmodeStr = root + UADDRESS_MODE_POST_FIX;
+    const string uaddressmodeStr = root + UADDRESS_MODE_SUFFIX;
     const ShaderPort* port = uniformBlock.find(uaddressmodeStr);
     ValuePtr intValue = port ? port->getValue() : nullptr;
     uaddressMode = ImageSamplingProperties::AddressMode(intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE);
 
-    const string vaddressmodeStr = root + VADDRESS_MODE_POST_FIX;
+    const string vaddressmodeStr = root + VADDRESS_MODE_SUFFIX;
     port = uniformBlock.find(vaddressmodeStr);
     intValue = port ? port->getValue() : nullptr;
     vaddressMode = ImageSamplingProperties::AddressMode(intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE);
 
-    const string filtertypeStr = root + FILTER_TYPE_POST_FIX;
+    const string filtertypeStr = root + FILTER_TYPE_SUFFIX;
     port = uniformBlock.find(filtertypeStr);
     intValue = port ? port->getValue() : nullptr;
     filterType = ImageSamplingProperties::FilterType(intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE);
 
-    const string defaultColorStr = root + DEFAULT_COLOR_POST_FIX;
+    const string defaultColorStr = root + DEFAULT_COLOR_SUFFIX;
     port = uniformBlock.find(defaultColorStr);
     ValuePtr colorValue = port ? port->getValue() : nullptr;
     if (colorValue)

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -20,6 +20,12 @@
 namespace MaterialX
 {
 
+extern const string IMAGE_PROPERTY_SEPARATOR;
+extern const string UADDRESS_MODE_SUFFIX;
+extern const string VADDRESS_MODE_SUFFIX;
+extern const string FILTER_TYPE_SUFFIX;
+extern const string DEFAULT_COLOR_SUFFIX;
+
 class VariableBlock;
 
 /// A function to perform image buffer deallocation

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -62,12 +62,12 @@ bool Mesh::generateTangents(MeshStreamPtr positionStream, MeshStreamPtr texcoord
 
         // Based on Eric Lengyel at http://www.terathon.com/code/tangent.html
 
-        const MeshIndexBuffer& indicies = part->getIndices();
+        const MeshIndexBuffer& indices = part->getIndices();
         for (size_t faceIndex = 0; faceIndex < part->getFaceCount(); faceIndex++)
         {
-            int i1 = indicies[faceIndex * MeshStream::STRIDE_3D + 0];
-            int i2 = indicies[faceIndex * MeshStream::STRIDE_3D + 1];
-            int i3 = indicies[faceIndex * MeshStream::STRIDE_3D + 2];
+            uint32_t i1 = indices[faceIndex * MeshStream::STRIDE_3D + 0];
+            uint32_t i2 = indices[faceIndex * MeshStream::STRIDE_3D + 1];
+            uint32_t i3 = indices[faceIndex * MeshStream::STRIDE_3D + 2];
 
             Vector3& v1 = *reinterpret_cast<Vector3*>(&(positions[i1 * positionStride]));
             Vector3& v2 = *reinterpret_cast<Vector3*>(&(positions[i2 * positionStride]));
@@ -172,7 +172,7 @@ void Mesh::splitByUdims()
 
     using UdimMap = std::map<uint32_t, MeshPartitionPtr>;
     UdimMap udimMap;
-    const unsigned int FACE_VERTEX_COUNT = 3;
+    const size_t FACE_VERTEX_COUNT = 3;
     for (size_t p = 0; p < getPartitionCount(); p++)
     {
         MeshPartitionPtr part = getPartition(p);

--- a/source/MaterialXRender/Mesh.h
+++ b/source/MaterialXRender/Mesh.h
@@ -15,7 +15,7 @@ namespace MaterialX
 {
 
 /// Geometry index buffer
-using MeshIndexBuffer = vector<unsigned int>;
+using MeshIndexBuffer = vector<uint32_t>;
 /// Float geometry buffer
 using MeshFloatBuffer = vector<float>;
 
@@ -59,9 +59,9 @@ class MeshStream
     }
 
     /// Resize data to an given number of elements
-    void resize(unsigned int elementCount)
+    void resize(size_t elementCount)
     {
-        _data.resize((size_t) elementCount * (size_t) _stride);
+        _data.resize(elementCount * (size_t) _stride);
     }
 
     /// Get stream name
@@ -143,7 +143,7 @@ class MeshPartition
     }
 
     /// Resize data to the given number of indices
-    void resize(unsigned int indexCount)
+    void resize(size_t indexCount)
     {
         _indices.resize(indexCount);
     }

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -94,7 +94,7 @@ class ShaderRenderer
 
     /// Create program based on an input shader
     /// @param shader Input Shader
-    virtual void createProgram(const ShaderPtr shader) = 0;
+    virtual void createProgram(ShaderPtr shader) = 0;
 
     /// Create program based on shader stage source code.
     /// @param stages Map of name and source code for the shader stages.

--- a/source/MaterialXRender/TinyObjLoader.cpp
+++ b/source/MaterialXRender/TinyObjLoader.cpp
@@ -79,9 +79,9 @@ bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
     Vector3 boxMin = { MAX_FLOAT, MAX_FLOAT, MAX_FLOAT };
     Vector3 boxMax = { -MAX_FLOAT, -MAX_FLOAT, -MAX_FLOAT };
 
-    int writeIndex0 = 0;
-    int writeIndex1 = 1;
-    int writeIndex2 = 2;
+    uint32_t writeIndex0 = 0;
+    uint32_t writeIndex1 = 1;
+    uint32_t writeIndex2 = 2;
 
     const size_t FACE_VERTEX_COUNT = 3;
     for (const tinyobj::shape_t& shape : shapes)

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -270,7 +270,7 @@ bool GlslRenderer::bindTarget(bool bind)
     return true;
 }
 
-void GlslRenderer::createProgram(const ShaderPtr shader)
+void GlslRenderer::createProgram(ShaderPtr shader)
 {
     StringVec errors;
     const string errorType("GLSL program creation error.");
@@ -464,8 +464,7 @@ void GlslRenderer::render()
     try
     {
         // Bind program and input parameters
-        bool useFixed = false;
-        if (_program && !useFixed)
+        if (_program)
         {
             // Check if we have any attributes to bind. If not then
             // there is nothing to draw
@@ -523,11 +522,6 @@ void GlslRenderer::save(const FilePath& filePath, bool floatingPoint)
 
     size_t bufferSize = _frameBufferWidth * _frameBufferHeight * 4;
     float* buffer = new float[bufferSize];
-    if (!buffer)
-    {
-        errors.push_back("Failed to read color buffer back.");
-        throw ExceptionShaderRenderError(errorType, errors);
-    }
 
     // Read back from the color texture.
     bindTarget(true);

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -61,7 +61,7 @@ class GlslRenderer : public ShaderRenderer
 
     /// Create GLSL program based on an input shader
     /// @param shader Input HwShader
-    void createProgram(const ShaderPtr shader) override;
+    void createProgram(ShaderPtr shader) override;
 
     /// Create GLSL program based on shader stage source code.
     /// @param stages Map of name and source code for the shader stages.

--- a/source/MaterialXRenderHw/WindowWrapper.cpp
+++ b/source/MaterialXRenderHw/WindowWrapper.cpp
@@ -44,7 +44,7 @@ WindowWrapper::WindowWrapper(ExternalWindowHandle externalHandle,
 WindowWrapper::WindowWrapper(const WindowWrapper& other)
 {
     _externalHandle = other._externalHandle;
-    if (_externalHandle && !_internalHandle)
+    if (_externalHandle && !other._internalHandle)
     {
         // Cache a HDC that corresponds to the window handle
         _internalHandle = GetDC(_externalHandle);
@@ -60,7 +60,7 @@ const WindowWrapper& WindowWrapper::operator=(const WindowWrapper& other)
     release();
 
     _externalHandle = other._externalHandle;
-    if (_externalHandle && !_internalHandle)
+    if (_externalHandle && !other._internalHandle)
     {
         // Cache a HDC that corresponds to the window handle
         _internalHandle = GetDC(_externalHandle);

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -302,7 +302,7 @@ void OslRenderer::compileOSL(const FilePath& oslFilePath)
     }
 }
 
-void OslRenderer::createProgram(const ShaderPtr shader)
+void OslRenderer::createProgram(ShaderPtr shader)
 {
     StageMap stages = { {Stage::PIXEL, shader->getStage(Stage::PIXEL).getSourceCode()} };
     createProgram(stages);

--- a/source/MaterialXRenderOsl/OslRenderer.h
+++ b/source/MaterialXRenderOsl/OslRenderer.h
@@ -63,7 +63,7 @@ class OslRenderer : public ShaderRenderer
     /// If render validation is not required, then the same temporary name will be used for
     /// all shaders validated using this method.
     /// @param shader Input shader
-    void createProgram(const ShaderPtr shader) override;
+    void createProgram(ShaderPtr shader) override;
 
     /// Create OSL program based on shader stage source code.
     /// @param stages Map of name and source code for the shader stages.

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -189,6 +189,11 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
 {
     const mx::UIProperties& ui = item.ui;
     mx::ValuePtr value = item.variable->getValue();
+    if (!value)
+    {
+        return;
+    }
+
     std::string label = item.label;
     const std::string& unit = item.variable->getUnit();
     if (!unit.empty())
@@ -200,11 +205,6 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
     mx::ValuePtr max = ui.uiMax;
     const mx::StringVec& enumeration = ui.enumeration;
     const std::vector<mx::ValuePtr> enumValues = ui.enumerationValues;
-
-    if (!value)
-    {
-        return;
-    }
 
     if (!group.empty())
     {
@@ -315,7 +315,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                material->setUniformFloat(path, v);
+                material->setUniformFloat(path, (float) v);
             }
         });
     }

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -142,7 +142,7 @@ class Material
 
     /// Bind a single image.
     bool bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
-                   mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, mx::Color4* fallbackColor = nullptr);
+                   mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, const mx::Color4* fallbackColor = nullptr);
 
     /// Bind lights to shader.
     void bindLights(mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr imageHandler, const mx::FileSearchPath& imagePath, 

--- a/source/PyMaterialX/PyMaterialXGenShader/PyUnitConverter.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyUnitConverter.cpp
@@ -25,7 +25,7 @@ class PyUnitConverter : public mx::UnitConverter
         );
     }
 
-    mx::Vector2 convert(mx::Vector2 input, const std::string& inputUnit, const std::string& outputUnit) const override
+    mx::Vector2 convert(const mx::Vector2& input, const std::string& inputUnit, const std::string& outputUnit) const override
     {
         PYBIND11_OVERLOAD_PURE(
             mx::Vector2,
@@ -37,7 +37,7 @@ class PyUnitConverter : public mx::UnitConverter
         );
     }
 
-    mx::Vector3 convert(mx::Vector3 input, const std::string& inputUnit, const std::string& outputUnit) const override
+    mx::Vector3 convert(const mx::Vector3& input, const std::string& inputUnit, const std::string& outputUnit) const override
     {
         PYBIND11_OVERLOAD_PURE(
             mx::Vector3,
@@ -49,7 +49,7 @@ class PyUnitConverter : public mx::UnitConverter
         );
     }
 
-    mx::Vector4 convert(mx::Vector4 input, const std::string& inputUnit, const std::string& outputUnit) const override
+    mx::Vector4 convert(const mx::Vector4& input, const std::string& inputUnit, const std::string& outputUnit) const override
     {
         PYBIND11_OVERLOAD_PURE(
             mx::Vector4,
@@ -67,10 +67,10 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
 void bindPyUnitConverters(py::module& mod)
 {
     py::class_<mx::UnitConverter, PyUnitConverter, mx::UnitConverterPtr>(mod, "UnitConverter")
-        .def("convert", (float       (mx::UnitConverter::*)(float      , const std::string&, const std::string&)const) &mx::UnitConverter::convert)
-        .def("convert", (mx::Vector2 (mx::UnitConverter::*)(mx::Vector2, const std::string&, const std::string&)const) &mx::UnitConverter::convert)
-        .def("convert", (mx::Vector3 (mx::UnitConverter::*)(mx::Vector3, const std::string&, const std::string&)const) &mx::UnitConverter::convert)
-        .def("convert", (mx::Vector4 (mx::UnitConverter::*)(mx::Vector4, const std::string&, const std::string&)const) &mx::UnitConverter::convert)
+        .def("convert", (float       (mx::UnitConverter::*)(float, const std::string&, const std::string&)const) &mx::UnitConverter::convert)
+        .def("convert", (mx::Vector2 (mx::UnitConverter::*)(const mx::Vector2&, const std::string&, const std::string&)const) &mx::UnitConverter::convert)
+        .def("convert", (mx::Vector3 (mx::UnitConverter::*)(const mx::Vector3&, const std::string&, const std::string&)const) &mx::UnitConverter::convert)
+        .def("convert", (mx::Vector4 (mx::UnitConverter::*)(const mx::Vector4&, const std::string&, const std::string&)const) &mx::UnitConverter::convert)
         .def("getUnitAsInteger", &mx::UnitConverter::getUnitAsInteger)
         .def("getUnitFromInteger", &mx::UnitConverter::getUnitFromInteger);
 
@@ -78,9 +78,9 @@ void bindPyUnitConverters(py::module& mod)
         .def_static("create", &mx::LinearUnitConverter::create)
         .def("getUnitScale", &mx::LinearUnitConverter::getUnitScale)
         .def("convert", (float       (mx::LinearUnitConverter::*)(float, const std::string&, const std::string&)const) &mx::LinearUnitConverter::convert)
-        .def("convert", (mx::Vector2 (mx::LinearUnitConverter::*)(mx::Vector2, const std::string&, const std::string&)const) &mx::LinearUnitConverter::convert)
-        .def("convert", (mx::Vector3 (mx::LinearUnitConverter::*)(mx::Vector3, const std::string&, const std::string&)const) &mx::LinearUnitConverter::convert)
-        .def("convert", (mx::Vector4 (mx::LinearUnitConverter::*)(mx::Vector4, const std::string&, const std::string&)const) &mx::LinearUnitConverter::convert)
+        .def("convert", (mx::Vector2 (mx::LinearUnitConverter::*)(const mx::Vector2&, const std::string&, const std::string&)const) &mx::LinearUnitConverter::convert)
+        .def("convert", (mx::Vector3 (mx::LinearUnitConverter::*)(const mx::Vector3&, const std::string&, const std::string&)const) &mx::LinearUnitConverter::convert)
+        .def("convert", (mx::Vector4 (mx::LinearUnitConverter::*)(const mx::Vector4&, const std::string&, const std::string&)const) &mx::LinearUnitConverter::convert)
         .def("getUnitAsInteger", &mx::LinearUnitConverter::getUnitAsInteger)
         .def("getUnitFromInteger", &mx::LinearUnitConverter::getUnitFromInteger);
 

--- a/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
@@ -27,7 +27,7 @@ class PyShaderRenderer : public mx::ShaderRenderer
         );
     }
 
-    void createProgram(const mx::ShaderPtr shader) override
+    void createProgram(mx::ShaderPtr shader) override
     {
         PYBIND11_OVERLOAD_PURE(
             void,
@@ -88,7 +88,7 @@ void bindPyShaderRenderer(py::module& mod)
         .def("getGeometryHandler", &mx::ShaderRenderer::getGeometryHandler)
         .def("setViewHandler", &mx::ShaderRenderer::setViewHandler)
         .def("getViewHandler", &mx::ShaderRenderer::getViewHandler)
-        .def("createProgram", static_cast<void (mx::ShaderRenderer::*)(const mx::ShaderPtr)>(&mx::ShaderRenderer::createProgram))
+        .def("createProgram", static_cast<void (mx::ShaderRenderer::*)(mx::ShaderPtr)>(&mx::ShaderRenderer::createProgram))
         .def("createProgram", static_cast<void (mx::ShaderRenderer::*)(const mx::ShaderRenderer::StageMap&)>(&mx::ShaderRenderer::createProgram))
         .def("validateInputs", &mx::ShaderRenderer::validateInputs)
         .def("render", &mx::ShaderRenderer::render)


### PR DESCRIPTION
Fixes for static analysis warnings reported by PVS, including the following:

- Fix references to undefined variables in constructors.
- Fix inconsistent null checks.
- Fix exception instantiations without calls to throw.
- Remove conditional expressions that always evaluate to true.
- Move common constants to shared locations.
- Const-correctness and type-matching fixes.