### PR TITLE
Update light paths in test suite

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -81,7 +81,7 @@
       <parameter name="radianceIBLPath" type="string" value="resources/Lights/san_giuseppe_bridge.hdr" />
 
       <!-- Suggested irradiance IBL file path -->
-      <parameter name="irradianceIBLPath" type="string" value="resources/Lights/san_giuseppe_bridge_diffuse.hdr" />
+      <parameter name="irradianceIBLPath" type="string" value="resources/Lights/irradiance/san_giuseppe_bridge.hdr" />
 
       <!-- Transforms UVs of loaded geometry -->
       <parameter name="transformUVs" type="matrix44" value="1.0f, 0.0f, 0.0f, -0.235f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f" />

--- a/resources/Materials/TestSuite/stdlib/texture/image_codecs.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image_codecs.mtlx
@@ -58,7 +58,7 @@
   </image>
   <output name="image4_output_bridge3_hdr" type="color4" nodename="image4_bridge3" xpos="5.84828" ypos="-9.44" />
   <image name="image4_bridge3" type="color4" xpos="6.4069" ypos="18.82">
-    <parameter name="file" type="filename" value="resources/Lights/san_giuseppe_bridge_diffuse.hdr" />
+    <parameter name="file" type="filename" value="resources/Lights/irradiance/san_giuseppe_bridge.hdr" />
     <parameter name="uaddressmode" type="string" value="constant" />
     <parameter name="vaddressmode" type="string" value="clamp" />
     <parameter name="filtertype" type="string" value="linear" />


### PR DESCRIPTION
This changelist updates two light paths in the render test suite, matching the new location of environment irradiance maps.