### PR TITLE
Energy compensation improvements for generated GLSL

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -1,17 +1,5 @@
 #include "pbrlib/genglsl/lib/mx_bsdfs.glsl"
 
-// https://www.graphics.rwth-aachen.de/publication/2/jgt.pdf
-float mx_golden_ratio_sequence(int i)
-{
-    return fract((float(i) + 1.0) * M_GOLDEN_RATIO);
-}
-
-// https://people.irisa.fr/Ricardo.Marques/articles/2013/SF_CGF.pdf
-vec2 mx_spherical_fibonacci(int i, int numSamples)
-{
-    return vec2((float(i) + 0.5) / float(numSamples), mx_golden_ratio_sequence(i));
-}
-
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html
 // Section 20.4 Equation 13
 float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamples)

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_brdf.glsl
@@ -26,12 +26,13 @@ void mx_generalized_schlick_brdf_reflection(vec3 L, vec3 V, float weight, vec3 c
     vec3 F = mx_fresnel_schlick(VdotH, color0, color90, exponent);
     float G = mx_ggx_smith_G(NdotL, NdotV, mx_average_roughness(roughness));
 
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), color0, color90);
+    vec3 comp = mx_ggx_energy_compensation(NdotV, mx_average_roughness(roughness), F);
+    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
     // Note: NdotL is cancelled out
-    result = D * F * G * weight / (4 * NdotV)		// Top layer reflection
-           + base * (1.0 - avgDirAlbedo * weight);	// Base layer reflection attenuated by top directional albedo
+    result = D * F * G * comp * weight / (4 * NdotV)    // Top layer reflection
+           + base * (1.0 - avgDirAlbedo * weight);      // Base layer reflection attenuated by top layer
 }
 
 void mx_generalized_schlick_brdf_transmission(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
@@ -48,10 +49,13 @@ void mx_generalized_schlick_brdf_transmission(vec3 V, float weight, vec3 color0,
 
     // Abs here to allow transparency through backfaces
     float NdotV = abs(dot(N, V)); 
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), color0, color90);
+    vec3 F = mx_fresnel_schlick(NdotV, color0, color90, exponent);
+
+    vec3 comp = mx_ggx_energy_compensation(NdotV, mx_average_roughness(roughness), F);
+    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
-    result = base * (1.0 - avgDirAlbedo * weight); // Base layer transmission attenuated by top directional albedo
+    result = base * (1.0 - avgDirAlbedo * weight); // Base layer transmission attenuated by top layer
 }
 
 void mx_generalized_schlick_brdf_indirect(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
@@ -62,12 +66,15 @@ void mx_generalized_schlick_brdf_indirect(vec3 V, float weight, vec3 color0, vec
         return;
     }
 
-    vec3 Li = mx_environment_radiance(N, V, X, roughness, color0, color90, distribution);
-
     float NdotV = dot(N, V);
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), color0, color90);
+    vec3 F = mx_fresnel_schlick(NdotV, color0, color90, exponent);
+
+    vec3 comp = mx_ggx_energy_compensation(NdotV, mx_average_roughness(roughness), F);
+    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, mx_average_roughness(roughness), color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
-    result = Li * weight                            // Top layer reflection
-           + base * (1.0 - avgDirAlbedo * weight);  // Base layer reflection attenuated by top directional albedo
+    vec3 Li = mx_environment_radiance(N, V, X, roughness, color0, color90, distribution);
+
+    result = Li * comp * weight                     // Top layer reflection
+           + base * (1.0 - avgDirAlbedo * weight);  // Base layer reflection attenuated by top layer
 }

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -396,6 +396,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     emitInclude("pbrlib/" + GlslShaderGenerator::LANGUAGE + "/lib/mx_defines.glsl", context, stage);
     const unsigned int maxLights = std::max(1u, context.getOptions().hwMaxActiveLightSources);
     emitLine("#define MAX_LIGHT_SOURCES " + std::to_string(maxLights), stage, false);
+    emitLine("#define REFERENCE_QUALITY " + std::to_string(int(context.getOptions().hwReferenceQuality)), stage, false);
     emitLineBreak(stage);
     emitTypeDefinitions(context, stage);
 

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -60,7 +60,8 @@ class GenOptions
         hwShadowMap(false),
         hwAmbientOcclusion(false),
         hwMaxActiveLightSources(3),
-        hwNormalizeUdimTexCoords(false)
+        hwNormalizeUdimTexCoords(false),
+        hwReferenceQuality(false)
     {
     }
     virtual ~GenOptions() { }
@@ -121,6 +122,10 @@ class GenOptions
     /// compress a set of UDIMs into a single normalized image for
     /// hardware rendering.
     bool hwNormalizeUdimTexCoords;
+
+    /// Enable reference quality mode, improving the accuracy of
+	/// shading computations at an additional cost to GPU resources.
+    bool hwReferenceQuality;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -124,7 +124,7 @@ class GenOptions
     bool hwNormalizeUdimTexCoords;
 
     /// Enable reference quality mode, improving the accuracy of
-	/// shading computations at an additional cost to GPU resources.
+    /// shading computations at an additional cost to GPU resources.
     bool hwReferenceQuality;
 };
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -759,6 +759,14 @@ void Viewer::createAdvancedSettings(Widget* parent)
         _drawEnvironment = enable;
     });
 
+    ng::CheckBox* referenceQualityBox = new ng::CheckBox(advancedPopup, "Reference Quality");
+    referenceQualityBox->setChecked(_genContext.getOptions().hwReferenceQuality);
+    referenceQualityBox->setCallback([this](bool enable)
+    {
+        _genContext.getOptions().hwReferenceQuality = enable;
+        reloadShaders();
+    });
+
     if (_specularEnvironmentMethod == mx::SPECULAR_ENVIRONMENT_FIS)
     {
         Widget* sampleGroup = new Widget(advancedPopup);


### PR DESCRIPTION
- Add mx_ggx_energy_compensation for computing multiple scattering compensation with GGX/Smith shading.
- Split mx_ggx_directional_albedo into approximate and reference versions for evaluating approximation accuracy.
- Incorporate energy compensation into conductor_brdf, dielectric_brdf, and generalized_schlick_brdf.
- Add a Reference Quality option to MaterialXView.