### PR TITLE
Shadow quality improvements

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -132,7 +132,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         {
             shadergen.emitLine("vec3 shadowCoord = (" + HW::T_SHADOW_MATRIX + " * vec4(" + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_POSITION_WORLD + ", 1.0)).xyz", stage);
             shadergen.emitLine("shadowCoord = shadowCoord * 0.5 + 0.5", stage);
-            shadergen.emitLine("vec2 shadowMoments = texture(" + HW::T_SHADOW_MAP + ", shadowCoord.xy).xw", stage);
+            shadergen.emitLine("vec2 shadowMoments = texture(" + HW::T_SHADOW_MAP + ", shadowCoord.xy).xy", stage);
             shadergen.emitLine("float shadowOcc = mx_variance_shadow_occlusion(shadowMoments, shadowCoord.z)", stage);
         }
         else

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -373,41 +373,58 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
         const string& nodetype = nodeDef->getNodeString();
         if (nodetype == "standard_surface")
         {
-            bool opaque = false;
+            bool opaque = true;
 
-            // First check the transmission weight
+            // Check transmission
             BindInputPtr transmission = shaderRef->getBindInput("transmission");
-            if (!transmission)
+            if (transmission)
             {
-                opaque = true;
-            }
-            else if (transmission->getOutputString() == EMPTY_STRING)
-            {
-                // Unconnected, check the value
-                ValuePtr value = transmission->getValue();
-                if (!value || isZero(value->asA<float>()))
+                if (transmission->getConnectedOutput())
                 {
-                    opaque = true;
+                    opaque = false;
                 }
-            }
-
-            // Second check the opacity
-            if (opaque)
-            {
-                opaque = false;
-
-                BindInputPtr opacity = shaderRef->getBindInput("opacity");
-                if (!opacity)
+                else
                 {
-                    opaque = true;
-                }
-                else if (opacity->getOutputString() == EMPTY_STRING)
-                {
-                    // Unconnected, check the value
-                    ValuePtr value = opacity->getValue();
-                    if (!value || (value->isA<Color3>() && isWhite(value->asA<Color3>())))
+                    ValuePtr value = transmission->getValue();
+                    if (value && value->isA<float>() && !isZero(value->asA<float>()))
                     {
-                        opaque = true;
+                        opaque = false;
+                    }
+                }
+            }
+
+            // Check opacity
+            BindInputPtr opacity = shaderRef->getBindInput("opacity");
+            if (opacity)
+            {
+                if (opacity->getConnectedOutput())
+                {
+                    opaque = false;
+                }
+                else
+                {
+                    ValuePtr value = opacity->getValue();
+                    if (value && value->isA<Color3>() && !isWhite(value->asA<Color3>()))
+                    {
+                        opaque = false;
+                    }
+                }
+            }
+
+            // Check subsurface
+            BindInputPtr subsurface = shaderRef->getBindInput("subsurface");
+            if (subsurface)
+            {
+                if (subsurface->getConnectedOutput())
+                {
+                    opaque = false;
+                }
+                else
+                {
+                    ValuePtr value = subsurface->getValue();
+                    if (value && value->isA<float>() && !isZero(value->asA<float>()))
+                    {
+                        opaque = false;
                     }
                 }
             }

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -98,6 +98,7 @@ bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, vaddressMode);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilterType);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilterType);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 16.0f);
 
     return true;
 }
@@ -140,34 +141,6 @@ bool GLTextureHandler::createRenderResources(ImagePtr image, bool generateMipMap
     int glType, glFormat, glInternalFormat;
     mapTextureFormatToGL(image->getBaseType(), image->getChannelCount(), false,
         glType, glFormat, glInternalFormat);
-
-    switch (image->getChannelCount())
-    {
-    case 3:
-    {
-        // Map {RGB} to {RGB, 1} at shader access time
-        GLint swizzleMaskRGB[] = { GL_RED, GL_GREEN, GL_BLUE, GL_ONE };
-        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskRGB);
-        break;
-    }
-    case 2:
-    {
-        // Map {red, green} to {red, alpha} at shader access time
-        GLint swizzleMaskRG[] = { GL_RED, GL_RED, GL_RED, GL_GREEN };
-        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskRG);
-        break;
-    }
-    case 1:
-    {
-        // Map { red } to {red, green, blue, 1} at shader access time
-        GLint swizzleMaskR[] = { GL_RED, GL_RED, GL_RED, GL_ONE };
-        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskR);
-        break;
-    }
-    default:
-        break;
-    }
-
     glTexImage2D(GL_TEXTURE_2D, 0, glInternalFormat, image->getWidth(), image->getHeight(),
         0, glFormat, glType, image->getResourceBuffer());
 

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* const argv[])
     mx::FileSearchPath searchPath;
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx";
     std::string meshFilename = "resources/Geometry/shaderball.obj";
-    std::string envRadiancePath = "resources/Lights/san_giuseppe_bridge.hdr";
+    std::string envRadiancePath = "resources/Lights/san_giuseppe_bridge_split.hdr";
     DocumentModifiers modifiers;
     int multiSampleCount = 0;
     int refresh = 50;

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -118,6 +118,13 @@ class Material
                              mx::DocumentPtr stdLib,
                              const std::string& shaderName);
 
+    /// Generate a blur shader.
+    bool generateBlurShader(mx::GenContext& context,
+                            mx::DocumentPtr stdLib,
+                            const std::string& shaderName,
+                            const std::string& filterType,
+                            float filterSize);
+
     /// Generate an environment background shader
     bool generateEnvironmentShader(mx::GenContext& context,
                                    const mx::FilePath& filename,

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -170,8 +170,10 @@ class Viewer : public ng::Screen
 
     // Shadow mapping
     MaterialPtr _shadowMaterial;
+    MaterialPtr _shadowBlurMaterial;
     mx::GLFrameBufferPtr _shadowFramebuffer;
     mx::ImagePtr _shadowMap;
+    unsigned int _shadowSoftness;
 
     // Ambient occlusion
     float _ambientOcclusionGain;


### PR DESCRIPTION
- Add a Gaussian blur step to shadow map generation.
- Clear the shadow framebuffer to one before rendering.
- Enable anisotropic filtering in the texture handler.
- Enable shadow maps by default.