### PR TITLE
Standard library path improvements

### DIFF
--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -74,6 +74,7 @@ By default, the MaterialX viewer loads and saves image files using `stb_image`, 
 The following are common command-line options for MaterialXView, and a complete list can be displayed with the `--help` option.
 - `--material [FILENAME]`: Specify the displayed material
 - `--mesh [FILENAME]`: Specify the displayed geometry
-- `--library [FILEPATH]`: Specify an additional library folder
-- `--path [FILEPATH]`: Specify an additional search-path folder
+- `--envRad [FILENAME]`: Specify the displayed environment light, stored as HDR environment radiance in the latitude-longitude format
+- `--path [FILEPATH]`: Specify an additional absolute search path location
+- `--library [FILEPATH]`: Specify an additional relative path to a custom data library folder
 - `--help`: Display the complete list of command-line options

--- a/python/MaterialXTest/genshader.py
+++ b/python/MaterialXTest/genshader.py
@@ -39,8 +39,8 @@ class TestGenShader(unittest.TestCase):
     def test_ShaderInterface(self):
         doc = mx.createDocument()
 
-        searchPath = os.path.join(_fileDir, "../../libraries")
-        libraryPath = os.path.join(searchPath, "stdlib")
+        searchPath = os.path.join(_fileDir, "../..")
+        libraryPath = os.path.join(searchPath, "libraries/stdlib")
         _loadLibraries(doc, searchPath, libraryPath)
 
         exampleName = u"shader_interface"
@@ -76,7 +76,7 @@ class TestGenShader(unittest.TestCase):
         # Add path to find all source code snippets
         context.registerSourceCodeSearchPath(searchPath)
         # Add path to find OSL include files
-        context.registerSourceCodeSearchPath(os.path.join(searchPath, "stdlib/osl"))
+        context.registerSourceCodeSearchPath(os.path.join(libraryPath, "osl"))
 
         # Test complete mode
         context.getOptions().shaderInterfaceType = int(ShaderInterfaceType.SHADER_INTERFACE_COMPLETE);

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -158,6 +158,9 @@ class FilePath
     /// Return the current working directory of the file system.
     static FilePath getCurrentPath();
 
+    /// Return the directory containing the executable module.
+    static FilePath getModulePath();
+
   private:
     StringVec _vec;
     Type _type;

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -47,9 +47,9 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
     }
     context.getShaderGenerator().getSyntax().makeValidName(_functionName);
 
-    if (!readFile(context.resolveSourceFile(file), _functionSource))
+    if (!readFile(context.resolveSourceFile(FilePath("libraries") / file), _functionSource))
     {
-        throw ExceptionShaderGenError("Can't find source file '" + file.asString() +
+        throw ExceptionShaderGenError("Could not find source file '" + file.asString() +
                                       "' used by implementation '" + impl.getName() + "'");
     }
 

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -318,10 +318,9 @@ void ShaderStage::addBlock(const string& str, GenContext& context)
 
 void ShaderStage::addInclude(const string& file, GenContext& context)
 {
-    string resolvedFile = file;
-    tokenSubstitution(context.getShaderGenerator().getTokenSubstitutions(), resolvedFile);
-
-    resolvedFile = context.resolveSourceFile(resolvedFile);
+    string modifiedFile = file;
+    tokenSubstitution(context.getShaderGenerator().getTokenSubstitutions(), modifiedFile);
+    FilePath resolvedFile = context.resolveSourceFile(FilePath("libraries") / modifiedFile);
 
     if (!_includes.count(resolvedFile))
     {

--- a/source/MaterialXGenShader/UnitConverter.cpp
+++ b/source/MaterialXGenShader/UnitConverter.cpp
@@ -10,14 +10,26 @@
 namespace MaterialX
 {
 
+namespace {
+
+const string SCALE_ATTRIBUTE = "scale";
+
+} // anonymous namespace
+
+//
+// LinearUnitConverter methods
+//
+
 LinearUnitConverter::LinearUnitConverter(UnitTypeDefPtr unitTypeDef)
 {
-    static const string SCALE_ATTRIBUTE = "scale";
-    unsigned int enumerant = 0;
+    if (!unitTypeDef)
+    {
+        return;
+    }
 
     // Populate the unit scale and offset maps for each UnitDef.
-    vector<UnitDefPtr> unitDefs = unitTypeDef->getUnitDefs();
-    for (UnitDefPtr unitdef : unitDefs)
+    unsigned int enumerant = 0;
+    for (UnitDefPtr unitdef : unitTypeDef->getUnitDefs())
     {
         for (UnitPtr unit : unitdef->getUnits())
         {
@@ -131,6 +143,10 @@ string LinearUnitConverter::getUnitFromInteger(int index) const
     return EMPTY_STRING;
 }
 
+//
+// UnitConverterRegistry methods
+//
+
 UnitConverterRegistryPtr UnitConverterRegistry::create()
 {
     static UnitConverterRegistryPtr registry(new UnitConverterRegistry());
@@ -139,36 +155,41 @@ UnitConverterRegistryPtr UnitConverterRegistry::create()
 
 bool UnitConverterRegistry::addUnitConverter(UnitTypeDefPtr def, UnitConverterPtr converter)
 {
-    const string& name = def->getName();
-    if (_unitConverters.find(name) != _unitConverters.end())
+    if (def && _unitConverters.find(def->getName()) == _unitConverters.end())
     {
-        return false;
+        _unitConverters[def->getName()] = converter;
+        return true;
     }
-    _unitConverters[name] = converter;
-    return true;
+
+    return false;
 }
 
 bool UnitConverterRegistry::removeUnitConverter(UnitTypeDefPtr def)
 {
-    const string& name = def->getName();
-    auto it = _unitConverters.find(name);
-    if (it == _unitConverters.end())
+    if (def)
     {
-        return false;
+        auto it = _unitConverters.find(def->getName());
+        if (it != _unitConverters.end())
+        {
+            _unitConverters.erase(it);
+            return true;
+        }
     }
 
-    _unitConverters.erase(it);
-    return true;
+    return false;
 }
 
 UnitConverterPtr UnitConverterRegistry::getUnitConverter(UnitTypeDefPtr def)
 {
-    const string& name = def->getName();
-    auto it = _unitConverters.find(name);
-    if (it != _unitConverters.end())
+    if (def)
     {
-        return it->second;
+        auto it = _unitConverters.find(def->getName());
+        if (it != _unitConverters.end())
+        {
+            return it->second;
+        }
     }
+
     return nullptr;
 }
 

--- a/source/MaterialXTest/File.cpp
+++ b/source/MaterialXTest/File.cpp
@@ -44,6 +44,12 @@ TEST_CASE("File system operations", "[file]")
         REQUIRE(path.exists());
         REQUIRE(mx::FileSearchPath().find(path).exists());
     }
+
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+    mx::FilePath modulePath = mx::FilePath::getModulePath();
+    bool expectedPaths = currentPath == modulePath ||
+                         currentPath == modulePath.getParentPath();
+    REQUIRE(expectedPaths);
 }
 
 TEST_CASE("File search path operations", "[file]")

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -8,10 +8,10 @@ const std::string options =
 " Options: \n"
 "    --material [FILENAME]    Specify the displayed material\n"
 "    --mesh [FILENAME]        Specify the displayed geometry\n"
-"    --library [FILEPATH]     Specify an additional library folder\n"
-"    --path [FILEPATH]        Specify an additional search-path folder\n"
-"    --envMethod [INTEGER]    Environment lighting method (0 = filtered importance sampling, 1 = prefiltered environment maps, Default is 0)\n"
-"    --envRad [FILENAME]      Specify the environment radiance HDR\n"
+"    --envRad [FILENAME]      Specify the displayed environment light, stored as HDR environment radiance in the latitude-longitude format\n"
+"    --envMethod [INTEGER]    Specify the environment lighting method (0 = filtered importance sampling, 1 = prefiltered environment maps, Default is 0)\n"
+"    --path [FILEPATH]        Specify an additional absolute search path location (e.g. '/projects/MaterialX').  This path will be queried when locating standard data libraries, XInclude references, and referenced images.\n"
+"    --library [FILEPATH]     Specify an additional relative path to a custom data library folder (e.g. 'libraries/custom').  MaterialX files at the root of this folder will be included in all content documents.\n"
 "    --msaa [INTEGER]         Multisampling count for anti-aliasing (0 = disabled, Default is 0)\n"
 "    --refresh [INTEGER]      Refresh period for the viewer in milliseconds (-1 = disabled, Default is 50)\n"
 "    --remap [TOKEN1:TOKEN2]  Remap one token to another when MaterialX document is loaded\n"
@@ -50,13 +50,9 @@ int main(int argc, char* const argv[])
         {
             meshFilename = nextToken;
         }
-        if (token == "--library" && !nextToken.empty())
+        if (token == "--envRad" && !nextToken.empty())
         {
-            libraryFolders.push_back(nextToken);
-        }
-        if (token == "--path" && !nextToken.empty())
-        {
-            searchPath.append(mx::FileSearchPath(nextToken));
+            envRadiancePath = nextToken;
         }
         if (token == "--envMethod" && !nextToken.empty())
         {
@@ -65,9 +61,13 @@ int main(int argc, char* const argv[])
                 specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_PREFILTER;
             }
         }
-        if (token == "--envRad" && !nextToken.empty())
+        if (token == "--path" && !nextToken.empty())
         {
-            envRadiancePath = nextToken;
+            searchPath.append(mx::FileSearchPath(nextToken));
+        }
+        if (token == "--library" && !nextToken.empty())
+        {
+            libraryFolders.push_back(nextToken);
         }
         if (token == "--msaa" && !nextToken.empty())
         {
@@ -100,31 +100,16 @@ int main(int argc, char* const argv[])
         }
     }
 
-    // Search current directory and parent directory if not found.
-    mx::FilePath currentPath(mx::FilePath::getCurrentPath());
-    mx::FilePath parentCurrentPath = currentPath.getParentPath();
-    std::vector<mx::FilePath> libraryPaths =
-    { 
-        mx::FilePath("libraries")
-    };
-    for (const auto& libraryPath : libraryPaths)
+    // Add the module path to the search path.
+    mx::FilePath modulePath = mx::FilePath::getModulePath();
+    if ((modulePath.getParentPath() / "libraries").exists())
     {
-        mx::FilePath fullPath(currentPath / libraryPath);
-        if (!fullPath.exists())
-        {
-            fullPath = parentCurrentPath / libraryPath;
-            if (fullPath.exists())
-            {
-                searchPath.append(fullPath);
-            }
-        }
-        else
-        {
-            searchPath.append(fullPath);
-        }
+        searchPath.append(modulePath.getParentPath());
     }
-    searchPath.append(parentCurrentPath);
-    searchPath.prepend(currentPath);
+    else
+    {
+        searchPath.append(modulePath);
+    }
 
     try
     {

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -105,11 +105,15 @@ bool Material::generateEnvironmentShader(mx::GenContext& context,
 
     // Create the shader.
     std::string shaderName = "__ENV_SHADER__";
-    _hwShader = createShader(shaderName, context, output); 
-    if (!_hwShader)
+    try
+    {
+        _hwShader = createShader(shaderName, context, output); 
+    }
+    catch (std::exception&)
     {
         return false;
     }
+
     std::string vertexShader = _hwShader->getSourceCode(mx::Stage::VERTEX);
     std::string pixelShader = _hwShader->getSourceCode(mx::Stage::PIXEL);
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1203,6 +1203,10 @@ void Viewer::loadStandardLibraries()
 {
     // Initialize the standard library.
     _stdLib = loadLibraries(_libraryFolders, _searchPath);
+    if (_stdLib->getChildren().empty())
+    {
+        std::cerr << "Could not find standard data libraries on the given search path: " << _searchPath.asString() << std::endl;
+    }
     for (std::string sourceUri : _stdLib->getReferencedSourceUris())
     {
         _xincludeFiles.insert(sourceUri);


### PR DESCRIPTION
- Make unit conversion robust to missing standard data libraries.
- Add a viewer warning for missing standard data libraries.
- Add helper method FilePath::getModulePath, which returns the directory containing the executable module.
- Update the viewer to leverage FilePath::getModulePath.
- Improve documentation for the --path and --library flags in the viewer.