### PR TITLE
GLSL shading improvements

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -1,11 +1,15 @@
 #include "pbrlib/genglsl/lib/mx_bsdfs.glsl"
 
-vec2 mx_latlong_projection(vec3 dir)
+// https://www.graphics.rwth-aachen.de/publication/2/jgt.pdf
+float mx_golden_ratio_sequence(int i)
 {
-    float latitude = -asin(dir.y) * M_PI_INV + 0.5;
-    latitude = clamp(latitude, 0.01, 0.99);
-    float longitude = atan(dir.x, -dir.z) * M_PI_INV * 0.5 + 0.5;
-    return vec2(longitude, latitude);
+    return fract((float(i) + 1.0) * M_GOLDEN_RATIO);
+}
+
+// https://people.irisa.fr/Ricardo.Marques/articles/2013/SF_CGF.pdf
+vec2 mx_spherical_fibonacci(int i, int numSamples)
+{
+    return vec2((float(i) + 0.5) / float(numSamples), mx_golden_ratio_sequence(i));
 }
 
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -1,11 +1,3 @@
-vec2 mx_latlong_projection(vec3 dir)
-{
-    float latitude = -asin(dir.y) * M_PI_INV + 0.5;
-    latitude = clamp(latitude, 0.01, 0.99);
-    float longitude = atan(dir.x, -dir.z) * M_PI_INV * 0.5 + 0.5;
-    return vec2(longitude, latitude);
-}
-
 vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, sampler2D sampler)
 {
     vec2 res = textureSize(sampler, 0);

--- a/libraries/pbrlib/genglsl/lib/mx_math.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_math.glsl
@@ -56,14 +56,9 @@ float mx_mix(float v00, float v01, float v10, float v11,
    return mix(v0_, v1_, y);
 }
 
-// https://www.graphics.rwth-aachen.de/publication/2/jgt.pdf
-float mx_golden_ratio_sequence(int i)
+vec2 mx_latlong_projection(vec3 dir)
 {
-    return fract((float(i) + 1.0) * M_GOLDEN_RATIO);
-}
-
-// https://people.irisa.fr/Ricardo.Marques/articles/2013/SF_CGF.pdf
-vec2 mx_spherical_fibonacci(int i, int numSamples)
-{
-    return vec2((float(i) + 0.5) / float(numSamples), mx_golden_ratio_sequence(i));
+    float latitude = -asin(dir.y) * M_PI_INV + 0.5;
+    float longitude = atan(dir.x, -dir.z) * M_PI_INV * 0.5 + 0.5;
+    return vec2(longitude, latitude);
 }

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -676,7 +676,12 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
 
             if (image)
             {
-                if (imageHandler->bindImage(image, ImageSamplingProperties()))
+                ImageSamplingProperties samplingProperties;
+                samplingProperties.uaddressMode = ImageSamplingProperties::AddressMode::PERIODIC;
+                samplingProperties.vaddressMode = ImageSamplingProperties::AddressMode::CLAMP;
+                samplingProperties.filterType = ImageSamplingProperties::FilterType::LINEAR;
+
+                if (imageHandler->bindImage(image, samplingProperties))
                 {
                     GLTextureHandlerPtr textureHandler = std::static_pointer_cast<GLTextureHandler>(imageHandler);
                     int textureLocation = textureHandler->getBoundTextureLocation(image->getResourceId());

--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -48,12 +48,6 @@ target_link_libraries(
     nanogui
     ${NANOGUI_EXTRA_LIBS})
 
-add_custom_command(TARGET MaterialXView POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_CURRENT_BINARY_DIR}/libraries)
-add_custom_command(TARGET MaterialXView POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../resources ${CMAKE_CURRENT_BINARY_DIR}/resources)
 if(MATERIALX_BUILD_OIIO AND OPENIMAGEIO_ROOT_DIR)
     add_custom_command(TARGET MaterialXView POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -100,15 +100,13 @@ int main(int argc, char* const argv[])
         }
     }
 
-    // Add the module path to the search path.
-    mx::FilePath modulePath = mx::FilePath::getModulePath();
-    if ((modulePath.getParentPath() / "libraries").exists())
+    // Add default search paths for the viewer.
+    mx::FilePath installSearchPath = mx::FilePath::getModulePath().getParentPath();
+    mx::FilePath devSearchPath = installSearchPath.getParentPath().getParentPath().getParentPath();
+    searchPath.append(installSearchPath);
+    if (!devSearchPath.isEmpty() && (devSearchPath / "libraries").exists())
     {
-        searchPath.append(modulePath.getParentPath());
-    }
-    else
-    {
-        searchPath.append(modulePath);
+        searchPath.append(devSearchPath);
     }
 
     try

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -464,7 +464,7 @@ void Material::bindLights(mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr 
         if (image && _glShader->uniform(env.first, false) != -1)
         {
             mx::ImageSamplingProperties samplingProperties;
-            samplingProperties.uaddressMode = mx::ImageSamplingProperties::AddressMode::CLAMP;
+            samplingProperties.uaddressMode = mx::ImageSamplingProperties::AddressMode::PERIODIC;
             samplingProperties.vaddressMode = mx::ImageSamplingProperties::AddressMode::CLAMP;
             samplingProperties.filterType = mx::ImageSamplingProperties::FilterType::LINEAR;
 


### PR DESCRIPTION
- Remove duplicate library and resource folders that were generated during the MaterialXView build process.  This makes shader development more straightforward, where a developer can edit library source files directly and hit 'R' to reload shaders in the viewer.
- Use texture address modes rather than shader logic to keep latitude-longitude texture coordinates within bounds.  This addresses lighting artifacts along longitude seams in filtered importance sampling.
- Move spherical Fibonacci methods from mx_math.glsl to mx_environment_fis.glsl, removing them from generated shaders where they're not needed.