### PR TITLE
Update example materials

### DIFF
--- a/resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx
@@ -7,8 +7,8 @@
       <bindinput name="diffuse_roughness" type="float" value="0"/>
       <bindinput name="specular" type="float" value="1"/>
       <bindinput name="specular_color" type="color3" value="1, 1, 1"/>
-      <bindinput name="specular_roughness" type="float" value="0.1"/>
-      <bindinput name="specular_IOR" type="float" value="1.52"/>
+      <bindinput name="specular_roughness" type="float" value="0.2"/>
+      <bindinput name="specular_IOR" type="float" value="1.5"/>
       <bindinput name="specular_anisotropy" type="float" value="0"/>
       <bindinput name="specular_rotation" type="float" value="0"/>
       <bindinput name="metalness" type="float" value="0"/>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_velvet.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_velvet.mtlx
@@ -9,9 +9,6 @@
       <bindinput name="specular_IOR" type="float" value="0" />
       <bindinput name="sheen" type="float" value="1" />
       <bindinput name="sheen_color" type="color3" value="0.40380001, 0.057999998, 1" />
-      <bindinput name="coat_color" type="color3" value="0, 0, 0" />
-      <bindinput name="coat_roughness" type="float" value="0.79166668653488159" />
-      <bindinput name="coat_IOR" type="float" value="0" />
     </shaderref>
   </material>
 </materialx>


### PR DESCRIPTION
- Update standard_surface_default bindings to match the current definition of the shader.
- Remove standard_surface_velvet bindings that have no visible effect (clearcoat properties that are set without a clearcoat weight).