### PR TITLE
Vector class improvements

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -68,6 +68,14 @@ class TestMaterialX(unittest.TestCase):
         self.assertTrue(v2 - v1 == mx.Vector3(1, 2, 3))
         self.assertTrue(v2 * v1 == mx.Vector3(2, 8, 18))
         self.assertTrue(v2 / v1 == mx.Vector3(2, 2, 2))
+        v2 += v1
+        self.assertTrue(v2 == mx.Vector3(3, 6, 9))
+        v2 -= v1
+        self.assertTrue(v2 == mx.Vector3(2, 4, 6))
+        v2 *= v1
+        self.assertTrue(v2 == mx.Vector3(2, 8, 18))
+        v2 /= v1
+        self.assertTrue(v2 == mx.Vector3(2, 4, 6))
         self.assertTrue(v1 * 2 == v2)
         self.assertTrue(v2 / 2 == v1)
 

--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXCore/Types.h>
 
-#include <cmath>
-
 namespace MaterialX
 {
 
@@ -34,26 +32,6 @@ const Matrix44 Matrix44::IDENTITY(1, 0, 0, 0,
                                   0, 1, 0, 0,
                                   0, 0, 1, 0,
                                   0, 0, 0, 1);
-
-//
-// Vector methods
-//
-
-template <> float VectorN<Vector2, float, 2>::getMagnitude() const
-{
-    return std::sqrt(_arr[0]*_arr[0] + _arr[1]*_arr[1]);
-}
-
-template <> float VectorN<Vector3, float, 3>::getMagnitude() const
-{
-    return std::sqrt(_arr[0]*_arr[0] + _arr[1]*_arr[1] + _arr[2]*_arr[2]);
-}
-
-template <> float VectorN<Vector4, float, 4>::getMagnitude() const
-{
-    return std::sqrt(_arr[0]*_arr[0] + _arr[1]*_arr[1] +
-                     _arr[2]*_arr[2] + _arr[3]*_arr[3]);
-}
 
 //
 // Matrix33 methods

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -12,6 +12,7 @@
 #include <MaterialXCore/Library.h>
 
 #include <array>
+#include <cmath>
 
 namespace MaterialX
 {
@@ -187,7 +188,13 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
     /// @{
 
     /// Return the magnitude of the vector.
-    S getMagnitude() const;
+    S getMagnitude() const
+    {
+        S res{};
+        for (size_t i = 0; i < N; i++)
+            res += _arr[i] * _arr[i];
+        return std::sqrt(res);
+    }
 
     /// Return a normalized vector.
     V getNormalized() const
@@ -292,26 +299,41 @@ class Vector4 : public VectorN<Vector4, float, 4>
 
 /// @class Color2
 /// A two-component color value
-class Color2 : public Vector2
+class Color2 : public VectorN<Color2, float, 2>
 {
   public:
-    using Vector2::Vector2;
+    using VectorN<Color2, float, 2>::VectorN;
+    Color2() { }
+    Color2(float r, float a) : VectorN(Uninit{})
+    {
+        _arr = {r, a};
+    }
 };
 
 /// @class Color3
 /// A three-component color value
-class Color3 : public Vector3
+class Color3 : public VectorN<Color3, float, 3>
 {
   public:
-    using Vector3::Vector3;
+    using VectorN<Color3, float, 3>::VectorN;
+    Color3() { }
+    Color3(float r, float g, float b) : VectorN(Uninit{})
+    {
+        _arr = {r, g, b};
+    }
 };
 
 /// @class Color4
 /// A four-component color value
-class Color4 : public Vector4
+class Color4 : public VectorN<Color4, float, 4>
 {
   public:
-    using Vector4::Vector4;
+    using VectorN<Color4, float, 4>::VectorN;
+    Color4() { }
+    Color4(float r, float g, float b, float a) : VectorN(Uninit{})
+    {
+        _arr = {r, g, b, a};
+    }
 };
 
 /// The base class for square matrices of scalar values

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -9,8 +9,6 @@
 #include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 
-#include <cmath>
-
 namespace MaterialX
 {
 

--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -7,8 +7,6 @@
 
 #include <MaterialXRender/Types.h>
 
-#include <cmath>
-
 namespace MaterialX
 {
 

--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -27,12 +27,30 @@ class Vector3d : public VectorN<Vector3d, double, 3>
     }
 };
 
-/// @class Color3d
-/// A three-component color value (double-precision)
-class Color3d : public Vector3d
+/// @class Vector4d
+/// A vector of four floating-point values (double-precision)
+class Vector4d : public VectorN<Vector4d, double, 4>
 {
   public:
-    using Vector3d::Vector3d;
+    using VectorN<Vector4d, double, 4>::VectorN;
+    Vector4d() { }
+    Vector4d(double x, double y, double z, double w) : VectorN(Uninit{})
+    {
+        _arr = {x, y, z, w};
+    }
+};
+
+/// @class Color3d
+/// A three-component color value (double-precision)
+class Color3d : public VectorN<Color3d, double, 3>
+{
+  public:
+    using VectorN<Color3d, double, 3>::VectorN;
+    Color3d() { }
+    Color3d(double r, double g, double b) : VectorN(Uninit{})
+    {
+        _arr = {r, g, b};
+    }
 };
 
 /// @class Half

--- a/source/MaterialXRender/ViewHandler.cpp
+++ b/source/MaterialXRender/ViewHandler.cpp
@@ -4,7 +4,6 @@
 //
 
 #include <MaterialXRender/ViewHandler.h>
-#include <cmath>
 
 namespace MaterialX
 { 

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -9,7 +9,6 @@
 #include <MaterialXRenderHw/SimpleWindow.h>
 #include <MaterialXRender/TinyObjLoader.h>
 
-#include <cmath>
 #include <iostream>
 
 namespace MaterialX

--- a/source/MaterialXTest/Types.cpp
+++ b/source/MaterialXTest/Types.cpp
@@ -8,8 +8,6 @@
 #include <MaterialXCore/Types.h>
 #include <MaterialXCore/Value.h>
 
-#include <cmath>
-
 namespace mx = MaterialX;
 
 const float EPSILON = 1e-4f;

--- a/source/MaterialXTest/Units.cpp
+++ b/source/MaterialXTest/Units.cpp
@@ -12,8 +12,6 @@
 #include <MaterialXGenShader/Util.h>
 #include <MaterialXGenShader/UnitConverter.h>
 
-#include <cmath>
-
 namespace mx = MaterialX;
 
 const float EPSILON = 1e-4f;

--- a/source/PyMaterialX/PyMaterialXCore/PyTypes.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyTypes.cpp
@@ -92,17 +92,20 @@ void bindPyTypes(py::module& mod)
         .def(py::init<float, float, float, float>())
         .def("asTuple", [](const mx::Vector4& v) { return std::make_tuple(v[0], v[1], v[2], v[3]); });
 
-    py::class_<mx::Color2, mx::Vector2>(mod, "Color2")
+    py::class_<mx::Color2, mx::VectorBase>(mod, "Color2")
         BIND_VECTOR_SUBCLASS(mx::Color2, 2)
-        .def(py::init<float, float>());
+        .def(py::init<float, float>())
+        .def("asTuple", [](const mx::Vector2& v) { return std::make_tuple(v[0], v[1]); });
 
-    py::class_<mx::Color3, mx::Vector3>(mod, "Color3")
+    py::class_<mx::Color3, mx::VectorBase>(mod, "Color3")
         BIND_VECTOR_SUBCLASS(mx::Color3, 3)
-        .def(py::init<float, float, float>());
+        .def(py::init<float, float, float>())
+        .def("asTuple", [](const mx::Vector3& v) { return std::make_tuple(v[0], v[1], v[2]); });
 
-    py::class_<mx::Color4, mx::Vector4>(mod, "Color4")
+    py::class_<mx::Color4, mx::VectorBase>(mod, "Color4")
         BIND_VECTOR_SUBCLASS(mx::Color4, 4)
-        .def(py::init<float, float, float, float>());
+        .def(py::init<float, float, float, float>())
+        .def("asTuple", [](const mx::Vector4& v) { return std::make_tuple(v[0], v[1], v[2], v[3]); });
 
     py::class_<mx::Matrix33, mx::MatrixBase>(mod, "Matrix33")
         BIND_MATRIX_SUBCLASS(mx::Matrix33, 3)


### PR DESCRIPTION
- Generalize getMagnitude to handle all subclasses of VectorN
- Specialize Color classes directly from VectorN for consistent handling of operators.
- Move <cmath> library include to Types.h.
- Add missing Python tests for Vector operators.