### PR TITLE
Shadow rendering improvements

### DIFF
--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -274,4 +274,58 @@ int GLTextureHandler::mapFilterTypeToGL(ImageSamplingProperties::FilterType filt
     return filterType;
 }
 
+void GLTextureHandler::mapTextureFormatToGL(Image::BaseType baseType, unsigned int channelCount, bool srgb,
+                                            int& glType, int& glFormat, int& glInternalFormat)
+{
+    switch (channelCount)
+    {
+        case 4: glFormat = GL_RGBA; break;
+        case 3: glFormat = GL_RGB; break;
+        case 2: glFormat = GL_RG; break;
+        case 1: glFormat = GL_RED; break;
+        default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
+    }
+
+    if (baseType == Image::BaseType::UINT8)
+    {
+        glType = GL_UNSIGNED_BYTE;
+        switch (channelCount)
+        {
+            case 4: glInternalFormat = srgb ? GL_SRGB8_ALPHA8 : GL_RGBA8; break;
+            case 3: glInternalFormat = srgb ? GL_SRGB8 : GL_RGB8; break;
+            case 2: glInternalFormat = GL_RG8; break;
+            case 1: glInternalFormat = GL_R8; break;
+            default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
+        }
+    }
+    else if (baseType == Image::BaseType::HALF)
+    {
+        glType = GL_HALF_FLOAT;
+        switch (channelCount)
+        {
+            case 4: glInternalFormat = GL_RGBA16F; break;
+            case 3: glInternalFormat = GL_RGB16F; break;
+            case 2: glInternalFormat = GL_RG16F; break;
+            case 1: glInternalFormat = GL_R16F; break;
+            default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
+        }
+    }
+    else if (baseType == Image::BaseType::FLOAT)
+    {
+        glType = GL_FLOAT;
+        switch (channelCount)
+        {
+            case 4: glInternalFormat = GL_RGBA32F; break;
+            case 3: glInternalFormat = GL_RGB32F; break;
+            case 2: glInternalFormat = GL_RG32F; break;
+            case 1: glInternalFormat = GL_R32F; break;
+            default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
+        }
+    }
+    else
+    {
+        throw Exception("Unsupported base type in mapTextureFormatToGL");
+    }
+}
+
 } // namespace MaterialX

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -57,6 +57,9 @@ class GLTextureHandler : public ImageHandler
     /// Utility to map a filter type enumeration to an OpenGL filter type
     static int mapFilterTypeToGL(ImageSamplingProperties::FilterType filterTypeEnum);
 
+    static void mapTextureFormatToGL(Image::BaseType baseType, unsigned int channelCount, bool srgb,
+                                     int& glType, int& glFormat, int& glInternalFormat);
+
   protected:
     // Protected constructor
     GLTextureHandler(ImageLoaderPtr imageLoader);

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* const argv[])
     mx::FileSearchPath searchPath;
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx";
     std::string meshFilename = "resources/Geometry/shaderball.obj";
-    std::string envRadiancePath = "resources/Lights/san_giuseppe_bridge_split.hdr";
+    std::string envRadiancePath = "resources/Lights/san_giuseppe_bridge.hdr";
     DocumentModifiers modifiers;
     int multiSampleCount = 0;
     int refresh = 50;


### PR DESCRIPTION
- Add helper function GLTextureHandler::mapTextureFormatToGL for consistency.
- Defer shadow map allocations until requested by the user.
- To view a scene with variance shadow maps, click Load Environment and select Resources/Lights/san_giuseppe_bridge_split.hdr, then enable Shadow Maps in the Advanced Settings page.