### PR TITLE
Update CMake policy for broader compatibility

### DIFF
--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -9,8 +9,8 @@ assign_source_group("Source Files" ${materialx_source})
 assign_source_group("Header Files" ${materialx_headers})
 
 if(POLICY CMP0072)
-    cmake_policy(SET CMP0072 NEW)
-endif(POLICY CMP0072)
+    cmake_policy(SET CMP0072 OLD)
+endif()
 
 if(APPLE)
     find_library(COCOA_FRAMEWORK Cocoa)


### PR DESCRIPTION
This changelist updates the CMake policy for OpenGL library preferences, requesting that older libraries be used when both new and old are present in the same environment.  This addresses an issue brought up by Frankie Liu at Nvidia on the MaterialX discussion forum.