### PR TITLE
Initial support for wedge rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## [1.37.1] - Development
 
 ### Added
+- Added initial support for wedge rendering in the viewer.
+- Added utility methods Backdrop\:\:setContainsElements and Backdrop\:\:getContainsElements.
 - Added backwards compatibility for OpenImageIO 1.x.
+
+### Changed
+- Updated the GLSL implementation of Smith masking-shadowing from uncorrelated to height-correlated forms.
+- Renamed Backdrop\:\:setContains and getContains to Backdrop\:\:setContainsString and getContainsString for consistency.
 
 ## [1.37.0] - 2020-03-20
 

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -108,6 +108,15 @@ string replaceSubstrings(string str, const StringMap& stringMap)
     return str;
 }
 
+bool stringEndsWith(const std::string& str, const std::string& suffix)
+{
+    if (str.length() >= suffix.length())
+    {
+        return !str.compare(str.length() - suffix.length(), suffix.length(), suffix);
+    }
+    return false;
+}
+
 string prettyPrint(ConstElementPtr elem)
 {
     string text;

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -44,6 +44,9 @@ StringVec splitString(const string& str, const string& sep);
 /// Apply the given substring substitutions to the input string.
 string replaceSubstrings(string str, const StringMap& stringMap);
 
+/// Return true if the given string ends with the given suffix.
+bool stringEndsWith(const std::string& str, const std::string& suffix);
+
 /// Pretty print the given element tree, calling asString recursively on each
 /// element in depth-first order.
 string prettyPrint(ConstElementPtr elem);

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -130,6 +130,12 @@ class FilePath
         return i != string::npos ? baseName.substr(i + 1) : EMPTY_STRING;
     }
 
+    /// Add a file extension to the given path.
+    void addExtension(const string& ext)
+    {
+        assign(asString() + "." + ext);
+    }
+
     /// Concatenate two paths with a directory separator, returning the
     /// combined path.
     FilePath operator/(const FilePath& rhs) const;

--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -50,9 +50,6 @@ class Image
         return ImagePtr(new Image(width, height, channelCount, baseType));
     }
 
-    /// Create a constant color image with the given properties.
-    static ImagePtr createConstantColor(unsigned int width, unsigned int height, const Color4& color);
-
     ~Image();
 
     /// Return the width of the image.
@@ -158,6 +155,12 @@ class Image
     ImageBufferDeallocator _resourceBufferDeallocator;
     unsigned int _resourceId;
 };
+
+/// Create a uniform-color image with the given properties.
+ImagePtr createUniformImage(unsigned int width, unsigned int height, const Color4& color);
+
+/// Create a horizontal image strip from a vector of images with identical resolutions and formats.
+ImagePtr createImageStrip(vector<ImagePtr> imageVec);
 
 } // namespace MaterialX
 

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -40,7 +40,7 @@ const string ImageLoader::TXR_EXTENSION = "txr";
 ImageHandler::ImageHandler(ImageLoaderPtr imageLoader)
 {
     addLoader(imageLoader);
-    _zeroImage = Image::createConstantColor(1, 1, Color4(0.0f));
+    _zeroImage = createUniformImage(1, 1, Color4(0.0f));
 }
 
 void ImageHandler::addLoader(ImageLoaderPtr loader)
@@ -117,7 +117,7 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4
     }
     if (fallbackColor)
     {
-        ImagePtr image = Image::createConstantColor(1, 1, *fallbackColor);
+        ImagePtr image = createUniformImage(1, 1, *fallbackColor);
         if (image)
         {
             cacheImage(filePath, image);

--- a/source/MaterialXTest/Render.cpp
+++ b/source/MaterialXTest/Render.cpp
@@ -180,7 +180,7 @@ TEST_CASE("Render: Image Handler Load", "[rendercore]")
     try
     {
         mx::Color4 color(1.0f, 0.0f, 0.0f, 1.0f);
-        mx::ImagePtr uniformImage = mx::Image::createConstantColor(1, 1, color);
+        mx::ImagePtr uniformImage = createUniformImage(1, 1, color);
         CHECK(uniformImage->getWidth() == 1);
         CHECK(uniformImage->getHeight() == 1);
         CHECK(uniformImage->getMaxMipCount() == 1);

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -668,7 +668,7 @@ mx::ShaderPort* Material::findUniform(const std::string& path) const
         port = publicUniforms->find(
             [path](mx::ShaderPort* port)
             {
-                return (port && (port->getPath() == path));
+                return (port && mx::stringEndsWith(port->getPath(), path));
             });
 
         // Check if the uniform exists in the shader program

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -42,15 +42,6 @@ const float MODEL_SPHERE_RADIUS = 2.0f;
 
 namespace {
 
-bool stringEndsWith(const std::string& str, std::string const& end)
-{
-    if (str.length() >= end.length())
-    {
-        return !str.compare(str.length() - end.length(), end.length(), end);
-    }
-    return false;
-}
-
 void writeTextFile(const std::string& text, const std::string& filePath)
 {
     std::ofstream file;
@@ -104,7 +95,7 @@ void applyModifiers(mx::DocumentPtr doc, const DocumentModifiers& modifiers)
         if (elem->hasFilePrefix() && !modifiers.filePrefixTerminator.empty())
         {
             std::string filePrefix = elem->getFilePrefix();
-            if (!stringEndsWith(filePrefix, modifiers.filePrefixTerminator))
+            if (!mx::stringEndsWith(filePrefix, modifiers.filePrefixTerminator))
             {
                 elem->setFilePrefix(filePrefix + modifiers.filePrefixTerminator);
             }
@@ -199,7 +190,12 @@ Viewer::Viewer(const std::string& materialFilename,
     _envSamples(DEFAULT_ENV_SAMPLES),
     _drawEnvironment(false),
     _showAdvancedProperties(false),
-    _captureFrame(false),
+    _captureRequested(false),
+    _wedgeRequested(false),
+    _wedgePropertyName("specular_roughness"),
+    _wedgePropertyMin(0.0f),
+    _wedgePropertyMax(1.0f),
+    _wedgeImageCount(8),
     _bakeRequested(false)
 {
     _window = new ng::Window(this, "Viewer Options");
@@ -594,10 +590,9 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
         // Save document
         if (material && !filename.isEmpty())
         {
-            mx::DocumentPtr doc = material->getDocument();
             if (filename.getExtension() != mx::MTLX_EXTENSION)
             {
-                filename = mx::FilePath(filename.asString() + "." + mx::MTLX_EXTENSION);
+                filename.addExtension(mx::MTLX_EXTENSION);
             }
 
             if (_bakeTextures)
@@ -619,7 +614,7 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
                 mx::XmlWriteOptions writeOptions;
                 writeOptions.writeXIncludeEnable = true;
                 writeOptions.elementPredicate = skipXincludes;
-                mx::writeToXmlFile(doc, filename, &writeOptions);
+                mx::writeToXmlFile(material->getDocument(), filename, &writeOptions);
             }
 
             // Update material file name
@@ -1248,6 +1243,16 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         return true;
     }
 
+    // Adjust camera zoom.
+    if (key == GLFW_KEY_KP_ADD && action == GLFW_PRESS)
+    {
+        _userZoom *= 1.1f;
+    }
+    if (key == GLFW_KEY_KP_SUBTRACT && action == GLFW_PRESS)
+    {
+        _userZoom = std::max(0.1f, _userZoom * 0.9f);
+    }
+
     // Reload the current document, and optionally the standard libraries, from
     // the file system.
     if (key == GLFW_KEY_R && action == GLFW_PRESS)
@@ -1285,29 +1290,31 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         return true;
     }
 
-    // Capture the current frame and save to file.
+    // Capture the current frame and save as an image file.
     if (key == GLFW_KEY_F && action == GLFW_PRESS)
     {
-        mx::StringSet extensions;
-        _imageHandler->supportedExtensions(extensions);
-        if (!extensions.empty())
+        _captureFilename = ng::file_dialog({ { mx::ImageLoader::TGA_EXTENSION, mx::ImageLoader::TGA_EXTENSION } }, true);
+        if (!_captureFilename.isEmpty())
         {
-            std::vector<std::pair<std::string, std::string>> filetypes;
-            for (const auto& extension : extensions)
+            if (_captureFilename.getExtension() != mx::ImageLoader::TGA_EXTENSION)
             {
-                filetypes.push_back(std::make_pair(extension, extension));
+                _captureFilename.addExtension(mx::ImageLoader::TGA_EXTENSION);
             }
-            std::string fileName = ng::file_dialog(filetypes, true);
-            if (!fileName.empty())
+            _captureRequested = true;
+        }
+    }
+
+    // Render a wedge for the current material.
+    if (key == GLFW_KEY_W && action == GLFW_PRESS)
+    {
+        _wedgeFilename = ng::file_dialog({ { mx::ImageLoader::TGA_EXTENSION, mx::ImageLoader::TGA_EXTENSION } }, true);
+        if (!_wedgeFilename.isEmpty())
+        {
+            if (_wedgeFilename.getExtension() != mx::ImageLoader::TGA_EXTENSION)
             {
-                std::string fileExtension = mx::FilePath(fileName).getExtension();
-                if (extensions.count(fileExtension) == 0)
-                {
-                    fileName += "." + *extensions.begin();
-                }
-                _captureFrameFilename = fileName;
-                _captureFrame = true;
+                _wedgeFilename.addExtension(mx::ImageLoader::TGA_EXTENSION);
             }
+            _wedgeRequested = true;
         }
     }
 
@@ -1338,17 +1345,8 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
     return false;
 }
 
-void Viewer::drawContents()
+void Viewer::renderFrame()
 {
-    if (_geometryList.empty() || _materials.empty())
-    {
-        return;
-    }
-
-    updateViewHandlers();
-
-    checkGlErrors("before viewer render");
-
     // Initialize OpenGL state
     glDisable(GL_BLEND);
     glEnable(GL_DEPTH_TEST);
@@ -1366,9 +1364,9 @@ void Viewer::drawContents()
         updateShadowMap();
         shadowState.shadowMap = _shadowMap;
         shadowState.shadowMatrix = _cameraViewHandler->worldMatrix.getInverse() *
-                                   _shadowViewHandler->worldMatrix *
-                                   _shadowViewHandler->viewMatrix *
-                                   _shadowViewHandler->projectionMatrix;
+            _shadowViewHandler->worldMatrix *
+            _shadowViewHandler->viewMatrix *
+            _shadowViewHandler->projectionMatrix;
     }
 
     const mx::Matrix44& world = _cameraViewHandler->worldMatrix;
@@ -1409,8 +1407,8 @@ void Viewer::drawContents()
         material->bindShader();
         material->bindViewInformation(world, view, proj);
         material->bindLights(_lightHandler, _imageHandler,
-                             _directLighting, _indirectLighting, shadowState,
-                             _specularEnvironmentMethod, _envSamples);
+            _directLighting, _indirectLighting, shadowState,
+            _specularEnvironmentMethod, _envSamples);
         material->bindImages(_imageHandler, _searchPath);
         material->drawPartition(geom);
         material->unbindImages(_imageHandler);
@@ -1432,13 +1430,13 @@ void Viewer::drawContents()
         material->bindShader();
         material->bindViewInformation(world, view, proj);
         material->bindLights(_lightHandler, _imageHandler,
-                             _directLighting, _indirectLighting, ShadowState(),
-                             _specularEnvironmentMethod, _envSamples);
+            _directLighting, _indirectLighting, ShadowState(),
+            _specularEnvironmentMethod, _envSamples);
         material->bindImages(_imageHandler, _searchPath);
         material->drawPartition(geom);
         material->unbindImages(_imageHandler);
     }
-    
+
     glDisable(GL_BLEND);
     glDisable(GL_FRAMEBUFFER_SRGB);
 
@@ -1451,71 +1449,132 @@ void Viewer::drawContents()
         _wireMaterial->drawPartition(getSelectedGeometry());
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     }
+}
 
-    // Frame capture
-    if (_captureFrame)
+mx::ImagePtr Viewer::getFrameImage()
+{
+    glFlush();
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
+
+    // Create an image with dimensions adjusted for device DPI.
+    mx::ImagePtr image = mx::Image::create((unsigned int) (mSize.x() * mPixelRatio),
+                                           (unsigned int) (mSize.y() * mPixelRatio), 3);
+    image->createResourceBuffer();
+
+    // Read pixels into the image buffer.
+    glReadPixels(0, 0, image->getWidth(), image->getHeight(), GL_RGB, GL_UNSIGNED_BYTE, image->getResourceBuffer());
+
+    return image;
+}
+
+mx::ImagePtr Viewer::renderWedge()
+{
+    MaterialPtr material = getSelectedMaterial();
+    mx::ShaderPort* uniform = material ? material->findUniform(_wedgePropertyName) : nullptr;
+    float origPropertyValue = uniform && uniform->getValue()->isA<float>() ? uniform->getValue()->asA<float>() : 0.0f;
+
+    std::vector<mx::ImagePtr> imageVec;
+    float wedgePropertyStep = (_wedgePropertyMax - _wedgePropertyMin) / (_wedgeImageCount - 1);
+    for (unsigned int i = 0; i < _wedgeImageCount; i++)
     {
-        _captureFrame = false;
+        if (material)
+        {
+            float propertyValue = (i == _wedgeImageCount - 1) ? _wedgePropertyMax : _wedgePropertyMin + wedgePropertyStep * i;
+            material->setUniformFloat(_wedgePropertyName, propertyValue);
+        }
+        renderFrame();
+        imageVec.push_back(getFrameImage());
+    }
 
-        glFlush();
-        glPixelStorei(GL_PACK_ALIGNMENT, 1);
-        glReadBuffer(GL_COLOR_ATTACHMENT0);
+    if (material)
+    {
+        material->setUniformFloat(_wedgePropertyName, origPropertyValue);
+    }
 
-        // Create an image with dimensions adjusted for device DPI.
-        mx::ImagePtr image = mx::Image::create((unsigned int) (mSize.x() * mPixelRatio),
-                                               (unsigned int) (mSize.y() * mPixelRatio), 3);
-        image->createResourceBuffer();
+    return mx::createImageStrip(imageVec);
+}
 
-        // Read pixels into the image buffer.
-        glReadPixels(0, 0, image->getWidth(), image->getHeight(), GL_RGB, GL_UNSIGNED_BYTE, image->getResourceBuffer());
+void Viewer::bakeTextures()
+{
+    MaterialPtr material = getSelectedMaterial();
+    mx::ShaderRefPtr shaderRef = material->getElement()->asA<mx::ShaderRef>();
+    mx::FileSearchPath searchPath = _searchPath;
+    if (material->getDocument())
+    {
+        mx::FilePath documentFilename = material->getDocument()->getSourceUri();
+        searchPath.append(documentFilename.getParentPath());
+    }
 
-        // Save the image to disk.
-        bool saved = _imageHandler->saveImage(_captureFrameFilename, image, true);
-        if (!saved)
+    mx::ImageHandlerPtr imageHandler = mx::GLTextureHandler::create(mx::StbImageLoader::create());
+    imageHandler->setSearchPath(searchPath);
+    if (!material->getUdim().empty())
+    {
+        mx::StringResolverPtr resolver = mx::StringResolver::create();
+        resolver->setUdimString(material->getUdim());
+        imageHandler->setFilenameResolver(resolver);
+    }
+
+    try
+    {
+        mx::TextureBakerPtr baker = mx::TextureBaker::create();
+        baker->setImageHandler(imageHandler);
+        baker->bakeShaderInputs(shaderRef, _genContext, _bakeFilename.getParentPath());
+        baker->writeBakedDocument(shaderRef, _bakeFilename);
+    }
+    catch (mx::Exception& e)
+    {
+        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to bake textures", e.what());
+    }
+
+    glfwMakeContextCurrent(mGLFWWindow);
+    glfwGetFramebufferSize(mGLFWWindow, &mFBSize[0], &mFBSize[1]);
+    glViewport(0, 0, mFBSize[0], mFBSize[1]);
+}
+
+void Viewer::drawContents()
+{
+    if (_geometryList.empty() || _materials.empty())
+    {
+        return;
+    }
+
+    updateViewHandlers();
+
+    checkGlErrors("before viewer render");
+
+    // Render a wedge for the current material.
+    if (_wedgeRequested)
+    {
+        _wedgeRequested = false;
+        mx::ImagePtr wedgeImage = renderWedge();
+        if (!wedgeImage || !_imageHandler->saveImage(_wedgeFilename, wedgeImage, true))
         {
             new ng::MessageDialog(this, ng::MessageDialog::Type::Information,
-                "Failed to save frame to disk: ", _captureFrameFilename.asString());
+                "Failed to save wedge to disk: ", _wedgeFilename.asString());
         }
     }
 
-    // Texture baking
+    // Render the current frame.
+    renderFrame();
+
+    // Capture the current frame.
+    if (_captureRequested)
+    {
+        _captureRequested = false;
+        mx::ImagePtr frameImage = getFrameImage();
+        if (!frameImage || !_imageHandler->saveImage(_captureFilename, frameImage, true))
+        {
+            new ng::MessageDialog(this, ng::MessageDialog::Type::Information,
+                "Failed to save frame to disk: ", _captureFilename.asString());
+        }
+    }
+
+    // Bake textures for the current material.
     if (_bakeRequested)
     {
         _bakeRequested = false;
-
-        MaterialPtr material = getSelectedMaterial();
-        mx::ShaderRefPtr shaderRef = material->getElement()->asA<mx::ShaderRef>();
-        mx::FileSearchPath searchPath = _searchPath;
-        if (material->getDocument())
-        {
-            mx::FilePath documentFilename = material->getDocument()->getSourceUri();
-            searchPath.append(documentFilename.getParentPath());
-        }
-
-        mx::ImageHandlerPtr imageHandler = mx::GLTextureHandler::create(mx::StbImageLoader::create());
-        imageHandler->setSearchPath(searchPath);
-        if (!material->getUdim().empty())
-        {
-            mx::StringResolverPtr resolver = mx::StringResolver::create();
-            resolver->setUdimString(material->getUdim());
-            imageHandler->setFilenameResolver(resolver);
-        }
-
-        try
-        {
-            mx::TextureBakerPtr baker = mx::TextureBaker::create();
-            baker->setImageHandler(imageHandler);
-            baker->bakeShaderInputs(shaderRef, _genContext, _bakeFilename.getParentPath());
-            baker->writeBakedDocument(shaderRef, _bakeFilename);
-        }
-        catch (mx::Exception& e)
-        {
-            new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to bake textures", e.what());
-        }
-
-        glfwMakeContextCurrent(mGLFWWindow);
-        glfwGetFramebufferSize(mGLFWWindow, &mFBSize[0], &mFBSize[1]);
-        glViewport(0, 0, mFBSize[0], mFBSize[1]);
+        bakeTextures();
     }
 
     checkGlErrors("after viewer render");
@@ -1525,7 +1584,7 @@ bool Viewer::scrollEvent(const ng::Vector2i& p, const ng::Vector2f& rel)
 {
     if (!Screen::scrollEvent(p, rel))
     {
-        _userZoom = std::max(0.1f, _userZoom * ((rel.y() > 0) ? 1.1f : 0.9f));;
+        _userZoom = std::max(0.1f, _userZoom * ((rel.y() > 0) ? 1.1f : 0.9f));
     }
     return true;
 }
@@ -1637,8 +1696,8 @@ void Viewer::updateViewHandlers()
     float fH = std::tan(_viewAngle / 360.0f * PI) * _nearDist;
     float fW = fH * (float) mSize.x() / (float) mSize.y();
 
-    mx::Matrix44 cameraYaw = mx::Matrix44::createRotationY(_cameraYaw / 360.0f * PI);
-    mx::Matrix44 modelYaw = mx::Matrix44::createRotationY(_modelYaw / 360.0f * PI);
+    mx::Matrix44 cameraYaw = mx::Matrix44::createRotationY(_cameraYaw / 180.0f * PI);
+    mx::Matrix44 modelYaw = mx::Matrix44::createRotationY(_modelYaw / 180.0f * PI);
     ng::Matrix4f ngArcball = _arcball.matrix();
     mx::Matrix44 arcball = mx::Matrix44(ngArcball.data(), ngArcball.data() + ngArcball.size());
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -37,6 +37,11 @@ class Viewer : public ng::Screen
     bool mouseMotionEvent(const ng::Vector2i& p, const ng::Vector2i& rel, int button, int modifiers) override;
     bool mouseButtonEvent(const ng::Vector2i& p, int button, bool down, int modifiers) override;
 
+    void renderFrame();
+    mx::ImagePtr getFrameImage();
+    mx::ImagePtr renderWedge();
+    void bakeTextures();
+
     ng::Window* getWindow() const
     {
         return _window;
@@ -240,9 +245,17 @@ class Viewer : public ng::Screen
     // Property options
     bool _showAdvancedProperties;
 
-    // Image save
-    bool _captureFrame;
-    mx::FilePath _captureFrameFilename;
+    // Frame capture
+    bool _captureRequested;
+    mx::FilePath _captureFilename;
+
+    // Wedge rendering
+    bool _wedgeRequested;
+    mx::FilePath _wedgeFilename;
+    std::string _wedgePropertyName;
+    float _wedgePropertyMin;
+    float _wedgePropertyMax;
+    unsigned int _wedgeImageCount;
 
     // Texture baking
     bool _bakeRequested;

--- a/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
@@ -22,5 +22,6 @@ void bindPyUtil(py::module& mod)
     mod.def("incrementName", &mx::incrementName);
     mod.def("splitString", &mx::splitString);
     mod.def("replaceSubstrings", &mx::replaceSubstrings);
+    mod.def("stringEndsWith", &mx::stringEndsWith);
     mod.def("prettyPrint", &mx::prettyPrint);
 }

--- a/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
@@ -16,7 +16,6 @@ void bindPyImage(py::module& mod)
 
     py::class_<mx::Image>(mod, "Image")
         .def_static("create", &mx::Image::create)
-        .def_static("createConstantColor", &mx::Image::createConstantColor)
         .def("getWidth", &mx::Image::getWidth)
         .def("getHeight", &mx::Image::getHeight)
         .def("getChannelCount", &mx::Image::getChannelCount)
@@ -30,4 +29,7 @@ void bindPyImage(py::module& mod)
         .def("setResourceBufferDeallocator", &mx::Image::setResourceBufferDeallocator)
         .def("getResourceBufferDeallocator", &mx::Image::getResourceBufferDeallocator)
         .def("getTexelColor", &mx::Image::getTexelColor);
+
+        mod.def("createUniformImage", &mx::createUniformImage);
+        mod.def("createImageStrip", &mx::createImageStrip);
 }


### PR DESCRIPTION
- Add initial support for "wedge" rendering, where a single property is ramped between two values across successive screenshots, and the resulting image set is merged into a strip.  The new feature is activated by pressing the 'W' key in the MaterialX viewer, and settings for the render are hardcoded for now.
- Add hotkeys for adjusting camera zoom (+/-).
- Add utilities FilePath::addExtension and MaterialX::stringEndsWith.
- Refactor Viewer::drawContents for greater flexibility.
- Update changelog for recent work.