### PR TITLE
Viewer rendering fixes

### DIFF
--- a/source/MaterialXRender/LightHandler.cpp
+++ b/source/MaterialXRender/LightHandler.cpp
@@ -3,9 +3,10 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
+#include <MaterialXRender/LightHandler.h>
+
 #include <MaterialXGenShader/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXRender/LightHandler.h>
 
 namespace MaterialX
 {

--- a/source/MaterialXRender/LightHandler.h
+++ b/source/MaterialXRender/LightHandler.h
@@ -41,10 +41,23 @@ class LightHandler
     /// Adds a light source node
     void addLightSource(NodePtr node);
 
-    /// Get the list of light sources.
+    /// Return the vector of active light sources.
     const vector<NodePtr>& getLightSources() const
     {
         return _lightSources;
+    }
+
+    /// Return the first active light source, if any, of the given category.
+    NodePtr getFirstLightOfCategory(const std::string category)
+    {
+        for (NodePtr light : _lightSources)
+        {
+            if (light->getCategory() == category)
+            {
+                return light;
+            }
+        }
+        return nullptr;
     }
 
     /// Get a list of identifiers associated with a given light nodedef

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -32,6 +32,13 @@ class DocumentModifiers
     std::string filePrefixTerminator;
 };
 
+class ShadowState
+{
+  public:
+    mx::ImagePtr ambientOcclusionMap;
+    float ambientOcclusionGain = 0.0f;
+};
+
 class Material
 {
   public:
@@ -140,8 +147,7 @@ class Material
 
     /// Bind lights to shader.
     void bindLights(mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr imageHandler,
-                    bool directLighting, bool indirectLighting,
-                    mx::ImagePtr ambientOcclusionMap, float ambientOcclusionGain,
+                    bool directLighting, bool indirectLighting, const ShadowState& shadowState,
                     mx::HwSpecularEnvironmentMethod specularEnvironmentMethod, int envSamples);
 
     /// Bind units.

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -83,9 +83,6 @@ class Viewer : public ng::Screen
     }
 
   private:
-    void drawScene3D();
-    void drawScene2D();
-
     void loadEnvironmentLight();
     void applyDirectLights(mx::DocumentPtr doc);
     void loadDocument(const mx::FilePath& filename, mx::DocumentPtr libraries);
@@ -98,6 +95,7 @@ class Viewer : public ng::Screen
     /// Assign the given material to the given geometry, or remove any
     /// existing assignment if the given material is nullptr.
     void assignMaterial(mx::MeshPartitionPtr geometry, MaterialPtr material);
+
     void initCamera();
     void updateViewHandlers();
     void updateGeometrySelections();
@@ -111,11 +109,6 @@ class Viewer : public ng::Screen
     void createSaveMaterialsInterface(Widget* parent, const std::string& label);
     void createPropertyEditorInterface(Widget* parent, const std::string& label);
     void createAdvancedSettings(Widget* parent);
-
-    mx::MeshStreamPtr createUvPositionStream(mx::MeshPtr mesh, 
-                                            const std::string& uvStreamName,
-                                            unsigned int index,
-                                            const std::string& positionStreamName);
 
     /// Return the ambient occlusion image, if any, associated with the given material.
     mx::ImagePtr getAmbientOcclusionImage(MaterialPtr material);
@@ -158,6 +151,8 @@ class Viewer : public ng::Screen
     bool _directLighting;
     bool _indirectLighting;
     bool _splitDirectLight;
+
+    // Ambient occlusion
     float _ambientOcclusionGain;
 
     // Geometry selections
@@ -184,7 +179,7 @@ class Viewer : public ng::Screen
     mx::LightHandlerPtr _lightHandler;
 
     // View handlers
-    mx::ViewHandlerPtr _sceneViewHandler;
+    mx::ViewHandlerPtr _cameraViewHandler;
 
     // Supporting materials and geometry.
     mx::GeometryHandlerPtr _envGeometryHandler;
@@ -221,13 +216,6 @@ class Viewer : public ng::Screen
     // Image save
     bool _captureFrame;
     mx::FilePath _captureFrameFileName;
-
-    // UV wireframe drawing
-    bool _drawUVGeometry;
-    MaterialPtr _wireMaterialUV;
-    mx::Vector3 _uvScale;
-    mx::Vector3 _uvTranslation;
-    float _uvZoom;
 };
 
 #endif // MATERIALXVIEW_VIEWER_H


### PR DESCRIPTION
This changelist fixes two rendering issues in the MaterialX viewer:

- Fix wireframe rendering with the Outline Selected Geometry option.
- Fix rendering of mixed opaque/transparent looks.

For simplicity, the UV wireframe hotkey has been removed, as it required some duplication of rendering logic, and we can integrate this functionality into the main render pathway if needed in the future.