### PR TITLE
Improvements to image functionality

### DIFF
--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -12,9 +12,7 @@
 #include <MaterialXFormat/File.h>
 
 #include <MaterialXCore/Element.h>
-#include <MaterialXCore/Types.h>
 
-#include <cmath>
 #include <map>
 
 namespace MaterialX
@@ -26,73 +24,127 @@ extern const string VADDRESS_MODE_SUFFIX;
 extern const string FILTER_TYPE_SUFFIX;
 extern const string DEFAULT_COLOR_SUFFIX;
 
+class Image;
 class VariableBlock;
+
+/// A shared pointer to an image
+using ImagePtr = shared_ptr<Image>;
 
 /// A function to perform image buffer deallocation
 using ImageBufferDeallocator = std::function<void(void*)>;
 
-/// @class ImageDesc
-/// Interface to describe an image. Images are assumed to be float type.
-class ImageDesc
+/// @class Image
+/// A class representing an image in memory
+class Image
 {
   public:
-    ~ImageDesc()
+    enum class BaseType
     {
-        freeResourceBuffer();
-    }
-
-    /// Image base type identifier
-    using BaseType = string;
-    /// Set of base type identifiers
-    using BaseTypeSet = std::set<BaseType>;
-
-    /// Preset base type identifiers
-    static BaseType BASETYPE_UINT8;
-    static BaseType BASETYPE_HALF;
-    static BaseType BASETYPE_FLOAT;
-
-    /// Image type identifier
-    using ImageType = string;
-
-    /// Preset image type identifiers
-    static ImageType IMAGETYPE_2D;
-
-    /// Compute the number of mip map levels based on size of the image
-    void computeMipCount()
-    {
-        mipCount = (unsigned int) std::log2(std::max(width, height)) + 1;
-    }
-
-    /// Free any resource buffer memory
-    void freeResourceBuffer();
+        UINT8 = 0,
+        HALF = 1,
+        FLOAT = 2
+    };
 
   public:
-    unsigned int width = 0;
-    unsigned int height = 0;
-    unsigned int channelCount = 0;
-    unsigned int mipCount = 0;
+    /// Create an empty image with the given properties.
+    static ImagePtr create(unsigned int width, unsigned int height, unsigned int channelCount, BaseType baseType = BaseType::UINT8)
+    {
+        return ImagePtr(new Image(width, height, channelCount, baseType));
+    }
 
-    BaseType baseType = BASETYPE_UINT8;
-    ImageType imageType = IMAGETYPE_2D;
+    /// Create a constant color image with the given properties.
+    static ImagePtr createConstantColor(unsigned int width, unsigned int height, const Color4& color);
 
-    // CPU buffer. May be empty.
-    void* resourceBuffer = nullptr;
+    ~Image();
 
-    // Deallocator to free resource buffer memory. If not defined then malloc() is
-    // assumed to have been used to allocate the buffer and corresponding free() is
-    // used to deallocate.
-    ImageBufferDeallocator resourceBufferDeallocator = nullptr;
+    /// Return the width of the image.
+    unsigned int getWidth() const
+    {
+        return _width;
+    }
 
-    // Hardware target dependent resource identifier. May be undefined.
-    unsigned int resourceId = 0;
-};
+    /// Return the height of the image.
+    unsigned int getHeight() const
+    {
+        return _height;
+    }
 
-/// Structure containing harware image description restrictions
-class ImageDescRestrictions
-{
-  public:
-    /// List of base types that can be supported
-    ImageDesc::BaseTypeSet supportedBaseTypes;
+    /// Return the channel count of the image.
+    unsigned int getChannelCount() const
+    {
+        return _channelCount;
+    }
+
+    /// Return the base type of the image.
+    BaseType getBaseType() const
+    {
+        return _baseType;
+    }
+
+    /// Return the stride of our base type in bytes.
+    unsigned int getBaseStride() const;
+
+    /// Return the maximum number of mipmaps for this image.
+    unsigned int getMaxMipCount() const;
+
+    /// Set the resource buffer for this image.
+    void setResourceBuffer(void* buffer)
+    {
+        _resourceBuffer = buffer;
+    }
+
+    /// Return the resource buffer for this image.
+    void* getResourceBuffer() const
+    {
+        return _resourceBuffer;
+    }
+
+    /// Set the resource buffer deallocator for this image.
+    void setResourceBufferDeallocator(ImageBufferDeallocator deallocator)
+    {
+        _resourceBufferDeallocator = deallocator;
+    }
+
+    /// Return the resource buffer deallocator for this image.
+    ImageBufferDeallocator getResourceBufferDeallocator() const
+    {
+        return _resourceBufferDeallocator;
+    }
+
+    /// Set the resource ID for this image.
+    void setResourceId(unsigned int id)
+    {
+        _resourceId = id;
+    }
+
+    /// Return the resource ID for this image.
+    unsigned int getResourceId() const
+    {
+        return _resourceId;
+    }
+
+    /// Return the texel color at the given coordinates.  If the coordinates
+    /// or image resource buffer are invalid, then an exception is thrown.
+    Color4 getTexelColor(unsigned int x, unsigned int y) const;
+
+    /// Allocate a resource buffer for this image that matches its properties.
+    void createResourceBuffer();
+
+    /// Release the resource buffer for this image.
+    void releaseResourceBuffer();
+
+  protected:
+    Image(unsigned int width, unsigned int height, unsigned int channelCount, BaseType baseType);
+
+  protected:
+    unsigned int _width;
+    unsigned int _height;
+    unsigned int _channelCount;
+    BaseType _baseType;
+
+    void* _resourceBuffer;
+    ImageBufferDeallocator _resourceBufferDeallocator;
+    unsigned int _resourceId;
 };
 
 /// @class ImageSamplingProperties
@@ -141,8 +193,8 @@ class ImageSamplingProperties
     Color4 defaultColor = { 0.0f, 0.0f, 0.0f, 1.0f };
 };
 
-/// A map from strings to image descriptions.
-using ImageDescMap = std::unordered_map<string, ImageDesc>;
+/// A map from strings to images.
+using ImageMap = std::unordered_map<string, ImagePtr>;
 
 /// Shared pointer to an ImageLoader
 using ImageLoaderPtr = std::shared_ptr<class ImageLoader>;
@@ -157,22 +209,22 @@ class ImageLoader
     }
     virtual ~ImageLoader() { }
 
-    /// Stock extension names
-    static string BMP_EXTENSION;
-    static string EXR_EXTENSION;
-    static string GIF_EXTENSION;
-    static string HDR_EXTENSION;
-    static string JPG_EXTENSION;
-    static string JPEG_EXTENSION;
-    static string PIC_EXTENSION;
-    static string PNG_EXTENSION;
-    static string PSD_EXTENSION;
-    static string TGA_EXTENSION;
-    static string TIF_EXTENSION;
-    static string TIFF_EXTENSION;
-    static string TXT_EXTENSION;
-    static string TX_EXTENSION;
-    static string TXR_EXTENSION;
+    /// Standard image file extensions
+    static const string BMP_EXTENSION;
+    static const string EXR_EXTENSION;
+    static const string GIF_EXTENSION;
+    static const string HDR_EXTENSION;
+    static const string JPG_EXTENSION;
+    static const string JPEG_EXTENSION;
+    static const string PIC_EXTENSION;
+    static const string PNG_EXTENSION;
+    static const string PSD_EXTENSION;
+    static const string TGA_EXTENSION;
+    static const string TIF_EXTENSION;
+    static const string TIFF_EXTENSION;
+    static const string TXT_EXTENSION;
+    static const string TX_EXTENSION;
+    static const string TXR_EXTENSION;
 
     /// Returns a list of supported extensions
     /// @return List of support extensions
@@ -181,25 +233,22 @@ class ImageLoader
         return _extensions;
     }
 
-    /// Save image to disk. This method must be implemented by derived classes.
+    /// Save an image to the file system. This method must be implemented by derived classes.
     /// @param filePath Path to save image to
     /// @param imageDesc Description of image
     /// @param verticalFlip Whether the image should be flipped in Y during save
     /// @return if save succeeded
     virtual bool saveImage(const FilePath& filePath,
-                           const ImageDesc &imageDesc,
+                           ImagePtr image,
                            bool verticalFlip = false) = 0;
 
-    /// Load an image from disk. This method must be implemented by derived classes.
-    /// @param filePath Path to load image from
-    /// @param imageDesc Description of image updated during load.
-    /// @param restrictions Hardware image description restrictions. Default value is nullptr, meaning no restrictions.
-    /// @return if load succeeded
-    virtual bool loadImage(const FilePath& filePath, ImageDesc &imageDesc,
-                           const ImageDescRestrictions* restrictions = nullptr) = 0;
+    /// Load an image from the file system. This method must be implemented by derived classes.
+    /// @param filePath The requested image file path.
+    /// @return On success, a shared pointer to the loaded image; otherwise an empty shared pointer.
+    virtual ImagePtr loadImage(const FilePath& filePath) = 0;
 
   protected:
-    /// List of supported string extensions
+    // List of supported string extensions
     StringSet _extensions;
 };
 
@@ -221,7 +270,6 @@ class ImageHandler
     {
         return ImageHandlerPtr(new ImageHandler(imageLoader));
     }
-
     virtual ~ImageHandler()
     {
         clearImageCache();
@@ -241,44 +289,36 @@ class ImageHandler
     /// @param verticalFlip Whether the image should be flipped in Y during save
     /// @return if save succeeded
     virtual bool saveImage(const FilePath& filePath,
-                           const ImageDesc &imageDesc,
+                           ImagePtr image,
                            bool verticalFlip = false);
 
     /// Acquire an image from the cache or file system.  If the image is not
     /// found in the cache, then each image loader will be applied in turn.
     /// @param filePath File path of the image.
-    /// @param imageDesc On success, this image descriptor will be filled out
-    ///    and assigned ownership of a resource buffer.
     /// @param generateMipMaps Generate mip maps if supported.
     /// @param fallbackColor Optional uniform color of a fallback texture
     ///    to create when the image cannot be loaded from the file system.
     ///    By default, no fallback texture is created.
-    /// @return True if the image was successfully found in the cache or
-    ///    file system.  Returns false if this call generated a fallback
-    ///    texture.
-    virtual bool acquireImage(const FilePath& filePath,
-                              ImageDesc& imageDesc,
-                              bool generateMipMaps,
-                              const Color4* fallbackColor = nullptr);
-
-    /// Utility to create a solid color color image
-    /// @param color Uniform color of the image to create
-    /// @param imageDesc On success, the newly created image description
-    /// @return True if the image was successfully created
-    virtual bool createColorImage(const Color4& color, ImageDesc& imageDesc);
+    /// @param message Optional pointer to a message string, where any warning
+    ///    or error messages from the acquire operation will be stored.
+    /// @return On success, a shared pointer to the acquired Image.
+    virtual ImagePtr acquireImage(const FilePath& filePath,
+                                  bool generateMipMaps,
+                                  const Color4* fallbackColor = nullptr,
+                                  string* message = nullptr);
 
     /// Bind an image. Derived classes should implement this method to handle logical binding of
     /// an image resource. The default implementation performs no action.
-    /// @param desc The image description to bind
+    /// @param desc The image to bind
     /// @param samplingProperties Sampling properties for the image
-    virtual bool bindImage(const ImageDesc& desc, const ImageSamplingProperties& samplingProperties);
+    virtual bool bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties);
 
     /// Unbind an image. The default implementation performs no action.
-    /// @param desc The image description to unbind
-    virtual bool unbindImage(const ImageDesc& desc);
+    /// @param desc The image to unbind
+    virtual bool unbindImage(ImagePtr image);
 
     /// Clear the contents of the image cache.
-    /// deleteImage() will be called for each cache description to
+    /// deleteImage() will be called for each cached image to
     /// allow derived classes to clean up any associated resources.
     void clearImageCache();
 
@@ -306,12 +346,6 @@ class ImageHandler
         return _resolver;
     }
 
-    /// Find the given file on the registered search path.
-    FilePath findFile(const FilePath& filePath)
-    {
-        return _searchPath.find(filePath);
-    }
-
     /// Return the bound texture location for a given resource.
     virtual int getBoundTextureLocation(unsigned int)
     {
@@ -322,25 +356,20 @@ class ImageHandler
     // Protected constructor.
     ImageHandler(ImageLoaderPtr imageLoader);
 
-    // Add an image description to the cache.
-    void cacheImage(const string& filePath, const ImageDesc& imageDesc);
+    // Add an image to the cache.
+    void cacheImage(const string& filePath, ImagePtr image);
 
-    // Return the cached image description, if found; otherwise
-    // return a null pointer.
-    const ImageDesc* getCachedImage(const FilePath& filePath);
+    // Return the cached image, if found; otherwise return an empty
+    // shared pointer.
+    ImagePtr getCachedImage(const FilePath& filePath);
 
     // Delete an image. Derived classes should override this method to clean
     // up any related resources when an image is deleted from the handler.
-    virtual void deleteImage(ImageDesc& imageDesc);
-
-    // Return image description restrictions. By default nullptr is
-    // returned meaning no restrictions. Derived classes can override
-    // this to add restrictions specific to that handler.
-    virtual const ImageDescRestrictions* getRestrictions() const { return nullptr; }
+    virtual void deleteImage(ImagePtr image);
 
   protected:
     ImageLoaderMap _imageLoaders;
-    ImageDescMap _imageCache;
+    ImageMap _imageCache;
     FileSearchPath _searchPath;
     StringResolverPtr _resolver;
 };

--- a/source/MaterialXRender/OiioImageLoader.h
+++ b/source/MaterialXRender/OiioImageLoader.h
@@ -46,22 +46,13 @@ class OiioImageLoader : public ImageLoader
     /// Create a new OpenImageIO image loader
     static OiioImageLoaderPtr create() { return std::make_shared<OiioImageLoader>(); }
 
-    /// Save image to disk. This method must be implemented by derived classes.
-    /// @param filePath Path to file to save image to
-    /// @param imageDesc Description of image
-    /// @param verticalFlip Whether the image should be flipped in Y during save
-    /// @return if save succeeded
+    /// Save an image to the file system.
     bool saveImage(const FilePath& filePath,
-                   const ImageDesc &imageDesc,
+                   ImagePtr image,
                    bool verticalFlip = false) override;
 
-    /// Load an image from disk. This method must be implemented by derived classes.
-    /// @param filePath Path to file to load image from
-    /// @param imageDesc Description of image updated during load.
-    /// @param restrictions Hardware image description restrictions. Default value is nullptr, meaning no restrictions.
-    /// @return if load succeeded
-    bool loadImage(const FilePath& filePath, ImageDesc &imageDesc,
-                   const ImageDescRestrictions* restrictions = nullptr) override;
+    /// Load an image from the file system.
+    ImagePtr loadImage(const FilePath& filePath) override;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXRender/StbImageLoader.h
+++ b/source/MaterialXRender/StbImageLoader.h
@@ -40,22 +40,13 @@ class StbImageLoader : public ImageLoader
     /// Create a new stb image loader
     static StbImageLoaderPtr create() { return std::make_shared<StbImageLoader>(); }
 
-    /// Save image to disk. This method must be implemented by derived classes.
-    /// @param filePath Path to file to save image to
-    /// @param imageDesc Description of image
-    /// @param verticalFlip Whether the image should be flipped in Y during save
-    /// @return if save succeeded
+    /// Save an image to the file system.
     bool saveImage(const FilePath& filePath,
-                   const ImageDesc &imageDesc,
+                   ImagePtr image,
                    bool verticalFlip = false) override;
 
-    /// Load an image from disk. This method must be implemented by derived classes.
-    /// @param filePath Path to file to load image from
-    /// @param imageDesc Description of image updated during load.
-    /// @param restrictions Hardware image description restrictions. Default value is nullptr, meaning no restrictions.
-    /// @return if load succeeded
-    bool loadImage(const FilePath& filePath, ImageDesc &imageDesc,
-                   const ImageDescRestrictions* restrictions = nullptr) override;
+    /// Load an image from the file system.
+    ImagePtr loadImage(const FilePath& filePath) override;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -17,13 +17,12 @@ GLTextureHandler::GLTextureHandler(ImageLoaderPtr imageLoader) :
     ImageHandler(imageLoader),
     _maxImageUnits(-1)
 {
-    _restrictions.supportedBaseTypes = { ImageDesc::BASETYPE_HALF, ImageDesc::BASETYPE_FLOAT, ImageDesc::BASETYPE_UINT8 };
 }
 
-bool GLTextureHandler::acquireImage(const FilePath& filePath,
-                                    ImageDesc& imageDesc,
-                                    bool generateMipMaps,
-                                    const Color4* fallbackColor)
+ImagePtr GLTextureHandler::acquireImage(const FilePath& filePath,
+                                        bool generateMipMaps,
+                                        const Color4* fallbackColor,
+                                        string* message)
 {
     // Resolve the input filepath.
     FilePath resolvedFilePath = filePath;
@@ -33,15 +32,18 @@ bool GLTextureHandler::acquireImage(const FilePath& filePath,
     }
 
     // Return a cached image if available.
-    const ImageDesc* cachedDesc = getCachedImage(resolvedFilePath);
+    ImagePtr cachedDesc = getCachedImage(resolvedFilePath);
     if (cachedDesc)
     {
-        imageDesc = *cachedDesc;
-        return true;
+        return cachedDesc;
     }
 
-    // Apply the search path.
-    resolvedFilePath = findFile(resolvedFilePath);
+    // Call the base acquire method.
+    ImagePtr image = ImageHandler::acquireImage(resolvedFilePath, generateMipMaps, fallbackColor, message);
+    if (!image)
+    {
+        return nullptr;
+    }
 
     // Initialize OpenGL setup if needed.
     if (!glActiveTexture)
@@ -61,130 +63,92 @@ bool GLTextureHandler::acquireImage(const FilePath& filePath,
         _boundTextureLocations.resize(maxTextureUnits, MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
     }
 
-    bool textureLoaded = false;
-    if (ImageHandler::acquireImage(resolvedFilePath, imageDesc, generateMipMaps, fallbackColor))
+    unsigned int resourceId = MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glGenTextures(1, &resourceId);
+    image->setResourceId(resourceId);
+
+    int textureUnit = getNextAvailableTextureLocation();
+    if (textureUnit < 0)
     {
-        imageDesc.resourceId = MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        glGenTextures(1, &imageDesc.resourceId);
-
-        int textureUnit = getNextAvailableTextureLocation();
-        if (textureUnit < 0)
-            return false;
-
-        glActiveTexture(GL_TEXTURE0 + textureUnit);
-        glBindTexture(GL_TEXTURE_2D, imageDesc.resourceId);
-
-        GLint internalFormat = GL_RGBA;
-        GLenum type = GL_UNSIGNED_BYTE;
-
-        if (imageDesc.baseType == ImageDesc::BASETYPE_FLOAT)
-        {
-            internalFormat = GL_RGBA32F;
-            type = GL_FLOAT;
-        }
-        else if (imageDesc.baseType == ImageDesc::BASETYPE_HALF)
-        {
-            internalFormat = GL_RGBA16F;
-            type = GL_HALF_FLOAT;
-        }
-
-        GLint format = GL_RGBA;
-        switch (imageDesc.channelCount)
-        {
-        case 3:
-        {
-            format = GL_RGB;
-            // Map {RGB} to {RGB, 1} at shader access time
-            GLint swizzleMaskRGB[] = { GL_RED, GL_GREEN, GL_BLUE, GL_ONE };
-            glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskRGB);
-            break;
-        }
-        case 2:
-        {
-            format = GL_RG;
-            // Map {red, green} to {red, alpha} at shader access time
-            GLint swizzleMaskRG[] = { GL_RED, GL_RED, GL_RED, GL_GREEN };
-            glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskRG);
-            break;
-        }
-        case 1:
-        {
-            format = GL_RED;
-            // Map { red } to {red, green, blue, 1} at shader access time
-            GLint swizzleMaskR[] = { GL_RED, GL_RED, GL_RED, GL_ONE };
-            glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskR);
-            break;
-        }
-        default:
-            break;
-        }
-
-        glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, imageDesc.width, imageDesc.height,
-            0, format, type, imageDesc.resourceBuffer);
-
-        if (generateMipMaps)
-        {
-            glGenerateMipmap(GL_TEXTURE_2D);
-        }
-        glBindTexture(GL_TEXTURE_2D, 0);
-
-        imageDesc.freeResourceBuffer();
-        cacheImage(resolvedFilePath, imageDesc);
-        textureLoaded = true;
+        return nullptr;
     }
 
-    // Create a fallback texture if failed to load
-    if (!textureLoaded && fallbackColor)
+    glActiveTexture(GL_TEXTURE0 + textureUnit);
+    glBindTexture(GL_TEXTURE_2D, image->getResourceId());
+
+    GLint internalFormat = GL_RGBA;
+    GLenum type = GL_UNSIGNED_BYTE;
+
+    if (image->getBaseType() == Image::BaseType::FLOAT)
     {
-        imageDesc.channelCount = 4;
-        imageDesc.width = 1;
-        imageDesc.height = 1;
-        imageDesc.baseType = ImageDesc::BASETYPE_FLOAT;
-        createColorImage(*fallbackColor, imageDesc);
-        if ((imageDesc.width * imageDesc.height > 0) && imageDesc.resourceBuffer)
-        {
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-            glGenTextures(1, &imageDesc.resourceId);
-
-            int textureUnit = getNextAvailableTextureLocation();
-            if (textureUnit < 0)
-                return false;
-
-            glActiveTexture(GL_TEXTURE0 + textureUnit);
-            glBindTexture(GL_TEXTURE_2D, imageDesc.resourceId);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, imageDesc.width, imageDesc.height, 0,
-                GL_RGBA, GL_FLOAT, imageDesc.resourceBuffer);
-            if (generateMipMaps)
-            {
-                glGenerateMipmap(GL_TEXTURE_2D);
-            }
-            glBindTexture(GL_TEXTURE_2D, 0);
-        }
-        imageDesc.freeResourceBuffer();
-        cacheImage(resolvedFilePath, imageDesc);
+        internalFormat = GL_RGBA32F;
+        type = GL_FLOAT;
+    }
+    else if (image->getBaseType() == Image::BaseType::HALF)
+    {
+        internalFormat = GL_RGBA16F;
+        type = GL_HALF_FLOAT;
     }
 
-    return textureLoaded;
+    GLint format = GL_RGBA;
+    switch (image->getChannelCount())
+    {
+    case 3:
+    {
+        format = GL_RGB;
+        // Map {RGB} to {RGB, 1} at shader access time
+        GLint swizzleMaskRGB[] = { GL_RED, GL_GREEN, GL_BLUE, GL_ONE };
+        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskRGB);
+        break;
+    }
+    case 2:
+    {
+        format = GL_RG;
+        // Map {red, green} to {red, alpha} at shader access time
+        GLint swizzleMaskRG[] = { GL_RED, GL_RED, GL_RED, GL_GREEN };
+        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskRG);
+        break;
+    }
+    case 1:
+    {
+        format = GL_RED;
+        // Map { red } to {red, green, blue, 1} at shader access time
+        GLint swizzleMaskR[] = { GL_RED, GL_RED, GL_RED, GL_ONE };
+        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskR);
+        break;
+    }
+    default:
+        break;
+    }
+
+    glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, image->getWidth(), image->getHeight(),
+        0, format, type, image->getResourceBuffer());
+
+    if (generateMipMaps)
+    {
+        glGenerateMipmap(GL_TEXTURE_2D);
+    }
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    return image;
 }
 
-bool GLTextureHandler::bindImage(const ImageDesc& desc, const ImageSamplingProperties& samplingProperties)
+bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties)
 {
-    unsigned int resourceId = desc.resourceId;
-
     // Bind a texture to the next available slot
     if (_maxImageUnits < 0)
     {
         glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &_maxImageUnits);
     }
-    if (resourceId == MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID ||
-        resourceId == static_cast<unsigned int>(_maxImageUnits))
+    if (image->getResourceId() == MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID ||
+        image->getResourceId() == static_cast<unsigned int>(_maxImageUnits))
     {
         return false;
     }
 
     // Update bound location if not already bound
-    int textureUnit = getBoundTextureLocation(resourceId);
+    int textureUnit = getBoundTextureLocation(image->getResourceId());
     if (textureUnit < 0)
     {
         textureUnit = getNextAvailableTextureLocation();
@@ -193,10 +157,10 @@ bool GLTextureHandler::bindImage(const ImageDesc& desc, const ImageSamplingPrope
     {
         return false;
     }      
-    _boundTextureLocations[textureUnit] = resourceId;
+    _boundTextureLocations[textureUnit] = image->getResourceId();
 
     glActiveTexture(GL_TEXTURE0 + textureUnit);
-    glBindTexture(GL_TEXTURE_2D, resourceId);
+    glBindTexture(GL_TEXTURE_2D, image->getResourceId());
 
     // Set up texture properties
     GLint minFilterType = mapFilterTypeToGL(samplingProperties.filterType);
@@ -213,16 +177,16 @@ bool GLTextureHandler::bindImage(const ImageDesc& desc, const ImageSamplingPrope
     return true;
 }
 
-bool GLTextureHandler::unbindImage(const ImageDesc& imageDesc)
+bool GLTextureHandler::unbindImage(ImagePtr image)
 {
     if (!glActiveTexture)
     {
         glewInit();
     }
 
-    if (imageDesc.resourceId != MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID)
+    if (image->getResourceId() != MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID)
     {
-        int textureUnit = getBoundTextureLocation(imageDesc.resourceId);
+        int textureUnit = getBoundTextureLocation(image->getResourceId());
         if (textureUnit >= 0)
         {
             glActiveTexture(GL_TEXTURE0 + textureUnit);
@@ -234,8 +198,7 @@ bool GLTextureHandler::unbindImage(const ImageDesc& imageDesc)
     return false;
 }
 
-
-void GLTextureHandler::deleteImage(ImageDesc& imageDesc)
+void GLTextureHandler::deleteImage(ImagePtr image)
 {
     if (!glActiveTexture)
     {
@@ -243,15 +206,16 @@ void GLTextureHandler::deleteImage(ImageDesc& imageDesc)
     }
 
     // Unbind a texture from image unit if bound and delete the texture
-    if (imageDesc.resourceId != MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID)
+    if (image->getResourceId() != MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID)
     {
-        unbindImage(imageDesc);
-        glDeleteTextures(1, &imageDesc.resourceId);
-        imageDesc.resourceId = MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
+        unbindImage(image);
+        unsigned int resourceId = image->getResourceId();
+        glDeleteTextures(1, &resourceId);
+        image->setResourceId(MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
     }
 
     // Delete any CPU side memory
-    ImageHandler::deleteImage(imageDesc);
+    ImageHandler::deleteImage(image);
 }
 
 int GLTextureHandler::getBoundTextureLocation(unsigned int resourceId)

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -31,18 +31,18 @@ class GLTextureHandler : public ImageHandler
 
     /// Acquire an image from the cache or file system.  If the image is not
     /// found in the cache, then each image loader will be applied in turn.
-    bool acquireImage(const FilePath& filePath,
-                      ImageDesc& imageDesc,
-                      bool generateMipMaps,
-                      const Color4* fallbackColor = nullptr) override;
+    ImagePtr acquireImage(const FilePath& filePath,
+                          bool generateMipMaps,
+                          const Color4* fallbackColor = nullptr,
+                          string* message = nullptr) override;
 
     /// Bind an image. This method will bind the texture to an active texture
     /// unit as defined by the corresponding image description. The method
     /// will fail if there are not enough available image units to bind to.
-    bool bindImage(const ImageDesc& desc, const ImageSamplingProperties& samplingProperties) override;
+    bool bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties) override;
 
     /// Unbind an image. 
-    bool unbindImage(const ImageDesc& desc) override;
+    bool unbindImage(ImagePtr image) override;
 
     /// Utility to map an address mode enumeration to an OpenGL address mode
     static int mapAddressModeToGL(ImageSamplingProperties::AddressMode addressModeEnum);
@@ -59,24 +59,13 @@ class GLTextureHandler : public ImageHandler
 
     // Delete an image. Any OpenGL texture resource and as well as any CPU-side
     // resource memory will be deleted.
-    void deleteImage(ImageDesc& imageDesc) override;
-
-    // Return restrictions specific to this handler
-    const ImageDescRestrictions* getRestrictions() const override
-    {
-        return &_restrictions;
-    }
+    void deleteImage(ImagePtr image) override;
 
     // Return the first free texture location that can be bound to.
     int getNextAvailableTextureLocation();
 
   protected:
-    // Maximum number of available image units
     int _maxImageUnits;
-
-    // Support restrictions
-    ImageDescRestrictions _restrictions;
-
     std::vector<unsigned int> _boundTextureLocations;
 };
 

--- a/source/MaterialXRenderGlsl/GlslProgram.h
+++ b/source/MaterialXRenderGlsl/GlslProgram.h
@@ -46,7 +46,7 @@ class GlslProgram
 
     /// Set up code stages to validate based on an input hardware shader.
     /// @param shader Hardware shader to use
-    void setStages(const ShaderPtr shader);
+    void setStages(ShaderPtr shader);
 
     /// Set the code stages based on a list of stage strings.
     /// Refer to the ordering of stages as defined by a HwShader.
@@ -231,9 +231,8 @@ class GlslProgram
     /// @{
 
     /// Bind an individual texture to a program uniform location
-    bool bindTexture(unsigned int uniformType, int uniformLocation, const FilePath& filePath,
-                     ImageHandlerPtr imageHandler, bool generateMipMaps, const ImageSamplingProperties& imageProperties,
-                     ImageDesc& desc);
+    ImagePtr bindTexture(unsigned int uniformType, int uniformLocation, const FilePath& filePath,
+                         ImageHandlerPtr imageHandler, bool generateMipMaps, const ImageSamplingProperties& imageProperties);
 
     /// Utility to check for OpenGL context errors.
     /// Will throw an ExceptionShaderRenderError exception which will list of the errors found

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -9,10 +9,13 @@
 #include <MaterialXRenderHw/SimpleWindow.h>
 #include <MaterialXRender/TinyObjLoader.h>
 
+#include <cmath>
 #include <iostream>
 
 namespace MaterialX
 {
+
+const float PI = std::acos(-1.0f);
 
 // View information
 const float FOV_PERSP = 45.0f; // degrees
@@ -404,7 +407,6 @@ void GlslRenderer::updateViewInformation(const Vector3& eye,
                                            float farDist,
                                            float objectScale)
 {
-    const float PI = std::acos(-1.0f);
     float fH = std::tan(viewAngle / 360.0f * PI) * nearDist;
     float fW = fH * 1.0f;
 
@@ -520,14 +522,16 @@ void GlslRenderer::save(const FilePath& filePath, bool floatingPoint)
         throw ExceptionShaderRenderError(errorType, errors);
     }
 
-    size_t bufferSize = _frameBufferWidth * _frameBufferHeight * 4;
-    float* buffer = new float[bufferSize];
+    // Create an image.
+    ImagePtr image = Image::create(_frameBufferWidth, _frameBufferHeight, 4);
+    image->createResourceBuffer();
 
     // Read back from the color texture.
     bindTarget(true);
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
     glReadBuffer(GL_COLOR_ATTACHMENT0);
-    glReadPixels(0, 0, _frameBufferWidth, _frameBufferHeight, GL_RGBA, floatingPoint ? GL_FLOAT : GL_UNSIGNED_BYTE, buffer);
+    glReadPixels(0, 0, image->getWidth(), image->getHeight(), GL_RGBA,
+                 floatingPoint ? GL_FLOAT : GL_UNSIGNED_BYTE, image->getResourceBuffer());
     bindTarget(false);
     try
     {
@@ -535,24 +539,13 @@ void GlslRenderer::save(const FilePath& filePath, bool floatingPoint)
     }
     catch (ExceptionShaderRenderError& e)
     {
-        delete[] buffer;
         errors.push_back("Failed to read color buffer back.");
         errors.insert(std::end(errors), std::begin(e.errorLog()), std::end(e.errorLog()));
         throw ExceptionShaderRenderError(errorType, errors);
     }
 
-    // Save using the handler
-    ImageDesc desc;
-    desc.width = _frameBufferWidth;
-    desc.height = _frameBufferHeight;
-    desc.channelCount = 4;
-    desc.resourceBuffer = buffer;
-    bool saved = _imageHandler->saveImage(filePath, desc, true);
-
-    desc.resourceBuffer = nullptr;
-    delete[] buffer;
-
-    if (!saved)
+    // Save using the handler.
+    if (!_imageHandler->saveImage(filePath, image, true))
     {
         errors.push_back("Failed to save to file:" + filePath.asString());
         throw ExceptionShaderRenderError(errorType, errors);

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -311,9 +311,9 @@ void Material::bindViewInformation(const mx::Matrix44& world, const mx::Matrix44
 
 void Material::unbindImages(mx::ImageHandlerPtr imageHandler)
 {
-    for (const mx::ImageDesc& desc : _boundImages)
+    for (mx::ImagePtr image : _boundImages)
     {
-        imageHandler->unbindImage(desc);
+        imageHandler->unbindImage(image);
     }
 }
 
@@ -344,20 +344,20 @@ void Material::bindImages(mx::ImageHandlerPtr imageHandler, const mx::FileSearch
         mx::ImageSamplingProperties samplingProperties;
         samplingProperties.setProperties(uniformVariable, *publicUniforms);
 
-        mx::ImageDesc desc;
-        if (bindImage(filename, uniformVariable, imageHandler, desc, samplingProperties, &IMAGE_DEFAULT_COLOR))
+        mx::ImagePtr image = bindImage(filename, uniformVariable, imageHandler, samplingProperties, &IMAGE_DEFAULT_COLOR);
+        if (image)
         {
-            _boundImages.push_back(desc);
+            _boundImages.push_back(image);
         }
     }
 }
 
-bool Material::bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
-                         mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, const mx::Color4* fallbackColor)
+mx::ImagePtr Material::bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
+                                 const mx::ImageSamplingProperties& samplingProperties, const mx::Color4* fallbackColor)
 {
     if (!_glShader)
     {
-        return false;
+        return nullptr;
     }
 
     // Create a filename resolver for geometric properties.
@@ -369,23 +369,28 @@ bool Material::bindImage(const mx::FilePath& filePath, const std::string& unifor
     imageHandler->setFilenameResolver(resolver);
 
     // Acquire the given image.
-    if (!imageHandler->acquireImage(filePath, desc, true, fallbackColor) && !filePath.isEmpty())
+    std::string error;
+    mx::ImagePtr image = imageHandler->acquireImage(filePath, true, fallbackColor, &error);
+    if (!error.empty())
     {
-        std::cerr << "Failed to load image: " << filePath.asString() << std::endl;
-        return false;
+        std::cerr << error << std::endl;
+    }
+    if (!image)
+    {
+        return nullptr;
     }
 
     // Bind the image and set its sampling properties.
-    if (imageHandler->bindImage(desc, samplingProperties))
+    if (imageHandler->bindImage(image, samplingProperties))
     {
-        int textureLocation = imageHandler->getBoundTextureLocation(desc.resourceId);
+        int textureLocation = imageHandler->getBoundTextureLocation(image->getResourceId());
         if (textureLocation >= 0)
         {
             _glShader->setUniform(uniformName, textureLocation, false);
-            return true;
+            return image;
         }
     }
-    return false;
+    return nullptr;
 }
 
 void Material::bindUniform(const std::string& name, mx::ConstValuePtr value)
@@ -471,25 +476,21 @@ void Material::bindLights(mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr 
         if (_glShader->uniform(pair.first, false) != -1)
         {
             mx::FilePath path = imagePath.find(pair.second);
-            const std::string filename = path.asString();
 
-            mx::ImageDesc desc;
             mx::ImageSamplingProperties samplingProperties;
             samplingProperties.uaddressMode = mx::ImageSamplingProperties::AddressMode::CLAMP;
             samplingProperties.vaddressMode = mx::ImageSamplingProperties::AddressMode::CLAMP;
             samplingProperties.filterType = mx::ImageSamplingProperties::FilterType::CUBIC;
 
-            if (bindImage(filename, pair.first, imageHandler, desc, samplingProperties, &IMAGE_DEFAULT_COLOR))
+            mx::ImagePtr image = bindImage(path, pair.first, imageHandler, samplingProperties, &IMAGE_DEFAULT_COLOR);
+            if (image && specularEnvironmentMethod == mx::SPECULAR_ENVIRONMENT_FIS)
             {
-                if (specularEnvironmentMethod == mx::SPECULAR_ENVIRONMENT_FIS)
+                // Bind any associated uniforms.
+                if (pair.first == mx::HW::ENV_RADIANCE)
                 {
-                    // Bind any associated uniforms.
-                    if (pair.first == mx::HW::ENV_RADIANCE)
+                    if (_glShader->uniform(mx::HW::ENV_RADIANCE_MIPS, false) != -1)
                     {
-                        if (_glShader->uniform(mx::HW::ENV_RADIANCE_MIPS, false) != -1)
-                        {
-                            _glShader->setUniform(mx::HW::ENV_RADIANCE_MIPS, desc.mipCount);
-                        }
+                        _glShader->setUniform(mx::HW::ENV_RADIANCE_MIPS, image->getMaxMipCount());
                     }
                 }
             }

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -141,8 +141,8 @@ class Material
     void unbindImages(mx::ImageHandlerPtr imageHandler);
 
     /// Bind a single image.
-    bool bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
-                   mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, const mx::Color4* fallbackColor = nullptr);
+    mx::ImagePtr bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
+                           const mx::ImageSamplingProperties& samplingProperties, const mx::Color4* fallbackColor = nullptr);
 
     /// Bind lights to shader.
     void bindLights(mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr imageHandler, const mx::FileSearchPath& imagePath, 
@@ -202,7 +202,7 @@ class Material
     bool _hasTransparency;
     mx::StringSet _uniformVariable;
 
-    std::vector<mx::ImageDesc> _boundImages;
+    std::vector<mx::ImagePtr> _boundImages;
 };
 
 #endif // MATERIALXVIEW_MATERIAL_H

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -18,27 +18,25 @@ class PyImageLoader : public mx::ImageLoader
     {
     }
 
-    bool saveImage(const mx::FilePath& filePath, const mx::ImageDesc &imageDesc, bool verticalFlip) override
+    bool saveImage(const mx::FilePath& filePath, mx::ImagePtr image, bool verticalFlip) override
     {
         PYBIND11_OVERLOAD_PURE(
             bool,
             mx::ImageLoader,
             saveImage,
             filePath,
-            imageDesc,
+            image,
             verticalFlip
         );
     }
 
-    bool loadImage(const mx::FilePath& filePath, mx::ImageDesc &imageDesc, const mx::ImageDescRestrictions* restrictions = nullptr) override
+    mx::ImagePtr loadImage(const mx::FilePath& filePath) override
     {
         PYBIND11_OVERLOAD_PURE(
-            bool,
+            mx::ImagePtr,
             mx::ImageLoader,
-            acquireImage,
-            filePath,
-            imageDesc,
-            restrictions
+            loadImage,
+            filePath
         );
     }
 
@@ -52,61 +50,50 @@ class PyImageHandler : public mx::ImageHandler
     {
     }
 
-    bool saveImage(const mx::FilePath& filePath, const mx::ImageDesc &imageDesc, bool verticalFlip = false) override
+    bool saveImage(const mx::FilePath& filePath, mx::ImagePtr image, bool verticalFlip = false) override
     {
         PYBIND11_OVERLOAD(
             bool,
             mx::ImageHandler,
             saveImage,
             filePath,
-            imageDesc,
+            image,
             verticalFlip
         );
     }
 
-    bool acquireImage(const mx::FilePath& filePath, mx::ImageDesc& desc, bool generateMipMaps, const mx::Color4* fallbackColor) override
+    mx::ImagePtr acquireImage(const mx::FilePath& filePath, bool generateMipMaps, const mx::Color4* fallbackColor, std::string* message) override
     {
         PYBIND11_OVERLOAD(
-            bool,
+            mx::ImagePtr,
             mx::ImageHandler,
             acquireImage,
             filePath,
-            desc,
             generateMipMaps,
-            fallbackColor
+            fallbackColor,
+            message
         );
     }
 
-    bool createColorImage(const mx::Color4& color, mx::ImageDesc& imageDesc) override
-    {
-        PYBIND11_OVERLOAD(
-            bool,
-            mx::ImageHandler,
-            createColorImage,
-            color,
-            imageDesc
-        );
-    }
-
-    bool bindImage(const mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties) override
+    bool bindImage(mx::ImagePtr image, const mx::ImageSamplingProperties& samplingProperties) override
     {
         PYBIND11_OVERLOAD(
             bool,
             mx::ImageHandler,
             bindImage,
-            desc,
+            image,
             samplingProperties
         );
     }
 
   protected:
-    void deleteImage(mx::ImageDesc& imageDesc) override
+    void deleteImage(mx::ImagePtr image) override
     {
         PYBIND11_OVERLOAD(
             void,
             mx::ImageHandler,
             deleteImage,
-            imageDesc
+            image
         );
     }
 };
@@ -115,17 +102,22 @@ void bindPyImageHandler(py::module& mod)
 {
     py::class_<mx::ImageBufferDeallocator>(mod, "ImageBufferDeallocator");
 
-    py::class_<mx::ImageDesc>(mod, "ImageDesc")
-        .def_readwrite("width", &mx::ImageDesc::width)
-        .def_readwrite("height", &mx::ImageDesc::height)
-        .def_readwrite("channelCount", &mx::ImageDesc::channelCount)
-        .def_readwrite("mipCount", &mx::ImageDesc::mipCount)
-        .def_readwrite("resourceBuffer", &mx::ImageDesc::resourceBuffer)
-        .def_readwrite("baseType", &mx::ImageDesc::baseType)
-        .def_readwrite("resourceId", &mx::ImageDesc::resourceId)
-        .def_readwrite("resourceBufferDeallocator ", &mx::ImageDesc::resourceBufferDeallocator)
-        .def("computeMipCount", &mx::ImageDesc::computeMipCount)
-        .def("freeResourceBuffer", &mx::ImageDesc::freeResourceBuffer);
+    py::class_<mx::Image>(mod, "Image")
+        .def_static("create", &mx::Image::create)
+        .def_static("createConstantColor", &mx::Image::createConstantColor)
+        .def("getWidth", &mx::Image::getWidth)
+        .def("getHeight", &mx::Image::getHeight)
+        .def("getChannelCount", &mx::Image::getChannelCount)
+        .def("getBaseType", &mx::Image::getBaseType)
+        .def("getBaseStride", &mx::Image::getBaseStride)
+        .def("getMaxMipCount", &mx::Image::getMaxMipCount)
+        .def("setResourceBuffer", &mx::Image::setResourceBuffer)
+        .def("getResourceBuffer", &mx::Image::getResourceBuffer)
+        .def("createResourceBuffer", &mx::Image::createResourceBuffer)
+        .def("releaseResourceBuffer", &mx::Image::releaseResourceBuffer)
+        .def("setResourceBufferDeallocator", &mx::Image::setResourceBufferDeallocator)
+        .def("getResourceBufferDeallocator", &mx::Image::getResourceBufferDeallocator)
+        .def("getTexelColor", &mx::Image::getTexelColor);
 
     py::class_<mx::ImageSamplingProperties>(mod, "ImageSamplingProperties")
         .def_readwrite("uaddressMode", &mx::ImageSamplingProperties::uaddressMode)
@@ -134,19 +126,19 @@ void bindPyImageHandler(py::module& mod)
         .def_readwrite("defaultColor", &mx::ImageSamplingProperties::defaultColor);
 
     py::class_<mx::ImageLoader, PyImageLoader, mx::ImageLoaderPtr>(mod, "ImageLoader")
-        .def_readwrite_static("BMP_EXTENSION", &mx::ImageLoader::BMP_EXTENSION)
-        .def_readwrite_static("EXR_EXTENSION", &mx::ImageLoader::EXR_EXTENSION)
-        .def_readwrite_static("GIF_EXTENSION", &mx::ImageLoader::GIF_EXTENSION)
-        .def_readwrite_static("HDR_EXTENSION", &mx::ImageLoader::HDR_EXTENSION)
-        .def_readwrite_static("JPG_EXTENSION", &mx::ImageLoader::JPG_EXTENSION)
-        .def_readwrite_static("JPEG_EXTENSION", &mx::ImageLoader::JPEG_EXTENSION)
-        .def_readwrite_static("PIC_EXTENSION", &mx::ImageLoader::PIC_EXTENSION)
-        .def_readwrite_static("PNG_EXTENSION", &mx::ImageLoader::PNG_EXTENSION)
-        .def_readwrite_static("PSD_EXTENSION", &mx::ImageLoader::PSD_EXTENSION)
-        .def_readwrite_static("TGA_EXTENSION", &mx::ImageLoader::TGA_EXTENSION)
-        .def_readwrite_static("TIF_EXTENSION", &mx::ImageLoader::TIF_EXTENSION)
-        .def_readwrite_static("TIFF_EXTENSION", &mx::ImageLoader::TIFF_EXTENSION)
-        .def_readwrite_static("TXT_EXTENSION", &mx::ImageLoader::TXT_EXTENSION)
+        .def_readonly_static("BMP_EXTENSION", &mx::ImageLoader::BMP_EXTENSION)
+        .def_readonly_static("EXR_EXTENSION", &mx::ImageLoader::EXR_EXTENSION)
+        .def_readonly_static("GIF_EXTENSION", &mx::ImageLoader::GIF_EXTENSION)
+        .def_readonly_static("HDR_EXTENSION", &mx::ImageLoader::HDR_EXTENSION)
+        .def_readonly_static("JPG_EXTENSION", &mx::ImageLoader::JPG_EXTENSION)
+        .def_readonly_static("JPEG_EXTENSION", &mx::ImageLoader::JPEG_EXTENSION)
+        .def_readonly_static("PIC_EXTENSION", &mx::ImageLoader::PIC_EXTENSION)
+        .def_readonly_static("PNG_EXTENSION", &mx::ImageLoader::PNG_EXTENSION)
+        .def_readonly_static("PSD_EXTENSION", &mx::ImageLoader::PSD_EXTENSION)
+        .def_readonly_static("TGA_EXTENSION", &mx::ImageLoader::TGA_EXTENSION)
+        .def_readonly_static("TIF_EXTENSION", &mx::ImageLoader::TIF_EXTENSION)
+        .def_readonly_static("TIFF_EXTENSION", &mx::ImageLoader::TIFF_EXTENSION)
+        .def_readonly_static("TXT_EXTENSION", &mx::ImageLoader::TXT_EXTENSION)
         .def(py::init<>())
         .def("supportedExtensions", &mx::ImageLoader::supportedExtensions)
         .def("saveImage", &mx::ImageLoader::saveImage)
@@ -158,10 +150,8 @@ void bindPyImageHandler(py::module& mod)
         .def("addLoader", &mx::ImageHandler::addLoader)
         .def("saveImage", &mx::ImageHandler::saveImage)
         .def("acquireImage", &mx::ImageHandler::acquireImage)
-        .def("createColorImage", &mx::ImageHandler::createColorImage)
         .def("bindImage", &mx::ImageHandler::bindImage)
         .def("clearImageCache", &mx::ImageHandler::clearImageCache)
         .def("setSearchPath", &mx::ImageHandler::setSearchPath)
-        .def("getSearchPath", &mx::ImageHandler::getSearchPath)
-        .def("findFile", &mx::ImageHandler::findFile);
+        .def("getSearchPath", &mx::ImageHandler::getSearchPath);
 }

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
@@ -14,7 +14,6 @@ void bindPyGLTextureHandler(py::module& mod)
 {
     py::class_<mx::GLTextureHandler, mx::ImageHandler, mx::GLTextureHandlerPtr>(mod, "GLTextureHandler")
         .def_static("create", &mx::GLTextureHandler::create)
-        .def("createColorImage", &mx::GLTextureHandler::createColorImage)
         .def("acquireImage", &mx::GLTextureHandler::acquireImage)
         .def("bindImage", &mx::GLTextureHandler::bindImage)
         .def("mapAddressModeToGL", &mx::GLTextureHandler::mapAddressModeToGL)


### PR DESCRIPTION
- Rename the ImageDesc class to Image, and create a clearer separation between its interface and data.
- Move image creation logic to the Image class.
- Move image caching and fallback behavior to the base ImageHandler class.
- Add an initial Image::getTexelColor method, opening the door to future image processing and analysis functionality.