### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Geom.cpp
+++ b/source/MaterialXCore/Geom.cpp
@@ -30,7 +30,7 @@ bool geomStringsMatch(const string& geom1, const string& geom2, bool contains)
     vector<GeomPath> paths1;
     for (const string& name1 : splitString(geom1, ARRAY_VALID_SEPARATORS))
     {
-        paths1.push_back(GeomPath(name1));
+        paths1.emplace_back(name1);
     }
     for (const string& name2 : splitString(geom2, ARRAY_VALID_SEPARATORS))
     {

--- a/source/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXCore/Traversal.cpp
@@ -50,7 +50,7 @@ TreeIterator& TreeIterator::operator++()
     if (!_prune && _elem && !_elem->getChildren().empty())
     {
         // Traverse to the first child of this element.
-        _stack.push_back(StackFrame(_elem, 0));
+        _stack.emplace_back(_elem, 0);
         _elem = _elem->getChildren()[0];
         return *this;
     }
@@ -112,7 +112,7 @@ GraphIterator& GraphIterator::operator++()
     if (!_prune && _upstreamElem && _upstreamElem->getUpstreamEdgeCount())
     {
         // Traverse to the first upstream edge of this element.
-        _stack.push_back(StackFrame(_upstreamElem, 0));
+        _stack.emplace_back(_upstreamElem, 0);
         Edge nextEdge = _upstreamElem->getUpstreamEdge(_material, 0);
         if (nextEdge && nextEdge.getUpstreamElement())
         {

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -152,7 +152,7 @@ FilePathVec FilePath::getFilesInDirectory(const string& extension) const
         {
             if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
             {
-                files.push_back(FilePath(fd.cFileName));
+                files.emplace_back(fd.cFileName);
             }
         } while (FindNextFile(hFind, &fd));
         FindClose(hFind);

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -260,7 +260,7 @@ public:
     /// Add an extra argument to be used for functions in this context.
     void addArgument(const TypeDesc* type, const string& name)
     {
-        _arguments.push_back(Argument(type,name));
+        _arguments.emplace_back(type, name);
     }
 
     /// Return a list of extra argument to be used for functions in this context.

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1440,7 +1440,7 @@ ShaderGraphEdgeIterator& ShaderGraphEdgeIterator::operator++()
     if (_upstream && _upstream->getNode()->numInputs())
     {
         // Traverse to the first upstream edge of this element.
-        _stack.push_back(StackFrame(_upstream, 0));
+        _stack.emplace_back(_upstream, 0);
 
         ShaderInput* input = _upstream->getNode()->getInput(0);
         ShaderOutput* output = input->getConnection();

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -772,7 +772,7 @@ vector<Vector2> getUdimCoordinates(const StringVec& udimIdentifiers)
         int uVal = udimVal % 10;
         uVal = (uVal == 0) ? 9 : uVal - 1;
         int vVal = (udimVal - uVal - 1) / 10;
-        udimCoordinates.push_back(Vector2(static_cast<float>(uVal), static_cast<float>(vVal)));
+        udimCoordinates.emplace_back(static_cast<float>(uVal), static_cast<float>(vVal));
     }
 
     return udimCoordinates;

--- a/source/MaterialXRenderHw/WindowWrapper.cpp
+++ b/source/MaterialXRenderHw/WindowWrapper.cpp
@@ -57,6 +57,11 @@ WindowWrapper::WindowWrapper(const WindowWrapper& other)
 
 const WindowWrapper& WindowWrapper::operator=(const WindowWrapper& other)
 {
+    if (this == &other)
+    {
+        return *this;
+    }
+
     release();
 
     _externalHandle = other._externalHandle;

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char* const argv[])
     std::vector<std::string> tokens;
     for (int i = 1; i < argc; i++)
     {
-        tokens.push_back(std::string(argv[i]));
+        tokens.emplace_back(argv[i]);
     }
 
     mx::FilePathVec libraryFolders = { "libraries/stdlib", "libraries/pbrlib", "libraries/stdlib/genglsl", "libraries/pbrlib/genglsl", 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -369,7 +369,7 @@ void Viewer::loadEnvironmentLight()
 
     // Look for an irradiance map using an expected filename convention.
     mx::ImagePtr envIrradianceMap;
-    if (!envIrradianceMap && !_normalizeEnvironment && !_splitDirectLight)
+    if (!_normalizeEnvironment && !_splitDirectLight)
     {
         mx::FilePath envIrradiancePath = _envRadiancePath.getParentPath() / IRRADIANCE_MAP_FOLDER / _envRadiancePath.getBaseName();
         envIrradianceMap = _imageHandler->acquireImage(_searchPath.find(envIrradiancePath), true, nullptr, &message);


### PR DESCRIPTION
Fixes for static analysis warnings reported by PVS:

- Add self-assignment check to WindowWrapper assignment operator.
- Remove extra null check in Viewer::loadEnvironmentLight.
- Replace push_back with emplace_back for simplicity.