### PR TITLE
Extend build tests to Clang 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: cpp
 
 addons:
   apt:
-    sources:
-      - llvm-toolchain-xenial-8
-      - ubuntu-toolchain-r-test
-    packages:
+    packages: &packages_base
       - libglu1-mesa-dev
       - libxxf86vm-dev
       - libxrandr-dev
@@ -13,9 +10,7 @@ addons:
       - libxcursor-dev
       - libxi-dev
       - libx11-dev
-      - g++-6
-      - g++-9
-      - clang-8
+    packages: *packages_base
 
 matrix:
   include:
@@ -38,14 +33,25 @@ matrix:
       dist: xenial
       compiler: gcc
       env: MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: [*packages_base, g++-6]
     - os: linux
       dist: xenial
       compiler: gcc
       env: MATRIX_EVAL="CC=gcc-9 && CXX=g++-9 && PY=3"
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: [*packages_base, g++-9]
     - os: linux
-      dist: xenial
+      dist: bionic
       compiler: clang
-      env: MATRIX_EVAL="CC=clang-8 && CXX=clang++-8 && PY=3"
+      env: MATRIX_EVAL="CC=clang-9 && CXX=clang++-9 && PY=3"
+      addons:
+        apt:
+          packages: [*packages_base, clang-9]
 
 before_install:
   - export PY=2

--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -5,6 +5,13 @@ include_directories(
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
+assign_source_group("Source Files" ${materialx_source})
+assign_source_group("Header Files" ${materialx_headers})
+
+if(POLICY CMP0072)
+    cmake_policy(SET CMP0072 NEW)
+endif(POLICY CMP0072)
+
 if(APPLE)
     find_library(COCOA_FRAMEWORK Cocoa)
     find_package(OpenGL REQUIRED)
@@ -22,9 +29,6 @@ elseif(UNIX)
     endif()
     include_directories(${X11_INCLUDE_DIR})
 endif()
-
-assign_source_group("Source Files" ${materialx_source})
-assign_source_group("Header Files" ${materialx_headers})
 
 add_library(MaterialXRenderGlsl STATIC ${materialx_source} ${materialx_headers})
 


### PR DESCRIPTION
Extend Travis build tests to Clang 9, and fix a related warning in MaterialXRenderGlsl.