### PR TITLE
Assume column vectors in createTranslation

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -96,26 +96,26 @@ class TestMaterialX(unittest.TestCase):
         # Translation and scale
         trans = mx.Matrix44.createTranslation(mx.Vector3(1, 2, 3))
         scale = mx.Matrix44.createScale(mx.Vector3(2))
-        self.assertTrue(trans == mx.Matrix44(1, 0, 0, 0,
-                                             0, 1, 0, 0,
-                                             0, 0, 1, 0,
-                                             1, 2, 3, 1))
+        self.assertTrue(trans == mx.Matrix44(1, 0, 0, 1,
+                                             0, 1, 0, 2,
+                                             0, 0, 1, 3,
+                                             0, 0, 0, 1))
         self.assertTrue(scale == mx.Matrix44(2, 0, 0, 0,
                                              0, 2, 0, 0,
                                              0, 0, 2, 0,
                                              0, 0, 0, 1))
 
         # Indexing operators
-        self.assertTrue(trans[3, 2] == 3)
-        trans[3, 2] = 4
-        self.assertTrue(trans[3, 2] == 4)
-        trans[3, 2] = 3
+        self.assertTrue(trans[2, 3] == 3)
+        trans[2, 3] = 4
+        self.assertTrue(trans[2, 3] == 4)
+        trans[2, 3] = 3
 
         # Matrix methods
-        self.assertTrue(trans.getTranspose() == mx.Matrix44(1, 0, 0, 1,
-                                                            0, 1, 0, 2,
-                                                            0, 0, 1, 3,
-                                                            0, 0, 0, 1))
+        self.assertTrue(trans.getTranspose() == mx.Matrix44(1, 0, 0, 0,
+                                                            0, 1, 0, 0,
+                                                            0, 0, 1, 0,
+                                                            1, 2, 3, 1))
         self.assertTrue(scale.getTranspose() == scale)
         self.assertTrue(trans.getDeterminant() == 1)
         self.assertTrue(scale.getDeterminant() == 8)
@@ -128,18 +128,18 @@ class TestMaterialX(unittest.TestCase):
         prod3 = trans * 2
         prod4 = trans
         prod4 *= scale
-        self.assertTrue(prod1 == mx.Matrix44(2, 0, 0, 0,
-                                             0, 2, 0, 0,
-                                             0, 0, 2, 0,
-                                             2, 4, 6, 1))
-        self.assertTrue(prod2 == mx.Matrix44(2, 0, 0, 0,
-                                             0, 2, 0, 0,
-                                             0, 0, 2, 0,
-                                             1, 2, 3, 1))
-        self.assertTrue(prod3 == mx.Matrix44(2, 0, 0, 0,
-                                             0, 2, 0, 0,
-                                             0, 0, 2, 0,
-                                             2, 4, 6, 2))
+        self.assertTrue(prod1 == mx.Matrix44(2, 0, 0, 1,
+                                             0, 2, 0, 2,
+                                             0, 0, 2, 3,
+                                             0, 0, 0, 1))
+        self.assertTrue(prod2 == mx.Matrix44(2, 0, 0, 2,
+                                             0, 2, 0, 4,
+                                             0, 0, 2, 6,
+                                             0, 0, 0, 1))
+        self.assertTrue(prod3 == mx.Matrix44(2, 0, 0, 2,
+                                             0, 2, 0, 4,
+                                             0, 0, 2, 6,
+                                             0, 0, 0, 2))
         self.assertTrue(prod4 == prod1)
 
         # Matrix division

--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -65,39 +65,39 @@ template <> Matrix33 MatrixN<Matrix33, float, 3>::getAdjugate() const
         _arr[0][0]*_arr[1][1] - _arr[1][0]*_arr[0][1]);
 }
 
-Vector3 Matrix33::multiply(const Vector3& rhs) const
+Vector3 Matrix33::multiply(const Vector3& v) const
 {
     return Vector3(
-      _arr[0][0] * rhs[0] + _arr[0][1] * rhs[1] + _arr[0][2] * rhs[2],
-      _arr[1][0] * rhs[0] + _arr[1][1] * rhs[1] + _arr[1][2] * rhs[2],
-      _arr[2][0] * rhs[0] + _arr[2][1] * rhs[1] + _arr[2][2] * rhs[2]
+      _arr[0][0] * v[0] + _arr[0][1] * v[1] + _arr[0][2] * v[2],
+      _arr[1][0] * v[0] + _arr[1][1] * v[1] + _arr[1][2] * v[2],
+      _arr[2][0] * v[0] + _arr[2][1] * v[1] + _arr[2][2] * v[2]
     );
 }
 
-Vector2 Matrix33::transformPoint(const Vector2& rhs) const
+Vector2 Matrix33::transformPoint(const Vector2& v) const
 {
-    Vector3 rhs3(rhs[0], rhs[1], 1.0f);
-    rhs3 = multiply(rhs3);
-    return Vector2(rhs3[0], rhs3[1]);
+    Vector3 v3(v[0], v[1], 1.0f);
+    v3 = multiply(v3);
+    return Vector2(v3[0], v3[1]);
 }
 
-Vector2 Matrix33::transformVector(const Vector2& rhs) const
+Vector2 Matrix33::transformVector(const Vector2& v) const
 {
-    Vector3 rhs3(rhs[0], rhs[1], 0.0f);
-    rhs3 = multiply(rhs3);
-    return Vector2(rhs3[0], rhs3[1]);
+    Vector3 v3(v[0], v[1], 0.0f);
+    v3 = multiply(v3);
+    return Vector2(v3[0], v3[1]);
 }
 
-Vector3 Matrix33::transformNormal(const Vector3& rhs) const
+Vector3 Matrix33::transformNormal(const Vector3& v) const
 {
-    return getInverse().getTranspose().multiply(rhs);
+    return getInverse().getTranspose().multiply(v);
 }
 
 Matrix33 Matrix33::createTranslation(const Vector2& v)
 {
-    return Matrix33(1.0f, 0.0f, 0.0f,
-                    0.0f, 1.0f, 0.0f,
-                    v[0], v[1], 1.0f);
+    return Matrix33(1.0f, 0.0f, v[0],
+                    0.0f, 1.0f, v[1],
+                    0.0f, 0.0f, 1.0f);
 }
 
 Matrix33 Matrix33::createScale(const Vector2& v)
@@ -193,44 +193,41 @@ template <> Matrix44 MatrixN<Matrix44, float, 4>::getAdjugate() const
         _arr[0][0]*_arr[2][1]*_arr[1][2] - _arr[1][0]*_arr[0][1]*_arr[2][2] - _arr[2][0]*_arr[1][1]*_arr[0][2]);
 }
 
-
-Vector4 Matrix44::multiply(const Vector4& rhs) const
+Vector4 Matrix44::multiply(const Vector4& v) const
 {
     return Vector4(
-      _arr[0][0] * rhs[0] + _arr[0][1] * rhs[1] + _arr[0][2] * rhs[2] + _arr[0][3] * rhs[3],
-      _arr[1][0] * rhs[0] + _arr[1][1] * rhs[1] + _arr[1][2] * rhs[2] + _arr[1][3] * rhs[3],
-      _arr[2][0] * rhs[0] + _arr[2][1] * rhs[1] + _arr[2][2] * rhs[2] + _arr[2][3] * rhs[3],
-      _arr[3][0] * rhs[0] + _arr[3][1] * rhs[1] + _arr[3][2] * rhs[2] + _arr[3][3] * rhs[3]
+      _arr[0][0] * v[0] + _arr[0][1] * v[1] + _arr[0][2] * v[2] + _arr[0][3] * v[3],
+      _arr[1][0] * v[0] + _arr[1][1] * v[1] + _arr[1][2] * v[2] + _arr[1][3] * v[3],
+      _arr[2][0] * v[0] + _arr[2][1] * v[1] + _arr[2][2] * v[2] + _arr[2][3] * v[3],
+      _arr[3][0] * v[0] + _arr[3][1] * v[1] + _arr[3][2] * v[2] + _arr[3][3] * v[3]
     );
 }
 
-Vector3 Matrix44::transformPoint(const Vector3& rhs) const
+Vector3 Matrix44::transformPoint(const Vector3& v) const
 {
-    Vector4 rhs4(rhs[0], rhs[1], rhs[2], 1.0f);
-    rhs4 = multiply(rhs4);
-    return Vector3(rhs4[0], rhs4[1], rhs4[2]);
+    Vector4 v4(v[0], v[1], v[2], 1.0f);
+    v4 = multiply(v4);
+    return Vector3(v4[0], v4[1], v4[2]);
 }
 
-Vector3 Matrix44::transformVector(const Vector3& rhs) const
+Vector3 Matrix44::transformVector(const Vector3& v) const
 {
-    Vector4 rhs4(rhs[0], rhs[1], rhs[2], 0.0f);
-    rhs4 = multiply(rhs4);
-    return Vector3(rhs4[0], rhs4[1], rhs4[2]);
+    Vector4 v4(v[0], v[1], v[2], 0.0f);
+    v4 = multiply(v4);
+    return Vector3(v4[0], v4[1], v4[2]);
 }
 
-Vector3 Matrix44::transformNormal(const Vector3& rhs) const
+Vector3 Matrix44::transformNormal(const Vector3& v) const
 {
-    Vector4 rhs4(rhs[0], rhs[1], rhs[2], 0.0f);
-    rhs4 = getInverse().getTranspose().multiply(rhs4);
-    return Vector3(rhs4[0], rhs4[1], rhs4[2]);
+    return getInverse().getTranspose().transformVector(v);
 }
 
 Matrix44 Matrix44::createTranslation(const Vector3& v)
 {
-    return Matrix44(1.0f, 0.0f, 0.0f, 0.0f,
-                    0.0f, 1.0f, 0.0f, 0.0f,
-                    0.0f, 0.0f, 1.0f, 0.0f,
-                    v[0], v[1], v[2], 1.0f);
+    return Matrix44(1.0f, 0.0f, 0.0f, v[0],
+                    0.0f, 1.0f, 0.0f, v[1],
+                    0.0f, 0.0f, 1.0f, v[2],
+                    0.0f, 0.0f, 0.0f, 1.0f);
 }
 
 Matrix44 Matrix44::createScale(const Vector3& v)

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -557,7 +557,9 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
 };
 
 /// @class Matrix33
-/// A 3x3 matrix of floating-point values
+/// A 3x3 matrix of floating-point values.
+///
+/// All vector transformations assume column vectors.
 class Matrix33 : public MatrixN<Matrix33, float, 3>
 {
   public:
@@ -573,17 +575,21 @@ class Matrix33 : public MatrixN<Matrix33, float, 3>
                 m20, m21, m22};
     }
 
-    /// @name Point/Vector/Normal Transformations
-    /// @{
-
-    Vector3 multiply(const Vector3& rhs) const;
-    Vector2 transformPoint(const Vector2& rhs) const;
-    Vector2 transformVector(const Vector2& rhs) const;
-    Vector3 transformNormal(const Vector3& rhs) const;
-
     /// @}
-    /// @name 2D Transformations
+    /// @name Vector Transformations
     /// @{
+
+    /// Return the product of this matrix and a 3D vector.
+    Vector3 multiply(const Vector3& v) const;
+
+    /// Transform the given 2D point.
+    Vector2 transformPoint(const Vector2& v) const;
+
+    /// Transform the given 2D direction vector.
+    Vector2 transformVector(const Vector2& v) const;
+
+    /// Transform the given 3D normal vector.
+    Vector3 transformNormal(const Vector3& v) const;
 
     /// Create a translation matrix.
     static Matrix33 createTranslation(const Vector2& v);
@@ -591,8 +597,8 @@ class Matrix33 : public MatrixN<Matrix33, float, 3>
     /// Create a scale matrix.
     static Matrix33 createScale(const Vector2& v);
 
-    // Create a rotation matrix.
-    // @param angle Angle in radians
+    /// Create a rotation matrix.
+    /// @param angle Angle in radians
     static Matrix33 createRotation(float angle);
 
     /// @}
@@ -602,7 +608,9 @@ class Matrix33 : public MatrixN<Matrix33, float, 3>
 };
 
 /// @class Matrix44
-/// A 4x4 matrix of floating-point values
+/// A 4x4 matrix of floating-point values.
+///
+/// All vector transformations assume column vectors.
 class Matrix44 : public MatrixN<Matrix44, float, 4>
 {
   public:
@@ -620,17 +628,21 @@ class Matrix44 : public MatrixN<Matrix44, float, 4>
                 m30, m31, m32, m33};
     }
 
-    /// @name Point/Vector/Normal Transformations
-    /// @{
-
-    Vector4 multiply(const Vector4& rhs) const;
-    Vector3 transformPoint(const Vector3& rhs) const;
-    Vector3 transformVector(const Vector3& rhs) const;
-    Vector3 transformNormal(const Vector3& rhs) const;
-
     /// @}
-    /// @name 3D Transformations
+    /// @name Vector Transformations
     /// @{
+
+    /// Return the product of this matrix and a 4D vector.
+    Vector4 multiply(const Vector4& v) const;
+
+    /// Transform the given 3D point.
+    Vector3 transformPoint(const Vector3& v) const;
+
+    /// Transform the given 3D direction vector.
+    Vector3 transformVector(const Vector3& v) const;
+
+    /// Transform the given 3D normal vector.
+    Vector3 transformNormal(const Vector3& v) const;
 
     /// Create a translation matrix.
     static Matrix44 createTranslation(const Vector3& v);

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -206,7 +206,7 @@ void GlslRenderer::updateViewInformation(const Vector3& eye,
     view = ViewHandler::createViewMatrix(eye, center, up);
     proj = ViewHandler::createPerspectiveMatrix(-fW, fW, -fH, fH, nearDist, farDist);
     world = Matrix44::createScale(Vector3(objectScale * meshFit));
-    world *= Matrix44::createTranslation(modelTranslation).getTranspose();
+    world *= Matrix44::createTranslation(modelTranslation);
 
     Matrix44 invView = view.getInverse();
     _viewHandler->viewDirection = { invView[0][2], invView[1][2], invView[2][2] };

--- a/source/MaterialXTest/Types.cpp
+++ b/source/MaterialXTest/Types.cpp
@@ -49,26 +49,26 @@ TEST_CASE("Matrices", "[types]")
     // Translation and scale
     mx::Matrix44 trans = mx::Matrix44::createTranslation(mx::Vector3(1, 2, 3));
     mx::Matrix44 scale = mx::Matrix44::createScale(mx::Vector3(2));
-    REQUIRE(trans == mx::Matrix44(1, 0, 0, 0,
-                                  0, 1, 0, 0,
-                                  0, 0, 1, 0,
-                                  1, 2, 3, 1));
+    REQUIRE(trans == mx::Matrix44(1, 0, 0, 1,
+                                  0, 1, 0, 2,
+                                  0, 0, 1, 3,
+                                  0, 0, 0, 1));
     REQUIRE(scale == mx::Matrix44(2, 0, 0, 0,
                                   0, 2, 0, 0,
                                   0, 0, 2, 0,
                                   0, 0, 0, 1));
 
     // Indexing operators
-    REQUIRE(trans[3][2] == 3);
-    trans[3][2] = 4;
-    REQUIRE(trans[3][2] == 4);
-    trans[3][2] = 3;
+    REQUIRE(trans[2][3] == 3);
+    trans[2][3] = 4;
+    REQUIRE(trans[2][3] == 4);
+    trans[2][3] = 3;
 
     // Matrix methods
-    REQUIRE(trans.getTranspose() == mx::Matrix44(1, 0, 0, 1,
-                                                 0, 1, 0, 2,
-                                                 0, 0, 1, 3,
-                                                 0, 0, 0, 1));
+    REQUIRE(trans.getTranspose() == mx::Matrix44(1, 0, 0, 0,
+                                                 0, 1, 0, 0,
+                                                 0, 0, 1, 0,
+                                                 1, 2, 3, 1));
     REQUIRE(scale.getTranspose() == scale);
     REQUIRE(trans.getDeterminant() == 1);
     REQUIRE(scale.getDeterminant() == 8);
@@ -81,18 +81,18 @@ TEST_CASE("Matrices", "[types]")
     mx::Matrix44 prod3 = trans * 2;
     mx::Matrix44 prod4 = trans;
     prod4 *= scale;
-    REQUIRE(prod1 == mx::Matrix44(2, 0, 0, 0,
-                                  0, 2, 0, 0,
-                                  0, 0, 2, 0,
-                                  2, 4, 6, 1));
-    REQUIRE(prod2 == mx::Matrix44(2, 0, 0, 0,
-                                  0, 2, 0, 0,
-                                  0, 0, 2, 0,
-                                  1, 2, 3, 1));
-    REQUIRE(prod3 == mx::Matrix44(2, 0, 0, 0,
-                                  0, 2, 0, 0,
-                                  0, 0, 2, 0,
-                                  2, 4, 6, 2));
+    REQUIRE(prod1 == mx::Matrix44(2, 0, 0, 1,
+                                  0, 2, 0, 2,
+                                  0, 0, 2, 3,
+                                  0, 0, 0, 1));
+    REQUIRE(prod2 == mx::Matrix44(2, 0, 0, 2,
+                                  0, 2, 0, 4,
+                                  0, 0, 2, 6,
+                                  0, 0, 0, 1));
+    REQUIRE(prod3 == mx::Matrix44(2, 0, 0, 2,
+                                  0, 2, 0, 4,
+                                  0, 0, 2, 6,
+                                  0, 0, 0, 2));
     REQUIRE(prod4 == prod1);
 
     // Matrix division

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1605,7 +1605,7 @@ void Viewer::updateViewHandlers()
     mx::Matrix44 arcball = mx::Matrix44(ngArcball.data(), ngArcball.data() + ngArcball.size()).getTranspose();
 
     _cameraViewHandler->worldMatrix = mx::Matrix44::createScale(mx::Vector3(_modelZoom * _userZoom));
-    _cameraViewHandler->worldMatrix *= mx::Matrix44::createTranslation(_modelTranslation + _userTranslation).getTranspose();
+    _cameraViewHandler->worldMatrix *= mx::Matrix44::createTranslation(_modelTranslation + _userTranslation);
     _cameraViewHandler->viewMatrix = mx::ViewHandler::createViewMatrix(_eye, _center, _up) * arcball;
     _cameraViewHandler->projectionMatrix = mx::ViewHandler::createPerspectiveMatrix(-fW, fW, -fH, fH, _nearDist, _farDist);
 
@@ -1614,7 +1614,7 @@ void Viewer::updateViewHandlers()
     {
         const float r = MODEL_SPHERE_RADIUS;
         _shadowViewHandler->worldMatrix = mx::Matrix44::createScale(mx::Vector3(_modelZoom));
-        _shadowViewHandler->worldMatrix *= mx::Matrix44::createTranslation(_modelTranslation).getTranspose();
+        _shadowViewHandler->worldMatrix *= mx::Matrix44::createTranslation(_modelTranslation);
         _shadowViewHandler->projectionMatrix = mx::ViewHandler::createOrthographicMatrix(-r, r, -r, r, 0.0f, r * 2.0f);
         mx::ValuePtr dir = dirLight->getInputValue("direction");
         if (dir->isA<mx::Vector3>())


### PR DESCRIPTION
This changelist updates Matrix33::createTranslation and Matrix44::createTranslation to assume column vectors, matching the prevailing convention in the MaterialX library.

Additional documentation and clarifications to Matrix33 and Matrix44 have been added where needed.