### PR TITLE
Minor updates for Pybind + OSL Reference test

### DIFF
--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -22,7 +22,11 @@ endif()
 
 add_custom_command(TARGET MaterialXTest POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
-	${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_CURRENT_BINARY_DIR}/libraries)
+	${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_CURRENT_BINARY_DIR}/libraries)     
+install(DIRECTORY DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/libraries/stdlib/reference/osl)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/stdlib/osl/"
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/libraries/stdlib/reference/osl 
+    FILES_MATCHING PATTERN "*.h")
 add_custom_command(TARGET MaterialXTest POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 	${CMAKE_CURRENT_SOURCE_DIR}/../../resources ${CMAKE_CURRENT_BINARY_DIR}/resources)

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -168,9 +168,14 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     context.registerSourceCodeSearchPath(librariesPath);
     context.getOptions().fileTextureVerticalFlip = true;
 
-    mx::OslRendererPtr oslRenderer = mx::OslRenderer::create();
-    oslRenderer->setOslCompilerExecutable(MATERIALX_OSLC_EXECUTABLE);
-    oslRenderer->setOslIncludePath(MATERIALX_OSL_INCLUDE_PATH);
+    bool runCompileTest = !std::string(MATERIALX_OSLC_EXECUTABLE).empty();
+    mx::OslRendererPtr oslRenderer = nullptr;
+    if (runCompileTest)
+    {
+        oslRenderer = mx::OslRenderer::create();
+        oslRenderer->setOslCompilerExecutable(MATERIALX_OSLC_EXECUTABLE);
+        oslRenderer->setOslIncludePath(MATERIALX_OSL_INCLUDE_PATH);
+    }
 
     const mx::FilePath logPath("genosl_reference_generate_test.txt");
     std::ofstream logFile;
@@ -200,7 +205,10 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
             file << shader->getSourceCode();
             file.close();
 
-            oslRenderer->compileOSL(filepath);
+            if (oslRenderer)
+            {
+                oslRenderer->compileOSL(filepath);
+            }
 
             mx::ImplementationPtr impl = implDoc->addImplementation("IM_" + nodeName + "_osl");
             impl->setNodeDef(nodedef);

--- a/source/PyMaterialX/PyBind11/include/pybind11/detail/common.h
+++ b/source/PyMaterialX/PyBind11/include/pybind11/detail/common.h
@@ -103,7 +103,7 @@
 #  endif
 #  pragma warning(push)
 #  pragma warning(disable: 4510 4610 4512 4005)
-#  if defined(_DEBUG)
+#  if defined(_DEBUG) && !defined(Py_DEBUG)
 #    define PYBIND11_DEBUG_MARKER
 #    undef _DEBUG
 #  endif


### PR DESCRIPTION
- Merge in fix for debug python (https://github.com/pybind/pybind11/pull/2025)
- Fix OSL reference generation unit test to have include files locally to allow for oslc for verification.
