### PR TITLE
Refactor two MaterialXGenShader methods for VS2019

### DIFF
--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -35,7 +35,6 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
         throw ExceptionShaderGenError("No source file specified for implementation '" + impl.getName() + "'");
     }
 
-    _functionSource = "";
     _inlined = (file.getExtension() == "inline");
 
     // Find the function name to use
@@ -47,7 +46,8 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
     }
     context.getShaderGenerator().getSyntax().makeValidName(_functionName);
 
-    if (!readFile(context.resolveSourceFile(FilePath("libraries") / file), _functionSource))
+    _functionSource = readFile(context.resolveSourceFile(FilePath("libraries") / file));
+    if (_functionSource.empty())
     {
         throw ExceptionShaderGenError("Could not find source file '" + file.asString() +
                                       "' used by implementation '" + impl.getName() + "'");
@@ -55,7 +55,7 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
 
     if (_inlined)
     {
-        _functionSource.erase(std::remove(_functionSource.begin(), _functionSource.end(), '\n'), _functionSource.end());
+        _functionSource = replaceSubstrings(_functionSource, { { "\n", "" } });
     }
 
     // Set hash using the function name.

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -324,8 +324,8 @@ void ShaderStage::addInclude(const string& file, GenContext& context)
 
     if (!_includes.count(resolvedFile))
     {
-        string content;
-        if (!readFile(resolvedFile, content))
+        string content = readFile(resolvedFile);
+        if (content.empty())
         {
             throw ExceptionShaderGenError("Could not find include file: '" + file + "'");
         }

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -27,7 +27,7 @@ string removeExtension(const string& filename)
     return filename.substr(0, lastDot);
 }
 
-bool readFile(const string& filename, string& contents)
+string readFile(const string& filename)
 {
     std::ifstream file(filename, std::ios::in);
     if (file)
@@ -37,12 +37,10 @@ bool readFile(const string& filename, string& contents)
         file.close();
         if (stream)
         {
-            contents = stream.str();
-            return (contents.size() > 0);
+            return stream.str();
         }
-        return false;
     }
-    return false;
+    return EMPTY_STRING;
 }
 
 void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, const StringSet& skipFiles,

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -25,8 +25,9 @@ class ShaderGenerator;
 /// Removes the extension from the provided filename
 string removeExtension(const string& filename);
 
-/// Reads the contents of a file into the given string
-bool readFile(const string& filename, string& content);
+/// Read the given file and return a string containing its contents; if the read is not
+/// successful, then the empty string is returned.
+string readFile(const string& filename);
 
 /// Scans for all documents under a root path and returns documents which can be loaded
 void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, const StringSet& skipFiles,

--- a/source/MaterialXTest/GenShader.cpp
+++ b/source/MaterialXTest/GenShader.cpp
@@ -182,11 +182,10 @@ TEST_CASE("GenShader: OSL Reference Implementation Check", "[genshader]")
             if (impl)
             {
                 // Scan for file and see if we can read in the contents
-                std::string sourceContents;
                 mx::FilePath sourcePath = impl->getFile();
                 mx::FilePath resolvedPath = sourceCodeSearchPath.find(sourcePath);
-                bool found = mx::readFile(resolvedPath.asString(), sourceContents);
-                if (!found)
+                std::string sourceContents = mx::readFile(resolvedPath.asString());
+                if (sourceContents.empty())
                 {
                     missing++;
                     missing_str += "Missing source code: " + sourcePath.asString() + " for nodeDef: "

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -27,7 +27,8 @@ bool getShaderSource(mx::GenContext& context,
     {
         sourcePath = implementation->getFile();
         resolvedPath = context.resolveSourceFile(sourcePath);
-        return mx::readFile(resolvedPath.asString(), sourceContents);
+        sourceContents = mx::readFile(resolvedPath.asString());
+        return !sourceContents.empty();
     }
     return false;
 }

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -131,14 +131,14 @@ bool Material::loadSource(const mx::FilePath& vertexShaderFile, const mx::FilePa
         _glShader = std::make_shared<ng::GLShader>();
     }
 
-    std::string vertexShader;
-    if (!mx::readFile(vertexShaderFile, vertexShader))
+    std::string vertexShader = mx::readFile(vertexShaderFile);
+    if (vertexShader.empty())
     {
         return false;
     }
 
-    std::string pixelShader;
-    if (!mx::readFile(pixelShaderFile, pixelShader))
+    std::string pixelShader = mx::readFile(pixelShaderFile);
+    if (pixelShader.empty())
     {
         return false;
     }


### PR DESCRIPTION
This changelist refactors the MaterialX::readFile and SourceCodeNode::initialize methods for better compatibility with Visual Studio 2019