### PR TITLE
MacOS build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
       dist: xenial
       compiler: clang
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: clang
 
     # Custom builds

--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -2,35 +2,33 @@ include_directories(
     ${EXTERNAL_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../)
 
-# Linux checks for X and OpenGL
-if(UNIX AND NOT APPLE)
-	find_package(PkgConfig REQUIRED)
-	find_package(X11 REQUIRED)
-	if(NOT X11_FOUND)
-		message("Error in building MaterialXRender: X11 was not found")
-	endif(NOT X11_FOUND)
-	if(NOT X11_Xt_FOUND)
-		message("Error in building MaterialXRender: Xt was not found")
-	endif(NOT X11_Xt_FOUND)
-	find_package(OpenGL REQUIRED)
-	if(NOT OPENGL_FOUND)
-		message("Error in building MaterialXRender: OpenGL was not found")
-	endif(NOT OPENGL_FOUND)
-	include_directories(${X11_INCLUDE_DIR})
-endif(UNIX AND NOT APPLE)
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
 if(APPLE)
-	find_library(COCOA_FRAMEWORK Cocoa)
-	find_package(OpenGL REQUIRED)
-	file(GLOB_RECURSE materialx_source_oc "${CMAKE_CURRENT_SOURCE_DIR}/*.m")
-	message("Objective C files: " ${materialx_source_oc})
-	set_source_files_properties(${materialx_source_oc} PROPERTIES
-		COMPILE_FLAGS "-x objective-c++")
-	set(materialx_source ${materialx_source} ${materialx_source_oc})
-endif(APPLE)
+    find_library(COCOA_FRAMEWORK Cocoa)
+    find_package(OpenGL REQUIRED)
+    file(GLOB_RECURSE materialx_source_oc "${CMAKE_CURRENT_SOURCE_DIR}/*.m")
+    message("Objective C files: " ${materialx_source_oc})
+    set_source_files_properties(${materialx_source_oc} PROPERTIES
+        COMPILE_FLAGS "-x objective-c++")
+    set(materialx_source ${materialx_source} ${materialx_source_oc})
+    add_compile_options(-Wno-deprecated-declarations -DGL_SILENCE_DEPRECATION)
+elseif(UNIX)
+    find_package(PkgConfig REQUIRED)
+    find_package(X11 REQUIRED)
+    if(NOT X11_FOUND)
+        message("Error in building MaterialXRender: X11 was not found")
+    endif(NOT X11_FOUND)
+    if(NOT X11_Xt_FOUND)
+        message("Error in building MaterialXRender: Xt was not found")
+    endif(NOT X11_Xt_FOUND)
+    find_package(OpenGL REQUIRED)
+    if(NOT OPENGL_FOUND)
+        message("Error in building MaterialXRender: OpenGL was not found")
+    endif(NOT OPENGL_FOUND)
+    include_directories(${X11_INCLUDE_DIR})
+endif()
 
 assign_source_group("Source Files" ${materialx_source})
 assign_source_group("Header Files" ${materialx_headers})
@@ -49,8 +47,8 @@ elseif(APPLE)
         MaterialXRenderHw
         ${CMAKE_DL_LIBS}
         ${OPENGL_LIBRARIES}
-	    "-framework Foundation"
-      	"-framework Cocoa")
+        "-framework Foundation"
+        "-framework Cocoa")
 elseif(UNIX)
     target_link_libraries(
         MaterialXRenderGlsl
@@ -59,7 +57,7 @@ elseif(UNIX)
         ${OPENGL_LIBRARIES}
         ${X11_LIBRARIES}
         ${X11_Xt_LIB})
-endif(MSVC)
+endif()
 
 set_target_properties(
     MaterialXRenderGlsl PROPERTIES

--- a/source/MaterialXRenderGlsl/GLCocoaWrappers.h
+++ b/source/MaterialXRenderGlsl/GLCocoaWrappers.h
@@ -31,7 +31,6 @@ void NSOpenGLClearDrawable(void* pContext);
 void NSOpenGLDescribePixelFormat(void* pPixelFormat, int attrib, int* vals);
 void NSOpenGLGetInteger(void* pContext, int param, int* vals);
 void NSOpenGLUpdate(void* pContext);
-void* NSOpenGLCGLContextObj(void* pContext);
 void* NSOpenGLGetWindow(void* pView);
 void NSOpenGLInitializeGLLibrary();
 

--- a/source/MaterialXRenderGlsl/GLCocoaWrappers.m
+++ b/source/MaterialXRenderGlsl/GLCocoaWrappers.m
@@ -196,13 +196,6 @@ void NSOpenGLUpdate(void* pContext)
     [context update];
 }
 
-void* NSOpenGLCGLContextObj(void* pContext)
-{
-  NSOpenGLContext *context = (NSOpenGLContext*)pContext;
-    NSOpenGLContextAuxiliary* contextAuxiliary =  [context CGLContextObj];
-    return contextAuxiliary;
-}
-
 void* NSOpenGLGetWindow(void* pView)
 {
   NSView *view = (NSView*)pView;

--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -12,12 +12,14 @@ set(NANOGUI_BUILD_SHARED OFF CACHE BOOL " " FORCE)
 set(NANOGUI_BUILD_PYTHON OFF CACHE BOOL " " FORCE)
 set(NANOGUI_INSTALL OFF CACHE BOOL " " FORCE)
 
-# Turn off some additional warnings in NanoGUI dependents
+# Locally disable additional warnings for NanoGUI and its dependencies
 set(PREV_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 set(PREV_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 if(MSVC)
     add_compile_options(-wd4389 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -DEIGEN_DONT_VECTORIZE)
-elseif(UNIX AND NOT APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+elseif(APPLE)
+    add_compile_options(-Wno-objc-multiple-method-names -DGL_SILENCE_DEPRECATION)
+elseif(UNIX AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     add_compile_options(-Wno-format-truncation -Wno-implicit-fallthrough -Wno-int-in-bool-context
                         -Wno-maybe-uninitialized -Wno-misleading-indentation)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy")
@@ -26,6 +28,7 @@ endif()
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/NanoGUI external/NanoGUI)
 set_property(TARGET nanogui nanogui-obj glfw glfw_objects PROPERTY FOLDER "External")
 
+# Restore warnings for MaterialXView
 set(CMAKE_C_FLAGS ${PREV_CMAKE_C_FLAGS})
 set(CMAKE_CXX_FLAGS ${PREV_CMAKE_CXX_FLAGS})
 


### PR DESCRIPTION
- Integrate Ashwin's MacOS fix from the Autodesk fork (https://github.com/autodesk-forks/MaterialX/pull/647)
- Silence OpenGL deprecation warnings in MacOS builds.
- Increment the osx_image setting to xcode11, so that we're testing against a more recent MacOS image.
- Minor fixes to CMake formatting and whitespace.