### PR TITLE
Move Image class to its own source and header files

### DIFF
--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -1,0 +1,136 @@
+//
+// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXRender/Image.h>
+
+#include <cmath>
+
+namespace MaterialX
+{
+
+//
+// Image methods
+//
+
+Image::Image(unsigned int width, unsigned int height, unsigned int channelCount, BaseType baseType) :
+    _width(width),
+    _height(height),
+    _channelCount(channelCount),
+    _baseType(baseType),
+    _resourceBuffer(nullptr),
+    _resourceBufferDeallocator(nullptr),
+    _resourceId(0)
+{
+}
+
+Image::~Image()
+{
+    releaseResourceBuffer();
+}
+
+unsigned int Image::getBaseStride() const
+{
+    if (_baseType == BaseType::HALF)
+    {
+        return 2;
+    }
+    if (_baseType == BaseType::FLOAT)
+    {
+        return 4;
+    }
+    return 1;
+}
+
+unsigned int Image::getMaxMipCount() const
+{
+    return (unsigned int) std::log2(std::max(_width, _height)) + 1;
+}
+
+ImagePtr Image::createConstantColor(unsigned int width, unsigned int height, const Color4& color)
+{
+    unsigned int channelCount = 4;
+    size_t bufferSize = width * height * channelCount;
+    if (!bufferSize)
+    {
+        return nullptr;
+    }
+
+    ImagePtr image = create(width, height, channelCount, Image::BaseType::FLOAT);
+    image->createResourceBuffer();
+    float* pixel = static_cast<float*>(image->getResourceBuffer());
+    for (size_t i = 0; i < image->getWidth(); i++)
+    {
+        for (size_t j = 0; j < image->getHeight(); j++)
+        {
+            for (unsigned int c = 0; c < image->getChannelCount(); c++)
+            {
+                *pixel++ = color[c];
+            }
+        }
+    }
+    return image;
+}
+
+Color4 Image::getTexelColor(unsigned int x, unsigned int y) const
+{
+    if (x >= _width || y >= _height)
+    {
+        throw Exception("Invalid coordinates in getTexelColor");
+    }
+    if (!_resourceBuffer)
+    {
+        throw Exception("Invalid resource buffer in getTexelColor");
+    }
+
+    if (_baseType == BaseType::FLOAT)
+    {
+        float* data = static_cast<float*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        if (_channelCount == 4)
+        {
+            return Color4(data[0], data[1], data[2], data[3]);
+        }
+        else if (_channelCount == 3)
+        {
+            return Color4(data[0], data[1], data[2], 1.0f);
+        }
+        else if (_channelCount == 1)
+        {
+            return Color4(data[0], data[0], data[0], 1.0f);
+        }
+        else
+        {
+            throw Exception("Unsupported channel count in getTexelColor");
+        }
+    }
+    else
+    {
+        throw Exception("Unsupported base type in getTexelColor");
+    }
+}
+
+void Image::createResourceBuffer()
+{
+    releaseResourceBuffer();
+    _resourceBuffer = malloc(_width * _height * _channelCount * getBaseStride());
+    _resourceBufferDeallocator = nullptr;
+}
+
+void Image::releaseResourceBuffer()
+{
+    if (_resourceBuffer)
+    {
+        if (_resourceBufferDeallocator)
+        {
+            _resourceBufferDeallocator(_resourceBuffer);
+        }
+        else
+        {
+            free(_resourceBuffer);
+        }
+        _resourceBuffer = nullptr;
+    }
+}
+
+} // namespace MaterialX

--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -1,0 +1,147 @@
+//
+// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_IMAGE_H
+#define MATERIALX_IMAGE_H
+
+/// @file
+/// Image class
+
+#include <MaterialXCore/Types.h>
+
+namespace MaterialX
+{
+
+class Image;
+
+/// A shared pointer to an image
+using ImagePtr = shared_ptr<Image>;
+
+/// A shared pointer to a const image
+using ConstImagePtr = shared_ptr<const Image>;
+
+/// A map from strings to images.
+using ImageMap = std::unordered_map<string, ImagePtr>;
+
+/// A function to perform image buffer deallocation
+using ImageBufferDeallocator = std::function<void(void*)>;
+
+/// @class Image
+/// Class representing an image in system memory
+class Image
+{
+  public:
+    enum class BaseType
+    {
+        UINT8 = 0,
+        HALF = 1,
+        FLOAT = 2
+    };
+
+  public:
+    /// Create an empty image with the given properties.
+    static ImagePtr create(unsigned int width, unsigned int height, unsigned int channelCount, BaseType baseType = BaseType::UINT8)
+    {
+        return ImagePtr(new Image(width, height, channelCount, baseType));
+    }
+
+    /// Create a constant color image with the given properties.
+    static ImagePtr createConstantColor(unsigned int width, unsigned int height, const Color4& color);
+
+    ~Image();
+
+    /// Return the width of the image.
+    unsigned int getWidth() const
+    {
+        return _width;
+    }
+
+    /// Return the height of the image.
+    unsigned int getHeight() const
+    {
+        return _height;
+    }
+
+    /// Return the channel count of the image.
+    unsigned int getChannelCount() const
+    {
+        return _channelCount;
+    }
+
+    /// Return the base type of the image.
+    BaseType getBaseType() const
+    {
+        return _baseType;
+    }
+
+    /// Return the stride of our base type in bytes.
+    unsigned int getBaseStride() const;
+
+    /// Return the maximum number of mipmaps for this image.
+    unsigned int getMaxMipCount() const;
+
+    /// Set the resource buffer for this image.
+    void setResourceBuffer(void* buffer)
+    {
+        _resourceBuffer = buffer;
+    }
+
+    /// Return the resource buffer for this image.
+    void* getResourceBuffer() const
+    {
+        return _resourceBuffer;
+    }
+
+    /// Set the resource buffer deallocator for this image.
+    void setResourceBufferDeallocator(ImageBufferDeallocator deallocator)
+    {
+        _resourceBufferDeallocator = deallocator;
+    }
+
+    /// Return the resource buffer deallocator for this image.
+    ImageBufferDeallocator getResourceBufferDeallocator() const
+    {
+        return _resourceBufferDeallocator;
+    }
+
+    /// Set the resource ID for this image.
+    void setResourceId(unsigned int id)
+    {
+        _resourceId = id;
+    }
+
+    /// Return the resource ID for this image.
+    unsigned int getResourceId() const
+    {
+        return _resourceId;
+    }
+
+    /// Return the texel color at the given coordinates.  If the coordinates
+    /// or image resource buffer are invalid, then an exception is thrown.
+    Color4 getTexelColor(unsigned int x, unsigned int y) const;
+
+    /// Allocate a resource buffer for this image that matches its properties.
+    void createResourceBuffer();
+
+    /// Release the resource buffer for this image.
+    void releaseResourceBuffer();
+
+  protected:
+    Image(unsigned int width, unsigned int height, unsigned int channelCount, BaseType baseType);
+
+  protected:
+    unsigned int _width;
+    unsigned int _height;
+    unsigned int _channelCount;
+    BaseType _baseType;
+
+    void* _resourceBuffer;
+    ImageBufferDeallocator _resourceBufferDeallocator;
+    unsigned int _resourceId;
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -31,7 +31,7 @@ namespace MaterialX
 {
 
 bool OiioImageLoader::saveImage(const FilePath& filePath,
-                                ImagePtr image,
+                                ConstImagePtr image,
                                 bool verticalFlip)
 {
     OIIO::ImageSpec imageSpec;

--- a/source/MaterialXRender/OiioImageLoader.h
+++ b/source/MaterialXRender/OiioImageLoader.h
@@ -48,7 +48,7 @@ class OiioImageLoader : public ImageLoader
 
     /// Save an image to the file system.
     bool saveImage(const FilePath& filePath,
-                   ImagePtr image,
+                   ConstImagePtr image,
                    bool verticalFlip = false) override;
 
     /// Load an image from the file system.

--- a/source/MaterialXRender/StbImageLoader.cpp
+++ b/source/MaterialXRender/StbImageLoader.cpp
@@ -29,7 +29,7 @@ namespace MaterialX
 {
 
 bool StbImageLoader::saveImage(const FilePath& filePath,
-                               ImagePtr image,
+                               ConstImagePtr image,
                                bool verticalFlip)
 {
     bool isChar = image->getBaseType() == Image::BaseType::UINT8;

--- a/source/MaterialXRender/StbImageLoader.h
+++ b/source/MaterialXRender/StbImageLoader.h
@@ -42,7 +42,7 @@ class StbImageLoader : public ImageLoader
 
     /// Save an image to the file system.
     bool saveImage(const FilePath& filePath,
-                   ImagePtr image,
+                   ConstImagePtr image,
                    bool verticalFlip = false) override;
 
     /// Load an image from the file system.

--- a/source/MaterialXRender/Util.h
+++ b/source/MaterialXRender/Util.h
@@ -13,87 +13,87 @@
 #include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
 
-#include <MaterialXCore/Document.h>
-
 #include <map>
 
 namespace MaterialX
 {
-    /// @name Shader utilities
-    /// @{
 
-    /// Create a shader for a given element
-    ShaderPtr createShader(const string& shaderName, GenContext& context, ElementPtr elem);
+/// @name Shader Utilities
+/// @{
 
-    /// Create a shader with a constant color output for a given element
-    ShaderPtr createConstantShader(GenContext& context,
-                                   DocumentPtr stdLib,
-                                   const string& shaderName,
-                                   const Color3& color);
+/// Create a shader for a given element.
+ShaderPtr createShader(const string& shaderName, GenContext& context, ElementPtr elem);
 
-    /// @}
-    /// @name User interface utilities
-    /// @{
+/// Create a shader with a constant color output, using the given standard libraries
+/// for code generation.
+ShaderPtr createConstantShader(GenContext& context,
+                               DocumentPtr stdLib,
+                               const string& shaderName,
+                               const Color3& color);
 
-    /// Set of possible UI properties for an element
-    struct UIProperties
-    {
-        /// UI name
-        string uiName;
+/// @}
+/// @name User Interface Utilities
+/// @{
 
-        /// UI folder
-        string uiFolder;
+/// Set of possible UI properties for an element
+struct UIProperties
+{
+    /// UI name
+    string uiName;
 
-        /// Enumeration
-        StringVec enumeration;
+    /// UI folder
+    string uiFolder;
 
-        /// Enumeration Values
-        vector<ValuePtr> enumerationValues;
+    /// Enumeration
+    StringVec enumeration;
 
-        /// UI minimum value
-        ValuePtr uiMin;
+    /// Enumeration Values
+    vector<ValuePtr> enumerationValues;
 
-        /// UI maximum value
-        ValuePtr uiMax;
+    /// UI minimum value
+    ValuePtr uiMin;
 
-        /// UI advanced element
-        bool uiAdvanced = false;
-    };
+    /// UI maximum value
+    ValuePtr uiMax;
 
-    /// Get the UI properties for a given nodedef element.
-    /// Returns the number of properties found.
-    unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& uiProperties);
+    /// UI advanced element
+    bool uiAdvanced = false;
+};
 
-    /// Get the UI properties for a given element path. If the path is to a node, a target
-    /// identifier can be provided.
-    /// Returns the number of properties found.
-    unsigned int getUIProperties(const string& path, DocumentPtr doc, const string& target, UIProperties& uiProperties);
+/// Get the UI properties for a given nodedef element.
+/// Returns the number of properties found.
+unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& uiProperties);
 
-    /// Interface for holding the UI properties associated shader port
-    struct UIPropertyItem
-    {
-        string label;
-        ValuePtr value;
-        ShaderPort* variable = nullptr;
-        UIProperties ui;
-    };
+/// Get the UI properties for a given element path. If the path is to a node, a target
+/// identifier can be provided.
+/// Returns the number of properties found.
+unsigned int getUIProperties(const string& path, DocumentPtr doc, const string& target, UIProperties& uiProperties);
 
-    /// A grouping of property items by name
-    using UIPropertyGroup = std::multimap<string, UIPropertyItem>;
+/// Interface for holding the UI properties associated shader port
+struct UIPropertyItem
+{
+    string label;
+    ValuePtr value;
+    ShaderPort* variable = nullptr;
+    UIProperties ui;
+};
 
-    /// Utility to group UI properties items based on Element group name from an element.
-    /// Returns a list of named and unnamed groups.
-    void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocument, TypedElementPtr materialElement,
-                                const string& pathSeparator, UIPropertyGroup& groups,
-                                UIPropertyGroup& unnamedGroups, ShaderPort* uniform = nullptr);
+/// A grouping of property items by name
+using UIPropertyGroup = std::multimap<string, UIPropertyItem>;
 
-    /// Utility to group UI properties items based on Element group name from a VariableBlock.
-    /// Returns a list of named and unnamed groups.
-    void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
-                                const string& pathSeparator, UIPropertyGroup& groups,
-                                UIPropertyGroup& unnamedGroups);
+/// Utility to group UI properties items based on Element group name from an element.
+/// Returns a list of named and unnamed groups.
+void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocument, TypedElementPtr materialElement,
+                            const string& pathSeparator, UIPropertyGroup& groups,
+                            UIPropertyGroup& unnamedGroups, ShaderPort* uniform = nullptr);
 
-    /// @}
+/// Utility to group UI properties items based on Element group name from a VariableBlock.
+/// Returns a list of named and unnamed groups.
+void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
+                            const string& pathSeparator, UIPropertyGroup& groups,
+                            UIPropertyGroup& unnamedGroups);
+
+/// @}
 
 } // namespace MaterialX
 

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -134,7 +134,7 @@ ImagePtr GLTextureHandler::acquireImage(const FilePath& filePath,
     return image;
 }
 
-bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties)
+bool GLTextureHandler::bindImage(ConstImagePtr image, const ImageSamplingProperties& samplingProperties)
 {
     // Bind a texture to the next available slot
     if (_maxImageUnits < 0)
@@ -177,7 +177,7 @@ bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& 
     return true;
 }
 
-bool GLTextureHandler::unbindImage(ImagePtr image)
+bool GLTextureHandler::unbindImage(ConstImagePtr image)
 {
     if (!glActiveTexture)
     {

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -39,10 +39,10 @@ class GLTextureHandler : public ImageHandler
     /// Bind an image. This method will bind the texture to an active texture
     /// unit as defined by the corresponding image description. The method
     /// will fail if there are not enough available image units to bind to.
-    bool bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties) override;
+    bool bindImage(ConstImagePtr image, const ImageSamplingProperties& samplingProperties) override;
 
     /// Unbind an image. 
-    bool unbindImage(ImagePtr image) override;
+    bool unbindImage(ConstImagePtr image) override;
 
     /// Utility to map an address mode enumeration to an OpenGL address mode
     static int mapAddressModeToGL(ImageSamplingProperties::AddressMode addressModeEnum);

--- a/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
@@ -1,0 +1,33 @@
+//
+// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <PyMaterialX/PyMaterialX.h>
+
+#include <MaterialXRender/Image.h>
+
+namespace py = pybind11;
+namespace mx = MaterialX;
+
+void bindPyImage(py::module& mod)
+{
+    py::class_<mx::ImageBufferDeallocator>(mod, "ImageBufferDeallocator");
+
+    py::class_<mx::Image>(mod, "Image")
+        .def_static("create", &mx::Image::create)
+        .def_static("createConstantColor", &mx::Image::createConstantColor)
+        .def("getWidth", &mx::Image::getWidth)
+        .def("getHeight", &mx::Image::getHeight)
+        .def("getChannelCount", &mx::Image::getChannelCount)
+        .def("getBaseType", &mx::Image::getBaseType)
+        .def("getBaseStride", &mx::Image::getBaseStride)
+        .def("getMaxMipCount", &mx::Image::getMaxMipCount)
+        .def("setResourceBuffer", &mx::Image::setResourceBuffer)
+        .def("getResourceBuffer", &mx::Image::getResourceBuffer)
+        .def("createResourceBuffer", &mx::Image::createResourceBuffer)
+        .def("releaseResourceBuffer", &mx::Image::releaseResourceBuffer)
+        .def("setResourceBufferDeallocator", &mx::Image::setResourceBufferDeallocator)
+        .def("getResourceBufferDeallocator", &mx::Image::getResourceBufferDeallocator)
+        .def("getTexelColor", &mx::Image::getTexelColor);
+}

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -18,7 +18,7 @@ class PyImageLoader : public mx::ImageLoader
     {
     }
 
-    bool saveImage(const mx::FilePath& filePath, mx::ImagePtr image, bool verticalFlip) override
+    bool saveImage(const mx::FilePath& filePath, mx::ConstImagePtr image, bool verticalFlip) override
     {
         PYBIND11_OVERLOAD_PURE(
             bool,
@@ -50,7 +50,7 @@ class PyImageHandler : public mx::ImageHandler
     {
     }
 
-    bool saveImage(const mx::FilePath& filePath, mx::ImagePtr image, bool verticalFlip = false) override
+    bool saveImage(const mx::FilePath& filePath, mx::ConstImagePtr image, bool verticalFlip = false) override
     {
         PYBIND11_OVERLOAD(
             bool,
@@ -75,7 +75,7 @@ class PyImageHandler : public mx::ImageHandler
         );
     }
 
-    bool bindImage(mx::ImagePtr image, const mx::ImageSamplingProperties& samplingProperties) override
+    bool bindImage(mx::ConstImagePtr image, const mx::ImageSamplingProperties& samplingProperties) override
     {
         PYBIND11_OVERLOAD(
             bool,
@@ -100,25 +100,6 @@ class PyImageHandler : public mx::ImageHandler
 
 void bindPyImageHandler(py::module& mod)
 {
-    py::class_<mx::ImageBufferDeallocator>(mod, "ImageBufferDeallocator");
-
-    py::class_<mx::Image>(mod, "Image")
-        .def_static("create", &mx::Image::create)
-        .def_static("createConstantColor", &mx::Image::createConstantColor)
-        .def("getWidth", &mx::Image::getWidth)
-        .def("getHeight", &mx::Image::getHeight)
-        .def("getChannelCount", &mx::Image::getChannelCount)
-        .def("getBaseType", &mx::Image::getBaseType)
-        .def("getBaseStride", &mx::Image::getBaseStride)
-        .def("getMaxMipCount", &mx::Image::getMaxMipCount)
-        .def("setResourceBuffer", &mx::Image::setResourceBuffer)
-        .def("getResourceBuffer", &mx::Image::getResourceBuffer)
-        .def("createResourceBuffer", &mx::Image::createResourceBuffer)
-        .def("releaseResourceBuffer", &mx::Image::releaseResourceBuffer)
-        .def("setResourceBufferDeallocator", &mx::Image::setResourceBufferDeallocator)
-        .def("getResourceBufferDeallocator", &mx::Image::getResourceBufferDeallocator)
-        .def("getTexelColor", &mx::Image::getTexelColor);
-
     py::class_<mx::ImageSamplingProperties>(mod, "ImageSamplingProperties")
         .def_readwrite("uaddressMode", &mx::ImageSamplingProperties::uaddressMode)
         .def_readwrite("vaddressMode", &mx::ImageSamplingProperties::vaddressMode)


### PR DESCRIPTION
- Move the Image class to its own source and header files (Image.cpp and Image.h), allowing image processors to depend on Image without depending on ImageHandler and ImageLoader.
- Add a ConstImagePtr alias to clarify the behavior of image processing interfaces.
- Minor whitespace fixes in Util.h.