### PR TITLE
Energy conservation improvements for generated GLSL

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_none.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_none.glsl
@@ -1,4 +1,4 @@
-vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution)
+vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, vec3 F0, vec3 F90, int distribution)
 {
     return vec3(0.0);
 }

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -27,10 +27,13 @@ vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lodBias, sampler2D sa
     return vec3(0.0);
 }
 
-vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution)
+vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, vec3 F0, vec3 F90, int distribution)
 {
-    vec3 dir = reflect(-V, N);
-    return mx_latlong_map_lookup(dir, $envMatrix, max(roughness.x, roughness.y), $envRadiance);
+    vec3 L = reflect(-V, N);
+    float NdotV = dot(N, V);
+
+    vec3 dirAlbedo = mx_microfacet_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), F0, F90);
+    return mx_latlong_map_lookup(L, $envMatrix, mx_average_roughness(roughness), $envRadiance) * dirAlbedo;
 }
 
 vec3 mx_environment_irradiance(vec3 N)

--- a/libraries/pbrlib/genglsl/lib/mx_refraction_index.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_refraction_index.glsl
@@ -1,3 +1,9 @@
+// Convert a real-valued index of refraction to normal-incidence reflectivity.
+float mx_ior_to_f0(float ior)
+{
+    return mx_square((ior - 1.0) / (ior + 1.0));
+}
+
 // "Artist Friendly Metallic Fresnel", Ole Gulbrandsen, 2014
 // http://jcgt.org/published/0003/04/03/paper.pdf
 

--- a/libraries/pbrlib/genglsl/mx_dielectric_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_brdf.glsl
@@ -20,17 +20,17 @@ void mx_dielectric_brdf_reflection(vec3 L, vec3 V, float weight, vec3 tint, floa
 
     vec3 H = normalize(L + V);
     float NdotH = dot(N, H);
+    float VdotH = dot(V, H);
 
     float D = mx_microfacet_ggx_NDF(X, Y, H, NdotH, roughness.x, roughness.y);
-    float G = mx_microfacet_ggx_smith_G(NdotL, NdotV, max(roughness.x, roughness.y));
-
-    float VdotH = dot(V, H);
     float F = mx_fresnel_schlick(VdotH, ior);
-    F *= weight;
+    float G = mx_microfacet_ggx_smith_G(NdotL, NdotV, mx_average_roughness(roughness));
+
+    float dirAlbedo = mx_microfacet_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), ior);
 
     // Note: NdotL is cancelled out
-    result = tint * D * G * F / (4 * NdotV) // Top layer reflection
-           + base * (1.0 - F);              // Base layer reflection attenuated by top fresnel
+    result = D * F * G * tint * weight / (4 * NdotV)    // Top layer reflection
+           + base * (1.0 - dirAlbedo * weight);         // Base layer reflection attenuated by top directional albedo
 }
 
 void mx_dielectric_brdf_transmission(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
@@ -46,11 +46,10 @@ void mx_dielectric_brdf_transmission(vec3 V, float weight, vec3 tint, float ior,
     // inverse of top layer reflectance.
 
     // Abs here to allow transparency through backfaces
-    float NdotV = abs(dot(N,V));
-    float F = mx_fresnel_schlick(NdotV, ior);
-    F *= weight;
+    float NdotV = abs(dot(N, V));
+    float dirAlbedo = mx_microfacet_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), ior);
 
-    result = base * (1.0 - F); // Base layer transmission attenuated by top fresnel
+    result = base * (1.0 - dirAlbedo * weight); // Base layer transmission attenuated by top directional albedo
 }
 
 void mx_dielectric_brdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
@@ -61,12 +60,11 @@ void mx_dielectric_brdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
         return;
     }
 
-    vec3 Li = mx_environment_radiance(N, V, X, roughness, distribution);
+    vec3 Li = mx_environment_radiance(N, V, X, roughness, vec3(mx_ior_to_f0(ior)), vec3(1.0), distribution);
 
-    float NdotV = dot(N,V);
-    float F = mx_fresnel_schlick_roughness(NdotV, ior, max(roughness.x, roughness.y));
-    F *= weight;
+    float NdotV = dot(N, V);
+    float dirAlbedo = mx_microfacet_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), ior);
 
-    result = Li * tint * F     // Top layer reflection
-           + base * (1.0 - F); // Base layer reflection attenuated by top fresnel
+    result = Li * tint * weight                 // Top layer reflection
+           + base * (1.0 - dirAlbedo * weight); // Base layer reflection attenuated by top directional albedo
 }


### PR DESCRIPTION
- Add mx_microfacet_ggx_directional_albedo for computing a directional albedo for the GGX/Smith/Schlick BRDF.
- Replace mirror Fresnel with directional albedo for BSDF layering.
- Move Fresnel computation into the lighting integral for filtered importance sampling.
- Add mx_average_roughness for converting from anisotropic to isotropic roughness.