### PR TITLE
Remove duplicate data folders for viewer

### DIFF
--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -55,13 +55,6 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/NanoGUI/include
     ${NANOGUI_EXTRA_INCS})
 
-add_custom_command(TARGET MaterialXView POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_CURRENT_BINARY_DIR}/libraries)
-add_custom_command(TARGET MaterialXView POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../resources ${CMAKE_CURRENT_BINARY_DIR}/resources)
-
 if(MATERIALX_BUILD_OIIO AND OPENIMAGEIO_ROOT_DIR)
     add_custom_command(TARGET MaterialXView POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory


### PR DESCRIPTION
This changelist restores an earlier improvement lost in the last merge, removing duplicate library and resource folders that were generated during the MaterialXView build process.