### PR TITLE
Extend build tests to Python 3.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,11 +10,11 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: Visual Studio 15 2017
       ARCH: Win32
-      PYTHON: C:\Python36
+      PYTHON: C:\Python37
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
       ARCH: x64
-      PYTHON: C:\Python37-x64
+      PYTHON: C:\Python38-x64
 
 configuration:
   - Release


### PR DESCRIPTION
Extend Appveyor build tests to include Python 3.8, which is supported by the latest version of PyBind11.