### PR TITLE
Initial support for spherical harmonic irradiance

### DIFF
--- a/source/MaterialXRender/Harmonics.cpp
+++ b/source/MaterialXRender/Harmonics.cpp
@@ -39,7 +39,7 @@ double imageYToTheta(unsigned int y, unsigned int height)
 Vector3d sphericalToCartesian(double theta, double phi)
 {
     double r = std::sin(theta);
-    return Color3d(r * std::cos(phi), r * std::sin(phi), std::cos(theta));
+    return Vector3d(r * std::cos(phi), r * std::sin(phi), std::cos(theta));
 }
 
 double texelSolidAngle(unsigned int y, unsigned int width, unsigned int height)
@@ -49,9 +49,9 @@ double texelSolidAngle(unsigned int y, unsigned int width, unsigned int height)
     // Reference:
     //   https://en.wikipedia.org/wiki/Solid_angle#Latitude-longitude_rectangle
 
-    double dtheta = std::cos(y * PI / height) - std::cos((y + 1) * PI / height);
-    double dphi = 2.0 * PI / width;
-    return dtheta * dphi;
+    double dTheta = std::cos(y * PI / height) - std::cos((y + 1) * PI / height);
+    double dPhi = 2.0 * PI / width;
+    return dTheta * dPhi;
 }
 
 ShScalarCoeffs evalDirection(const Vector3d& dir)

--- a/source/MaterialXRender/Harmonics.cpp
+++ b/source/MaterialXRender/Harmonics.cpp
@@ -104,10 +104,15 @@ ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance)
             // Evaluate the given direction as SH coefficients.
             ShScalarCoeffs shDir = evalDirection(dir);
 
+            // Combine color with texel weight.
+            Color3d weightedColor(color[0] * texelWeight,
+                                  color[1] * texelWeight,
+                                  color[2] * texelWeight);
+
             // Update coefficients for the influence of this texel.
             for (size_t i = 0; i < shCoeffs.NUM_COEFFS; i++)
             {
-                shCoeffs[i] += Color3d(color[0], color[1], color[2]) * texelWeight * shDir[i];
+                shCoeffs[i] += weightedColor * shDir[i];
             }
         }
     }

--- a/source/MaterialXRender/Harmonics.cpp
+++ b/source/MaterialXRender/Harmonics.cpp
@@ -1,0 +1,157 @@
+//
+// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXRender/Harmonics.h>
+
+#include <cmath>
+
+namespace MaterialX
+{
+
+namespace {
+
+const double PI = std::acos(-1.0);
+
+const double BASIS_CONSTANT_0 = std::sqrt( 1.0 / ( 4.0 * PI));
+const double BASIS_CONSTANT_1 = std::sqrt( 3.0 / ( 4.0 * PI));
+const double BASIS_CONSTANT_2 = std::sqrt(15.0 / ( 4.0 * PI));
+const double BASIS_CONSTANT_3 = std::sqrt( 5.0 / (16.0 * PI));
+const double BASIS_CONSTANT_4 = std::sqrt(15.0 / (16.0 * PI));
+
+const double COSINE_CONSTANT_0 = 1.0;
+const double COSINE_CONSTANT_1 = 2.0 / 3.0;
+const double COSINE_CONSTANT_2 = 1.0 / 4.0;
+
+double imageXToPhi(unsigned int x, unsigned int width)
+{
+    // Directions are measured from the center of the pixel, so add 0.5
+    // to convert from pixel indices to pixel coordinates.
+    return 2.0 * PI * (x + 0.5) / width;
+}
+
+double imageYToTheta(unsigned int y, unsigned int height)
+{
+    return PI * (y + 0.5) / height;
+}
+
+Vector3d sphericalToCartesian(double theta, double phi)
+{
+    double r = std::sin(theta);
+    return Color3d(r * std::cos(phi), r * std::sin(phi), std::cos(theta));
+}
+
+ShScalarCoeffs evalDirection(const Vector3d& dir)
+{
+    // Evaluate the spherical harmonic basis functions for the given direction,
+    // returning the first three bands of coefficients.
+    //
+    // References:
+    //   https://cseweb.ucsd.edu/~ravir/papers/envmap/envmap.pdf
+    //   http://orlandoaguilar.github.io/sh/spherical/harmonics/irradiance/map/2017/02/12/SphericalHarmonics.html
+
+    const double& x = dir[0];
+    const double& y = dir[1];
+    const double& z = dir[2];
+
+    return ShScalarCoeffs(
+    {
+        BASIS_CONSTANT_0,
+        BASIS_CONSTANT_1 * y,
+        BASIS_CONSTANT_1 * z,
+        BASIS_CONSTANT_1 * x,
+        BASIS_CONSTANT_2 * x * y,
+        BASIS_CONSTANT_2 * y * z,
+        BASIS_CONSTANT_3 * (3.0 * z * z - 1.0),
+        BASIS_CONSTANT_2 * x * z,
+        BASIS_CONSTANT_4 * (x * x - y * y)
+    });
+}
+
+} // anonymous namespace
+
+ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance)
+{
+    ShColorCoeffs shCoeffs;
+    double pixelArea = (2.0 * PI / env->getWidth()) * (PI / env->getHeight());
+
+    for (unsigned int y = 0; y < env->getHeight(); y++)
+    {
+        double theta = imageYToTheta(y, env->getHeight());
+
+        // Scale the pixel area by sin(theta) to account for the distortion
+        // introduced by a lat-long parameterization.
+        double weight = pixelArea * std::sin(theta);
+
+        for (unsigned int x = 0; x < env->getWidth(); x++)
+        {
+            // Sample the color at these coordinates.
+            Color4 color = env->getTexelColor(x, y);
+
+            // Compute the direction vector.
+            double phi = imageXToPhi(x, env->getWidth());
+            Vector3d dir = sphericalToCartesian(theta, phi);
+
+            // Evaluate the given direction as SH coefficients.
+            ShScalarCoeffs shDir = evalDirection(dir);
+
+            // Update coefficients for the influence of this texel.
+            for (size_t i = 0; i < shCoeffs.NUM_COEFFS; i++)
+            {
+                shCoeffs[i] += Color3d(color[0], color[1], color[2]) * weight * shDir[i];
+            }
+        }
+    }
+
+    // If irradiance is requested, then apply constant factors to convolve the
+    // signal by a clamped cosine lobe.
+    if (irradiance)
+    {
+        shCoeffs[0] *= COSINE_CONSTANT_0;
+        shCoeffs[1] *= COSINE_CONSTANT_1;
+        shCoeffs[2] *= COSINE_CONSTANT_1;
+        shCoeffs[3] *= COSINE_CONSTANT_1;
+        shCoeffs[4] *= COSINE_CONSTANT_2;
+        shCoeffs[5] *= COSINE_CONSTANT_2;
+        shCoeffs[6] *= COSINE_CONSTANT_2;
+        shCoeffs[7] *= COSINE_CONSTANT_2;
+        shCoeffs[8] *= COSINE_CONSTANT_2;
+    }
+
+    return shCoeffs;
+}
+
+ImagePtr renderEnvironment(ShColorCoeffs coeffs, unsigned int width, unsigned int height)
+{
+    ImagePtr env = Image::create(width, height, 3, Image::BaseType::FLOAT);
+    env->createResourceBuffer();
+
+    for (unsigned int y = 0; y < env->getHeight(); y++)
+    {
+        double theta = imageYToTheta(y, env->getHeight());
+        for (unsigned int x = 0; x < env->getWidth(); x++)
+        {
+            // Compute the direction vector.
+            double phi = imageXToPhi(x, env->getWidth());
+            Vector3d dir = sphericalToCartesian(theta, phi);
+
+            // Evaluate the given direction as SH coefficients.
+            ShScalarCoeffs shDir = evalDirection(dir);
+
+            // Compute the signal color in this direction.
+            Color3d color;
+            for (size_t i = 0; i < coeffs.NUM_COEFFS; i++)
+            {
+                color += coeffs[i] * shDir[i];
+            }
+
+            // Store the color as an environment texel.
+            env->setTexelColor(x, y, Color4((float) color[0], (float) color[1], (float) color[2], 1.0f));
+        }
+    }
+
+    return env;
+}
+
+} // namespace MaterialX

--- a/source/MaterialXRender/Harmonics.cpp
+++ b/source/MaterialXRender/Harmonics.cpp
@@ -54,7 +54,7 @@ double texelSolidAngle(unsigned int y, unsigned int width, unsigned int height)
     return dTheta * dPhi;
 }
 
-ShScalarCoeffs evalDirection(const Vector3d& dir)
+Sh3ScalarCoeffs evalDirection(const Vector3d& dir)
 {
     // Evaluate the spherical harmonic basis functions for the given direction,
     // returning the first three bands of coefficients.
@@ -67,7 +67,7 @@ ShScalarCoeffs evalDirection(const Vector3d& dir)
     const double& y = dir[1];
     const double& z = dir[2];
 
-    return ShScalarCoeffs(
+    return Sh3ScalarCoeffs(
     {
         BASIS_CONSTANT_0,
         BASIS_CONSTANT_1 * y,
@@ -83,9 +83,9 @@ ShScalarCoeffs evalDirection(const Vector3d& dir)
 
 } // anonymous namespace
 
-ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance)
+Sh3ColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance)
 {
-    ShColorCoeffs shEnv;
+    Sh3ColorCoeffs shEnv;
 
     for (unsigned int y = 0; y < env->getHeight(); y++)
     {
@@ -102,7 +102,7 @@ ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance)
             Vector3d dir = sphericalToCartesian(theta, phi);
 
             // Evaluate the given direction as SH coefficients.
-            ShScalarCoeffs shDir = evalDirection(dir);
+            Sh3ScalarCoeffs shDir = evalDirection(dir);
 
             // Combine color with texel weight.
             Color3d weightedColor(color[0] * texelWeight,
@@ -118,7 +118,7 @@ ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance)
     }
 
     // If irradiance is requested, then apply constant factors to convolve the
-    // signal by a clamped cosine lobe.
+    // signal by a clamped cosine kernel.
     if (irradiance)
     {
         shEnv[0] *= COSINE_CONSTANT_0;
@@ -135,7 +135,7 @@ ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance)
     return shEnv;
 }
 
-ImagePtr renderEnvironment(ShColorCoeffs shEnv, unsigned int width, unsigned int height)
+ImagePtr renderEnvironment(const Sh3ColorCoeffs& shEnv, unsigned int width, unsigned int height)
 {
     ImagePtr env = Image::create(width, height, 3, Image::BaseType::FLOAT);
     env->createResourceBuffer();
@@ -150,7 +150,7 @@ ImagePtr renderEnvironment(ShColorCoeffs shEnv, unsigned int width, unsigned int
             Vector3d dir = sphericalToCartesian(theta, phi);
 
             // Evaluate the given direction as SH coefficients.
-            ShScalarCoeffs shDir = evalDirection(dir);
+            Sh3ScalarCoeffs shDir = evalDirection(dir);
 
             // Compute the signal color in this direction.
             Color3d signalColor;

--- a/source/MaterialXRender/Harmonics.h
+++ b/source/MaterialXRender/Harmonics.h
@@ -79,11 +79,11 @@ using ShColorCoeffs = ShCoeffs<Color3d, 3>;
 ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance);
 
 /// Render the given spherical harmonic signal to an environment map.
-/// @param coeffs A color signal encoded as spherical harmonics.
+/// @param shEnv The color signal of the environment encoded as spherical harmonics.
 /// @param width The width of the output environment map.
 /// @param height The height of the output environment map.
 /// @return An environment map in the lat-long format.
-ImagePtr renderEnvironment(ShColorCoeffs coeffs, unsigned int width, unsigned int height);
+ImagePtr renderEnvironment(ShColorCoeffs shEnv, unsigned int width, unsigned int height);
 
 } // namespace MaterialX
 

--- a/source/MaterialXRender/Harmonics.h
+++ b/source/MaterialXRender/Harmonics.h
@@ -67,23 +67,26 @@ template <class C, size_t B> class ShCoeffs
     std::array<C, NUM_COEFFS> _arr;
 };
 
-using ShScalarCoeffs = ShCoeffs<double, 3>;
-using ShColorCoeffs = ShCoeffs<Color3d, 3>;
+/// Double-precision scalar coefficients for third-order spherical harmonics.
+using Sh3ScalarCoeffs = ShCoeffs<double, 3>;
 
-/// Project an environment map to three bands of spherical harmonics, with
-/// an optional convolution to convert radiance to irradiance.
+/// Double-precision color coefficients for third-order spherical harmonics.
+using Sh3ColorCoeffs = ShCoeffs<Color3d, 3>;
+
+/// Project an environment map to third-order SH, with an optional convolution
+///    to convert radiance to irradiance.
 /// @param env An environment map in lat-long format.
 /// @param irradiance If true, then the returned signal will be convolved
 ///    by a clamped cosine kernel to generate irradiance.
-/// @return The projection of the environment in three bands of SH.
-ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance);
+/// @return The projection of the environment to third-order SH.
+Sh3ColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance);
 
 /// Render the given spherical harmonic signal to an environment map.
-/// @param shEnv The color signal of the environment encoded as spherical harmonics.
+/// @param shEnv The color signal of the environment encoded as third-order SH.
 /// @param width The width of the output environment map.
 /// @param height The height of the output environment map.
 /// @return An environment map in the lat-long format.
-ImagePtr renderEnvironment(ShColorCoeffs shEnv, unsigned int width, unsigned int height);
+ImagePtr renderEnvironment(const Sh3ColorCoeffs& shEnv, unsigned int width, unsigned int height);
 
 } // namespace MaterialX
 

--- a/source/MaterialXRender/Harmonics.h
+++ b/source/MaterialXRender/Harmonics.h
@@ -1,0 +1,90 @@
+//
+// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_HARMONICS_H
+#define MATERIALX_HARMONICS_H
+
+/// @file
+/// Spherical harmonics functionality
+
+#include <MaterialXRender/Image.h>
+
+#include <MaterialXCore/Types.h>
+
+namespace MaterialX
+{
+
+/// @class Vector3d
+/// A vector of three floating-point values (double precision)
+class Vector3d : public VectorN<Vector3d, double, 3>
+{
+  public:
+    using VectorN<Vector3d, double, 3>::VectorN;
+    Vector3d() { }
+    Vector3d(double x, double y, double z) : VectorN(Uninit{})
+    {
+        _arr = {x, y, z};
+    }
+};
+
+/// @class Color3d
+/// A three-component color value (double precision)
+class Color3d : public Vector3d
+{
+  public:
+    using Vector3d::Vector3d;
+};
+
+/// Class template for a vector of spherical harmonic coefficients.
+///
+/// Template parameter C is the coefficient type (e.g. double, Color3).
+/// Template parameter B is the number of spherical harmonic bands.
+template <class C, size_t B> class ShCoeffs
+{
+  public:
+    static const size_t NUM_BANDS = B;
+    static const size_t NUM_COEFFS = B * B;
+
+  public:
+    ShCoeffs() { }
+    explicit ShCoeffs(const std::array<C, NUM_COEFFS>& arr) : _arr(arr) { }
+    ~ShCoeffs() { }
+
+    /// @name Indexing Operators
+    /// @{
+
+    /// Return the coefficient at the given index.
+    C& operator[](size_t i) { return _arr.at(i); }
+
+    /// Return the const coefficient at the given index.
+    const C& operator[](size_t i) const { return _arr.at(i); }
+
+    /// @}
+
+  protected:
+    std::array<C, NUM_COEFFS> _arr;
+};
+
+using ShScalarCoeffs = ShCoeffs<double, 3>;
+using ShColorCoeffs = ShCoeffs<Color3d, 3>;
+
+/// Project an environment map to three bands of spherical harmonics, with
+/// an optional convolution to convert radiance to irradiance.
+/// @param env An environment map in lat-long format.
+/// @param irradiance If true, then the returned signal will be convolved
+///    by a clamped cosine kernel to generate irradiance.
+/// @return The projection of the environment in three bands of SH.
+ShColorCoeffs projectEnvironment(ConstImagePtr env, bool irradiance);
+
+/// Render the given spherical harmonic signal to an environment map.
+/// @param coeffs A color signal encoded as spherical harmonics.
+/// @param width The width of the output environment map.
+/// @param height The height of the output environment map.
+/// @return An environment map in the lat-long format.
+ImagePtr renderEnvironment(ShColorCoeffs coeffs, unsigned int width, unsigned int height);
+
+} // namespace MaterialX
+
+#endif


### PR DESCRIPTION
- Add the ShCoeffs class template, representing a set of spherical harmonic coefficients for a particular data type and number of bands.
- Add the projectEnvironment function, allowing a lat-long environment to be projected to third-order spherical harmonics (with or without an irradiance convolution).
- Add the renderEnvironment function, allowing a third-order spherical harmonic signal to be rendered to a lat-long environment map.