### PR TITLE
Add backwards compatibility for OIIO 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [1.37.1] - Development
 
+### Added
+- Added backwards compatibility for OpenImageIO 1.x.
+
 ## [1.37.0] - 2020-03-20
 
 Updated the MaterialX library to the v1.37 specification.  See the [v1.37 changelist](http://www.materialx.org/assets/MaterialX.v1.37REV2.Changelist.pdf) for full details.

--- a/documents/DeveloperGuide/MainPage.md
+++ b/documents/DeveloperGuide/MainPage.md
@@ -24,7 +24,6 @@ The MaterialX C++ libraries are automatically included when building MaterialX t
 
 Additional options for the generation of MaterialX C++ include the following:
 
-- `MATERIALX_TEST_RENDER`: Requests that rendering functionality be included in the MaterialXTest unit-test suite.  When this option is enabled, GPU support will be required when MaterialXTest is run.
 - `MATERIALX_BUILD_OIIO`: Requests that MaterialXRender be built with OpenImageIO instead of stb_image, extending the set of supported image formats.
 - `MATERIALX_OIIO_DIR`: Path to the root folder of an OpenImageIO installation.  If the MATERIALX_BUILD_OIIO option has been enabled, then this path is required.
 


### PR DESCRIPTION
This changelist adds backwards compatibility for OpenImageIO 1.x, using the pattern described in the OpenImageIO 2 porting guide.

Also, remove a documentation line describing the MATERIALX_TEST_RENDER flag, which is now enabled by default in builds.