### PR TITLE
Document upgrade fixes

### DIFF
--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -48,7 +48,7 @@ const string& NodeDef::getType() const
     }
     else
     {
-        throw Exception("Nodedef: " + getName() + " has no outputs");
+        return DEFAULT_TYPE_STRING;
     }
 }
 

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -657,8 +657,14 @@ void Document::upgradeVersion()
         const string TWO_STRING = "2";
         const string THREE_STRING = "3";
         const string FOUR_STRING = "4";
-        for (NodePtr node : getNodes())
+        for (ElementPtr elem : traverseTree())
         {
+            if (!elem->isA<Node>())
+            {
+                continue;
+            }
+
+            NodePtr node = elem->asA<Node>();
             const string& nodeCategory = node->getCategory();
 
             // Change category from "invert to "invertmatrix" for matrix invert nodes


### PR DESCRIPTION
This changelist fixes two edge cases when upgrading documents to v1.37 at import time:

- Return a default value rather than throwing an exception in getType, as this method can be called during the upgrade process itself.
- Upgrade nested nodes as well as those at root scope.