### PR TITLE
Refactor sheen BRDF for clarity

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_bsdfs.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_bsdfs.glsl
@@ -17,13 +17,6 @@ vec3 mx_fresnel_schlick(float cosTheta, vec3 F0, vec3 F90, float exponent)
     return mix(F0, F90, pow(x, exponent));
 }
 
-vec3 mx_fresnel_schlick(float cosTheta, vec3 F0)
-{
-    float x = clamp(1.0 - cosTheta, 0.0, 1.0);
-    float x5 = mx_pow5(x);
-    return F0 + (1.0 - F0) * x5;
-}
-
 float mx_fresnel_schlick(float cosTheta, float ior)
 {
     float x = clamp(1.0 - cosTheta, 0.0, 1.0);

--- a/libraries/pbrlib/genglsl/mx_sheen_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_brdf.glsl
@@ -22,20 +22,16 @@ void mx_sheen_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float ro
     float alpha = clamp(roughness, M_FLOAT_EPS, 1.0);
     float D = mx_imageworks_sheen_NDF(NdotH, alpha);
 
-    vec3 F = color * weight;
-
     // Geometry term is skipped and we use a smoother denominator, as in:
     // https://blog.selfshadow.com/publications/s2013-shading-course/rad/s2013_pbs_rad_notes.pdf
-    vec3 fr = D * F / (4.0 * (NdotL + NdotV - NdotL*NdotV));
+    vec3 fr = D * color / (4.0 * (NdotL + NdotV - NdotL*NdotV));
 
-    // Get sheen directional albedo for attenuating base layer
-    // in order to be energy conserving.
-    float albedo = weight * mx_imageworks_sheen_directional_albedo(NdotV, alpha);
+    float dirAlbedo = mx_imageworks_sheen_directional_albedo(NdotV, alpha);
 
     // We need to include NdotL from the light integral here
     // as in this case it's not cancelled out by the BRDF denominator.
-    result = fr * NdotL             // Top layer reflection
-           + base * (1.0 - albedo); // Base layer reflection attenuated by top layer
+    result = fr * NdotL * weight                // Top layer reflection
+           + base * (1.0 - dirAlbedo * weight); // Base layer reflection attenuated by top layer
 }
 
 void mx_sheen_brdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 N, BSDF base, out vec3 result)
@@ -48,8 +44,9 @@ void mx_sheen_brdf_indirect(vec3 V, float weight, vec3 color, float roughness, v
 
     float NdotV = abs(dot(N,V));
     float alpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float albedo = weight * mx_imageworks_sheen_directional_albedo(NdotV, alpha);
+    float dirAlbedo = mx_imageworks_sheen_directional_albedo(NdotV, alpha);
 
     vec3 Li = mx_environment_irradiance(N);
-    result = Li * color * albedo + base * (1.0 - albedo);
+    result = Li * color * dirAlbedo * weight        // Top layer reflection
+             + base * (1.0 - dirAlbedo * weight);   // Base layer reflection attenuated by top layer
 }


### PR DESCRIPTION
- Refactor the implementation of the sheen BRDF in GLSL to align with other BxDF nodes.
- Remove an unused overload of mx_fresnel_schlick.