### PR TITLE
Harmonize vector conventions for matrix methods

### DIFF
--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -65,32 +65,31 @@ template <> Matrix33 MatrixN<Matrix33, float, 3>::getAdjugate() const
         _arr[0][0]*_arr[1][1] - _arr[1][0]*_arr[0][1]);
 }
 
-Vector3 Matrix33::multiply(const Vector3& rhs) const
+Vector3 Matrix33::multiply(const Vector3& v) const
 {
     return Vector3(
-      _arr[0][0] * rhs[0] + _arr[0][1] * rhs[1] + _arr[0][2] * rhs[2],
-      _arr[1][0] * rhs[0] + _arr[1][1] * rhs[1] + _arr[1][2] * rhs[2],
-      _arr[2][0] * rhs[0] + _arr[2][1] * rhs[1] + _arr[2][2] * rhs[2]
-    );
+      v[0] * _arr[0][0] + v[1] * _arr[1][0] + v[2] * _arr[2][0],
+      v[0] * _arr[0][1] + v[1] * _arr[1][1] + v[2] * _arr[2][1],
+      v[0] * _arr[0][2] + v[1] * _arr[1][2] + v[2] * _arr[2][2]);
 }
 
-Vector2 Matrix33::transformPoint(const Vector2& rhs) const
+Vector2 Matrix33::transformPoint(const Vector2& v) const
 {
-    Vector3 rhs3(rhs[0], rhs[1], 1.0f);
-    rhs3 = multiply(rhs3);
-    return Vector2(rhs3[0], rhs3[1]);
+    Vector3 v3(v[0], v[1], 1.0f);
+    v3 = multiply(v3);
+    return Vector2(v3[0], v3[1]);
 }
 
-Vector2 Matrix33::transformVector(const Vector2& rhs) const
+Vector2 Matrix33::transformVector(const Vector2& v) const
 {
-    Vector3 rhs3(rhs[0], rhs[1], 0.0f);
-    rhs3 = multiply(rhs3);
-    return Vector2(rhs3[0], rhs3[1]);
+    Vector3 v3(v[0], v[1], 0.0f);
+    v3 = multiply(v3);
+    return Vector2(v3[0], v3[1]);
 }
 
-Vector3 Matrix33::transformNormal(const Vector3& rhs) const
+Vector3 Matrix33::transformNormal(const Vector3& v) const
 {
-    return getInverse().getTranspose().multiply(rhs);
+    return getInverse().getTranspose().multiply(v);
 }
 
 Matrix33 Matrix33::createTranslation(const Vector2& v)
@@ -112,8 +111,8 @@ Matrix33 Matrix33::createRotation(float angle)
     float sine = std::sin(angle);
     float cosine = std::cos(angle);
 
-    return Matrix33(cosine, -sine, 0.0f,
-                    sine, cosine, 0.0f,
+    return Matrix33(cosine, sine, 0.0f,
+                    -sine, cosine, 0.0f,
                     0.0f, 0.0f, 1.0f);
 }
 
@@ -193,36 +192,32 @@ template <> Matrix44 MatrixN<Matrix44, float, 4>::getAdjugate() const
         _arr[0][0]*_arr[2][1]*_arr[1][2] - _arr[1][0]*_arr[0][1]*_arr[2][2] - _arr[2][0]*_arr[1][1]*_arr[0][2]);
 }
 
-
-Vector4 Matrix44::multiply(const Vector4& rhs) const
+Vector4 Matrix44::multiply(const Vector4& v) const
 {
     return Vector4(
-      _arr[0][0] * rhs[0] + _arr[0][1] * rhs[1] + _arr[0][2] * rhs[2] + _arr[0][3] * rhs[3],
-      _arr[1][0] * rhs[0] + _arr[1][1] * rhs[1] + _arr[1][2] * rhs[2] + _arr[1][3] * rhs[3],
-      _arr[2][0] * rhs[0] + _arr[2][1] * rhs[1] + _arr[2][2] * rhs[2] + _arr[2][3] * rhs[3],
-      _arr[3][0] * rhs[0] + _arr[3][1] * rhs[1] + _arr[3][2] * rhs[2] + _arr[3][3] * rhs[3]
-    );
+      v[0] * _arr[0][0] + v[1] * _arr[1][0] + v[2] * _arr[2][0] + v[3] * _arr[3][0],
+      v[0] * _arr[0][1] + v[1] * _arr[1][1] + v[2] * _arr[2][1] + v[3] * _arr[3][1],
+      v[0] * _arr[0][2] + v[1] * _arr[1][2] + v[2] * _arr[2][2] + v[3] * _arr[3][2],
+      v[0] * _arr[0][3] + v[1] * _arr[1][3] + v[2] * _arr[2][3] + v[3] * _arr[3][3]);
 }
 
-Vector3 Matrix44::transformPoint(const Vector3& rhs) const
+Vector3 Matrix44::transformPoint(const Vector3& v) const
 {
-    Vector4 rhs4(rhs[0], rhs[1], rhs[2], 1.0f);
-    rhs4 = multiply(rhs4);
-    return Vector3(rhs4[0], rhs4[1], rhs4[2]);
+    Vector4 v4(v[0], v[1], v[2], 1.0f);
+    v4 = multiply(v4);
+    return Vector3(v4[0], v4[1], v4[2]);
 }
 
-Vector3 Matrix44::transformVector(const Vector3& rhs) const
+Vector3 Matrix44::transformVector(const Vector3& v) const
 {
-    Vector4 rhs4(rhs[0], rhs[1], rhs[2], 0.0f);
-    rhs4 = multiply(rhs4);
-    return Vector3(rhs4[0], rhs4[1], rhs4[2]);
+    Vector4 v4(v[0], v[1], v[2], 0.0f);
+    v4 = multiply(v4);
+    return Vector3(v4[0], v4[1], v4[2]);
 }
 
-Vector3 Matrix44::transformNormal(const Vector3& rhs) const
+Vector3 Matrix44::transformNormal(const Vector3& v) const
 {
-    Vector4 rhs4(rhs[0], rhs[1], rhs[2], 0.0f);
-    rhs4 = getInverse().getTranspose().multiply(rhs4);
-    return Vector3(rhs4[0], rhs4[1], rhs4[2]);
+    return getInverse().getTranspose().transformVector(v);
 }
 
 Matrix44 Matrix44::createTranslation(const Vector3& v)
@@ -247,8 +242,8 @@ Matrix44 Matrix44::createRotationX(float angle)
     float cosine = std::cos(angle);
 
     return Matrix44(1.0f, 0.0f, 0.0f, 0.0f,
-                    0.0f, cosine, -sine, 0.0f,
-                    0.0f, sine, cosine, 0.0f,
+                    0.0f, cosine, sine, 0.0f,
+                    0.0f, -sine, cosine, 0.0f,
                     0.0f, 0.0f, 0.0f, 1.0f);
 }
 
@@ -257,9 +252,9 @@ Matrix44 Matrix44::createRotationY(float angle)
     float sine = std::sin(angle);
     float cosine = std::cos(angle);
 
-    return Matrix44(cosine, 0.0f, sine, 0.0f,
+    return Matrix44(cosine, 0.0f, -sine, 0.0f,
                     0.0f, 1.0f, 0.0f, 0.0f,
-                    -sine, 0.0f, cosine, 0.0f,
+                    sine, 0.0f, cosine, 0.0f,
                     0.0f, 0.0f, 0.0f, 1.0f);
 }
 
@@ -268,8 +263,8 @@ Matrix44 Matrix44::createRotationZ(float angle)
     float sine = std::sin(angle);
     float cosine = std::cos(angle);
 
-    return Matrix44(cosine, -sine, 0.0f, 0.0f,
-                    sine, cosine, 0.0f, 0.0f,
+    return Matrix44(cosine, sine, 0.0f, 0.0f,
+                    -sine, cosine, 0.0f, 0.0f,
                     0.0f, 0.0f, 1.0f, 0.0f,
                     0.0f, 0.0f, 0.0f, 1.0f);
 }

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -557,7 +557,10 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
 };
 
 /// @class Matrix33
-/// A 3x3 matrix of floating-point values
+/// A 3x3 matrix of floating-point values.
+///
+/// Vector transformation methods follow the row-vector convention,
+/// with matrix-vector multiplication computed as v' = vM.
 class Matrix33 : public MatrixN<Matrix33, float, 3>
 {
   public:
@@ -573,17 +576,20 @@ class Matrix33 : public MatrixN<Matrix33, float, 3>
                 m20, m21, m22};
     }
 
-    /// @name Point/Vector/Normal Transformations
+    /// @name Vector Transformations
     /// @{
 
-    Vector3 multiply(const Vector3& rhs) const;
-    Vector2 transformPoint(const Vector2& rhs) const;
-    Vector2 transformVector(const Vector2& rhs) const;
-    Vector3 transformNormal(const Vector3& rhs) const;
+    /// Return the product of this matrix and a 3D vector.
+    Vector3 multiply(const Vector3& v) const;
 
-    /// @}
-    /// @name 2D Transformations
-    /// @{
+    /// Transform the given 2D point.
+    Vector2 transformPoint(const Vector2& v) const;
+
+    /// Transform the given 2D direction vector.
+    Vector2 transformVector(const Vector2& v) const;
+
+    /// Transform the given 3D normal vector.
+    Vector3 transformNormal(const Vector3& v) const;
 
     /// Create a translation matrix.
     static Matrix33 createTranslation(const Vector2& v);
@@ -591,8 +597,8 @@ class Matrix33 : public MatrixN<Matrix33, float, 3>
     /// Create a scale matrix.
     static Matrix33 createScale(const Vector2& v);
 
-    // Create a rotation matrix.
-    // @param angle Angle in radians
+    /// Create a rotation matrix.
+    /// @param angle Angle in radians
     static Matrix33 createRotation(float angle);
 
     /// @}
@@ -602,7 +608,10 @@ class Matrix33 : public MatrixN<Matrix33, float, 3>
 };
 
 /// @class Matrix44
-/// A 4x4 matrix of floating-point values
+/// A 4x4 matrix of floating-point values.
+///
+/// Vector transformation methods follow the row-vector convention,
+/// with matrix-vector multiplication computed as v' = vM.
 class Matrix44 : public MatrixN<Matrix44, float, 4>
 {
   public:
@@ -620,17 +629,20 @@ class Matrix44 : public MatrixN<Matrix44, float, 4>
                 m30, m31, m32, m33};
     }
 
-    /// @name Point/Vector/Normal Transformations
+    /// @name Vector Transformations
     /// @{
 
-    Vector4 multiply(const Vector4& rhs) const;
-    Vector3 transformPoint(const Vector3& rhs) const;
-    Vector3 transformVector(const Vector3& rhs) const;
-    Vector3 transformNormal(const Vector3& rhs) const;
+    /// Return the product of this matrix and a 4D vector.
+    Vector4 multiply(const Vector4& v) const;
 
-    /// @}
-    /// @name 3D Transformations
-    /// @{
+    /// Transform the given 3D point.
+    Vector3 transformPoint(const Vector3& v) const;
+
+    /// Transform the given 3D direction vector.
+    Vector3 transformVector(const Vector3& v) const;
+
+    /// Transform the given 3D normal vector.
+    Vector3 transformNormal(const Vector3& v) const;
 
     /// Create a translation matrix.
     static Matrix44 createTranslation(const Vector3& v);

--- a/source/MaterialXRender/Harmonics.cpp
+++ b/source/MaterialXRender/Harmonics.cpp
@@ -167,8 +167,9 @@ void computeDominantLight(ConstImagePtr env, Vector3& lightDir, Color3& lightCol
     lightColor = Color3((float) color[0], (float) color[1], (float) color[2]);
 
     // Transform to match library conventions for latitude-longitude maps.
-    lightDir = Matrix44::createRotationY((float) PI / 2.0f).transformVector(lightDir);
-    lightDir = Matrix44::createScale(Vector3(1, 1, -1)).transformVector(lightDir);
+    Matrix44 lightTransform = Matrix44::createRotationY((float) PI / 2.0f) *
+                              Matrix44::createScale(Vector3(1, 1, -1));
+    lightDir = lightTransform.transformVector(lightDir);
 }
 
 ImagePtr renderEnvironment(const Sh3ColorCoeffs& shEnv, unsigned int width, unsigned int height)

--- a/source/MaterialXRender/ViewHandler.cpp
+++ b/source/MaterialXRender/ViewHandler.cpp
@@ -17,10 +17,10 @@ Matrix44 ViewHandler::createViewMatrix(const Vector3& eye,
     Vector3 y = x.cross(z);
 
     return Matrix44(
-        x[0], x[1], x[2], -x.dot(eye),
-        y[0], y[1], y[2], -y.dot(eye),
-        -z[0], -z[1], -z[2], z.dot(eye),
-        0.0f, 0.0f, 0.0f, 1.0f);
+        x[0], y[0], -z[0], 0.0f,
+        x[1], y[1], -z[1], 0.0f,
+        x[2], y[2], -z[2], 0.0f,
+        -x.dot(eye), -y.dot(eye), z.dot(eye), 1.0f);
 }
 
 Matrix44 ViewHandler::createPerspectiveMatrix(float left, float right,
@@ -30,8 +30,8 @@ Matrix44 ViewHandler::createPerspectiveMatrix(float left, float right,
     return Matrix44(
         (2.0f * nearP) / (right - left), 0.0f, (right + left) / (right - left), 0.0f,
         0.0f, (2.0f * nearP) / (top - bottom), (top + bottom) / (top - bottom), 0.0f,
-        0.0f, 0.0f, -(farP + nearP) / (farP - nearP), -(2.0f * farP * nearP) / (farP - nearP),
-        0.0f, 0.0f, -1.0f, 0.0f);
+        0.0f, 0.0f, -(farP + nearP) / (farP - nearP), -1.0f,
+        0.0f, 0.0f, -(2.0f * farP * nearP) / (farP - nearP), 0.0f);
 }
 
 Matrix44 ViewHandler::createOrthographicMatrix(float left, float right,
@@ -39,10 +39,10 @@ Matrix44 ViewHandler::createOrthographicMatrix(float left, float right,
                                                float nearP, float farP)
 {
     return Matrix44(
-        2.0f / (right - left), 0.0f, 0.0f, -(right + left) / (right - left),
-        0.0f, 2.0f / (top - bottom), 0.0f, -(top + bottom) / (top - bottom),
-        0.0f, 0.0f, -2.0f / (farP - nearP), -(farP + nearP) / (farP - nearP),
-        0.0f, 0.0f, 0.0f, 1.0f);
+        2.0f / (right - left), 0.0f, 0.0f, 0.0f,
+        0.0f, 2.0f / (top - bottom), 0.0f, 0.0f,
+        0.0f, 0.0f, -2.0f / (farP - nearP), 0.0f,
+        -(right + left) / (right - left), -(top + bottom) / (top - bottom), -(farP + nearP) / (farP - nearP), 1.0f);
 }
 
 } // namespace MaterialX

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -450,25 +450,25 @@ void GlslProgram::bindStreams(MeshPtr mesh)
     // Bind any named attribute information
     const GlslProgram::InputMap& uniformList = getUniformsList();
     findInputs(HW::GEOMATTR + "_", uniformList, foundList, false);
-    for (const auto& Input : foundList)
+    for (const auto& input : foundList)
     {
         // Only handle float1-4 types for now
-        switch (Input.second->gltype)
+        switch (input.second->gltype)
         {
             case GL_INT:
-                glUniform1i(Input.second->location, 1);
+                glUniform1i(input.second->location, 1);
                 break;
             case GL_FLOAT:
-                glUniform1f(Input.second->location, 0.0f);
+                glUniform1f(input.second->location, 0.0f);
                 break;
             case GL_FLOAT_VEC2:
-                glUniform2f(Input.second->location, 0.0f, 0.0f);
+                glUniform2f(input.second->location, 0.0f, 0.0f);
                 break;
             case GL_FLOAT_VEC3:
-                glUniform3f(Input.second->location, 0.0f, 0.0f, 0.0f);
+                glUniform3f(input.second->location, 0.0f, 0.0f, 0.0f);
                 break;
             case GL_FLOAT_VEC4:
-                glUniform4f(Input.second->location, 0.0f, 0.0f, 0.0f, 1.0f);
+                glUniform4f(input.second->location, 0.0f, 0.0f, 0.0f, 1.0f);
                 break;
             default:
                 break;
@@ -851,196 +851,169 @@ void GlslProgram::bindViewInformation(ViewHandlerPtr viewHandler)
 
     GLint location = GlslProgram::UNDEFINED_OPENGL_PROGRAM_LOCATION;
 
-    //
-    // View direction and position
-    //
+    // View position and direction
     const GlslProgram::InputMap& uniformList = getUniformsList();
-    auto Input = uniformList.find(HW::VIEW_POSITION);
-    if (Input != uniformList.end())
+    auto input = uniformList.find(HW::VIEW_POSITION);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniform3fv(location, 1, viewHandler->viewPosition.data());
         }
     }
-    Input = uniformList.find(HW::VIEW_DIRECTION);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::VIEW_DIRECTION);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniform3fv(location, 1, viewHandler->viewDirection.data());
         }
     }
 
-    //
     // World matrix variants
-    //
     Matrix44& world = viewHandler->worldMatrix;
     Matrix44 invWorld = world.getInverse();
     Matrix44 invTransWorld = invWorld.getTranspose();
-
-    // World matrix 
-    Input = uniformList.find(HW::WORLD_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::WORLD_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
-        if (location >= 0)
-        {
-            glUniformMatrix4fv(location, 1, false, world.getTranspose().data());
-        }
-    }
-    // World transpose matrix
-    Input = uniformList.find(HW::WORLD_TRANSPOSE_MATRIX);
-    if (Input != uniformList.end())
-    {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniformMatrix4fv(location, 1, false, world.data());
         }
     }
-    // World inverse matrix
-    Input = uniformList.find(HW::WORLD_INVERSE_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::WORLD_TRANSPOSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
-            glUniformMatrix4fv(location, 1, false, invWorld.getTranspose().data());
+            glUniformMatrix4fv(location, 1, false, world.getTranspose().data());
         }
     }
-    // World inverse transpose matrix
-    Input = uniformList.find(HW::WORLD_INVERSE_TRANSPOSE_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::WORLD_INVERSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
+        if (location >= 0)
+        {
+            glUniformMatrix4fv(location, 1, false, invWorld.data());
+        }
+    }
+    input = uniformList.find(HW::WORLD_INVERSE_TRANSPOSE_MATRIX);
+    if (input != uniformList.end())
+    {
+        location = input->second->location;
         if (location >= 0)
         {
             glUniformMatrix4fv(location, 1, false, invTransWorld.getTranspose().data());
         }
     }
 
-    //
     // Projection matrix variants
-    //
     Matrix44& proj = viewHandler->projectionMatrix;
-    // Projection matrix 
-    Input = uniformList.find(HW::PROJ_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::PROJ_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
-        if (location >= 0)
-        {
-            glUniformMatrix4fv(location, 1, false, proj.getTranspose().data());
-        }
-    }
-    // Projection tranpose matrix
-    Input = uniformList.find(HW::PROJ_TRANSPOSE_MATRIX);
-    if (Input != uniformList.end())
-    {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniformMatrix4fv(location, 1, false, proj.data());
         }
     }
-    // Projection inverse matrix
-    Matrix44 projInverse= proj.getInverse();
-    Input = uniformList.find(HW::PROJ_INVERSE_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::PROJ_TRANSPOSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
-            glUniformMatrix4fv(location, 1, false, projInverse.getTranspose().data());
+            glUniformMatrix4fv(location, 1, false, proj.getTranspose().data());
         }
     }
-    // Projection inverse transpose matrix
-    Input = uniformList.find(HW::PROJ_INVERSE_TRANSPOSE_MATRIX);
-    if (Input != uniformList.end())
+    Matrix44 projInverse= proj.getInverse();
+    input = uniformList.find(HW::PROJ_INVERSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniformMatrix4fv(location, 1, false, projInverse.data());
         }
     }
-
-
-    //
-    // View matrix variants
-    //
-    Matrix44& view = viewHandler->viewMatrix;
-
-    // View matrix
-    Input = uniformList.find(HW::VIEW_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::PROJ_INVERSE_TRANSPOSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
-            glUniformMatrix4fv(location, 1, false, view.getTranspose().data());
+            glUniformMatrix4fv(location, 1, false, projInverse.getTranspose().data());
         }
     }
-    // View tranpose
-    Input = uniformList.find(HW::VIEW_TRANSPOSE_MATRIX);
-    if (Input != uniformList.end())
+
+    // View matrix variants
+    Matrix44& view = viewHandler->viewMatrix;
+    input = uniformList.find(HW::VIEW_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniformMatrix4fv(location, 1, false, view.data());
         }
     }
-    // View inverse
-    Matrix44 viewInverse = view.getInverse();
-    Input = uniformList.find(HW::VIEW_INVERSE_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::VIEW_TRANSPOSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
-            glUniformMatrix4fv(location, 1, false, viewInverse.getTranspose().data());
+            glUniformMatrix4fv(location, 1, false, view.getTranspose().data());
         }
     }
-    // View inverse transpose
-    Input = uniformList.find(HW::VIEW_INVERSE_TRANSPOSE_MATRIX);
-    if (Input != uniformList.end())
+    Matrix44 viewInverse = view.getInverse();
+    input = uniformList.find(HW::VIEW_INVERSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniformMatrix4fv(location, 1, false, viewInverse.data());
         }
     }
-    
-    //
-    // View projection matrix
-    //
-    Matrix44 viewProj = proj * view;
-    Input = uniformList.find(HW::VIEW_PROJECTION_MATRIX);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::VIEW_INVERSE_TRANSPOSE_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
-            glUniformMatrix4fv(location, 1, false, viewProj.getTranspose().data());
+            glUniformMatrix4fv(location, 1, false, viewInverse.getTranspose().data());
+        }
+    }
+    
+    // View-projection matrix
+    Matrix44 viewProj = view * proj;
+    input = uniformList.find(HW::VIEW_PROJECTION_MATRIX);
+    if (input != uniformList.end())
+    {
+        location = input->second->location;
+        if (location >= 0)
+        {
+            glUniformMatrix4fv(location, 1, false, viewProj.data());
         }
     }
 
-    //
-    // World view projection world
-    //
-    Matrix44 viewProjWorld = world * viewProj;
-    Input = uniformList.find(HW::WORLD_VIEW_PROJECTION_MATRIX);
-    if (Input != uniformList.end())
+    // View-projection-world matrix
+    Matrix44 viewProjWorld = viewProj * world;
+    input = uniformList.find(HW::WORLD_VIEW_PROJECTION_MATRIX);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
-            glUniformMatrix4fv(location, 1, false, viewProjWorld.getTranspose().data());
+            glUniformMatrix4fv(location, 1, false, viewProjWorld.data());
         }
     } 
 
@@ -1062,10 +1035,10 @@ void GlslProgram::bindTimeAndFrame()
 
     // Bind time
     const GlslProgram::InputMap& uniformList = getUniformsList();
-    auto Input = uniformList.find(HW::TIME);
-    if (Input != uniformList.end())
+    auto input = uniformList.find(HW::TIME);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniform1f(location, 1.0f);
@@ -1073,10 +1046,10 @@ void GlslProgram::bindTimeAndFrame()
     }
 
     // Bind frame
-    Input = uniformList.find(HW::FRAME);
-    if (Input != uniformList.end())
+    input = uniformList.find(HW::FRAME);
+    if (input != uniformList.end())
     {
-        location = Input->second->location;
+        location = input->second->location;
         if (location >= 0)
         {
             glUniform1f(location, 1.0f);
@@ -1416,26 +1389,26 @@ void GlslProgram::findInputs(const std::string& variable,
     // Scan all attributes which match the attribute identifier completely or as a prefix
     //
     int ilocation = UNDEFINED_OPENGL_PROGRAM_LOCATION;
-    auto Input = variableList.find(variable);
-    if (Input != variableList.end())
+    auto input = variableList.find(variable);
+    if (input != variableList.end())
     {
-        ilocation = Input->second->location;
+        ilocation = input->second->location;
         if (ilocation >= 0)
         {
-            foundList[variable] = Input->second;
+            foundList[variable] = input->second;
         }
     }
     else if (!exactMatch)
     {
-        for (Input = variableList.begin(); Input != variableList.end(); Input++)
+        for (input = variableList.begin(); input != variableList.end(); ++input)
         {
-            const std::string& name = Input->first;
+            const std::string& name = input->first;
             if (name.compare(0, variable.size(), variable) == 0)
             {
-                ilocation = Input->second->location;
+                ilocation = input->second->location;
                 if (ilocation >= 0)
                 {
-                    foundList[Input->first] = Input->second;
+                    foundList[input->first] = input->second;
                 }
             }
         }

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -200,17 +200,14 @@ void GlslRenderer::updateViewInformation(const Vector3& eye,
     float meshFit = 2.0f / sphereRadius;
     Vector3 modelTranslation = sphereCenter * -1.0f;
 
-    Matrix44& world = _viewHandler->worldMatrix;
-    Matrix44& view = _viewHandler->viewMatrix;
-    Matrix44& proj = _viewHandler->projectionMatrix;
-    view = ViewHandler::createViewMatrix(eye, center, up);
-    proj = ViewHandler::createPerspectiveMatrix(-fW, fW, -fH, fH, nearDist, farDist);
-    world = Matrix44::createScale(Vector3(objectScale * meshFit));
-    world *= Matrix44::createTranslation(modelTranslation).getTranspose();
+    _viewHandler->viewMatrix = ViewHandler::createViewMatrix(eye, center, up);
+    _viewHandler->projectionMatrix = ViewHandler::createPerspectiveMatrix(-fW, fW, -fH, fH, nearDist, farDist);
+    _viewHandler->worldMatrix = Matrix44::createTranslation(modelTranslation) *
+                                Matrix44::createScale(Vector3(objectScale * meshFit));
 
-    Matrix44 invView = view.getInverse();
-    _viewHandler->viewDirection = { invView[0][2], invView[1][2], invView[2][2] };
-    _viewHandler->viewPosition = { invView[0][3], invView[1][3], invView[2][3] };
+    Matrix44 invView = _viewHandler->viewMatrix.getInverse();
+    _viewHandler->viewDirection = { invView[2][0], invView[2][1], invView[2][2] };
+    _viewHandler->viewPosition = { invView[3][0], invView[3][1], invView[3][2] };
 }
 
 void GlslRenderer::render()

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -281,15 +281,15 @@ void Material::bindViewInformation(const mx::Matrix44& world, const mx::Matrix44
         return;
     }
 
-    mx::Matrix44 viewProj = proj * view;
+    mx::Matrix44 viewProj = view * proj;
     mx::Matrix44 invView = view.getInverse();
     mx::Matrix44 invTransWorld = world.getInverse().getTranspose();
-    mx::Vector3 viewPosition(invView[0][3], invView[1][3], invView[2][3]);
+    mx::Vector3 viewPosition(invView[3][0], invView[3][1], invView[3][2]);
 
     // Bind view properties.
-    _glShader->setUniform(mx::HW::WORLD_MATRIX, ng::Matrix4f(world.getTranspose().data()), false);
-    _glShader->setUniform(mx::HW::VIEW_PROJECTION_MATRIX, ng::Matrix4f(viewProj.getTranspose().data()), false);
-    _glShader->setUniform(mx::HW::WORLD_INVERSE_TRANSPOSE_MATRIX, ng::Matrix4f(invTransWorld.getTranspose().data()), false);
+    _glShader->setUniform(mx::HW::WORLD_MATRIX, ng::Matrix4f(world.data()), false);
+    _glShader->setUniform(mx::HW::VIEW_PROJECTION_MATRIX, ng::Matrix4f(viewProj.data()), false);
+    _glShader->setUniform(mx::HW::WORLD_INVERSE_TRANSPOSE_MATRIX, ng::Matrix4f(invTransWorld.data()), false);
     _glShader->setUniform(mx::HW::VIEW_POSITION, ng::Vector3f(viewPosition.data()), false);
 }
 
@@ -567,7 +567,7 @@ void Material::bindLights(mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr 
                 _glShader->setUniform(mx::HW::SHADOW_MAP, textureLocation);
             }
         }
-        _glShader->setUniform(mx::HW::SHADOW_MATRIX, ng::Matrix4f(shadowState.shadowMatrix.getTranspose().data()), false);
+        _glShader->setUniform(mx::HW::SHADOW_MATRIX, ng::Matrix4f(shadowState.shadowMatrix.data()), false);
     }
 
     // Bind ambient occlusion properties.


### PR DESCRIPTION
This changelist aligns all matrix methods in MaterialX with the row-vector convention, in which matrix-vector multiplication is computed as v' = vM.

Previously, there was disagreement between the createTranslation methods (which followed row vector) and the createRotation/multiply methods (which followed column vector), requiring unnecessary calls to getTranspose in rendering code.

Documentation of the library vector convention has been added to Types.h, and related matrix code has been refactored for clarity.