### PR TITLE
Improvements to tangent frame generation

### DIFF
--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -61,7 +61,7 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
     explicit VectorN(const vector<S>& vec) { std::copy(vec.begin(), vec.end(), _arr.begin()); }
     explicit VectorN(const S* begin, const S* end) { std::copy(begin, end, _arr.begin()); }
 
-    /// @name Equality Operators
+    /// @name Comparison Operators
     /// @{
 
     /// Return true if the given vector is identical to this one.
@@ -69,6 +69,12 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
 
     /// Return true if the given vector differs from this one.
     bool operator!=(const V& rhs) const { return _arr != rhs._arr; }
+
+    /// Compare two vectors lexicographically.
+    bool operator<(const V& rhs) const
+    {
+        return _arr < rhs._arr;
+    }
 
     /// @}
     /// @name Indexing Operators
@@ -363,13 +369,13 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
     explicit MatrixN(S s) { std::fill_n(&_arr[0][0], N * N, s); }
     explicit MatrixN(const S* begin, const S* end) { std::copy(begin, end, &_arr[0][0]); }
 
-    /// @name Equality Operators
+    /// @name Comparison Operators
     /// @{
 
     /// Return true if the given matrix is identical to this one.
     bool operator==(const M& rhs) const { return _arr == rhs._arr; }
 
-    /// Return true if the given vector differs from this one.
+    /// Return true if the given matrix differs from this one.
     bool operator!=(const M& rhs) const { return _arr != rhs._arr; }
 
     /// Return true if the given matrix is equivalent to this one

--- a/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.cpp
@@ -20,7 +20,8 @@ void BitangentNodeGlsl::createVariables(const ShaderNode& node, GenContext&, Sha
     ShaderStage& vs = shader.getStage(Stage::VERTEX);
     ShaderStage& ps = shader.getStage(Stage::PIXEL);
 
-    addStageInput(HW::VERTEX_INPUTS, Type::VECTOR3, HW::T_IN_BITANGENT, vs);
+    addStageInput(HW::VERTEX_INPUTS, Type::VECTOR3, HW::T_IN_NORMAL, vs);
+    addStageInput(HW::VERTEX_INPUTS, Type::VECTOR3, HW::T_IN_TANGENT, vs);
 
     const ShaderInput* spaceInput = node.getInput(SPACE);
     const int space = spaceInput ? spaceInput->getValue()->asA<int>() : OBJECT_SPACE;
@@ -51,7 +52,8 @@ void BitangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
             if (!bitangent->isEmitted())
             {
                 bitangent->setEmitted();
-                shadergen.emitLine(prefix + bitangent->getVariable() + " = (" + HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX + " * vec4(" + HW::T_IN_BITANGENT + ",0.0)).xyz", stage);
+                shadergen.emitLine(prefix + bitangent->getVariable() +
+                    " = (" + HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX + " * vec4(cross(" + HW::T_IN_NORMAL + ", " + HW::T_IN_TANGENT + "), 0.0)).xyz", stage);
             }
         }
         else
@@ -60,7 +62,7 @@ void BitangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
             if (!bitangent->isEmitted())
             {
                 bitangent->setEmitted();
-                shadergen.emitLine(prefix + bitangent->getVariable() + " = " + HW::T_IN_BITANGENT, stage);
+                shadergen.emitLine(prefix + bitangent->getVariable() + " = cross(" + HW::T_IN_NORMAL + ", " + HW::T_IN_TANGENT + ")", stage);
             }
         }
     END_SHADER_STAGE(stage, Stage::VERTEX)

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -20,7 +20,6 @@ namespace HW
     const string T_IN_POSITION                    = "$inPosition";
     const string T_IN_NORMAL                      = "$inNormal";
     const string T_IN_TANGENT                     = "$inTangent";
-    const string T_IN_BITANGENT                   = "$inBitangent";
     const string T_IN_TEXCOORD                    = "$inTexcoord";
     const string T_IN_COLOR                       = "$inColor";
     const string T_POSITION_WORLD                 = "$positionWorld";
@@ -71,7 +70,6 @@ namespace HW
     const string IN_POSITION                      = "i_position";
     const string IN_NORMAL                        = "i_normal";
     const string IN_TANGENT                       = "i_tangent";
-    const string IN_BITANGENT                     = "i_bitangent";
     const string IN_TEXCOORD                      = "i_texcoord";
     const string IN_COLOR                         = "i_color";
     const string POSITION_WORLD                   = "positionWorld";
@@ -150,7 +148,6 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax) :
     _tokenSubstitutions[HW::T_IN_POSITION] = HW::IN_POSITION;
     _tokenSubstitutions[HW::T_IN_NORMAL] = HW::IN_NORMAL;
     _tokenSubstitutions[HW::T_IN_TANGENT] = HW::IN_TANGENT;
-    _tokenSubstitutions[HW::T_IN_BITANGENT] = HW::IN_BITANGENT;
     _tokenSubstitutions[HW::T_IN_TEXCOORD] = HW::IN_TEXCOORD;
     _tokenSubstitutions[HW::T_IN_COLOR] = HW::IN_COLOR;
     _tokenSubstitutions[HW::T_POSITION_WORLD] = HW::POSITION_WORLD;

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -86,7 +86,6 @@ namespace HW
     extern const string T_IN_POSITION;
     extern const string T_IN_NORMAL;
     extern const string T_IN_TANGENT;
-    extern const string T_IN_BITANGENT;
     extern const string T_IN_TEXCOORD;
     extern const string T_IN_COLOR;
     extern const string T_POSITION_WORLD;
@@ -139,7 +138,6 @@ namespace HW
     extern const string IN_POSITION;
     extern const string IN_NORMAL;
     extern const string IN_TANGENT;
-    extern const string IN_BITANGENT;
     extern const string IN_TEXCOORD;
     extern const string IN_COLOR;
     extern const string POSITION_WORLD;

--- a/source/MaterialXRender/Mesh.h
+++ b/source/MaterialXRender/Mesh.h
@@ -82,16 +82,28 @@ class MeshStream
         return _index;
     }
 
-    /// Get stream data
+    /// Return the raw float vector
     MeshFloatBuffer& getData()
     {
         return _data;
     }
 
-    /// Get stream data
+    /// Return the raw float vector
     const MeshFloatBuffer& getData() const
     {
         return _data;
+    }
+
+    // Return the typed element at the given index
+    template <class T> T& getElement(size_t index)
+    {
+        return reinterpret_cast<T*>(getData().data())[index];
+    }
+
+    // Return the typed element at the given index
+    template <class T> const T& getElement(size_t index) const
+    {
+        return reinterpret_cast<const T*>(getData().data())[index];
     }
 
     /// Get stride between elements
@@ -275,6 +287,16 @@ class Mesh
         _streams.push_back(stream);
     }
 
+    /// Remove a mesh stream
+    void removeStream(MeshStreamPtr stream)
+    {
+        auto it = std::find(_streams.begin(), _streams.end(), stream);
+        if (it != _streams.end())
+        {
+            _streams.erase(it);
+        }
+    }
+
     /// Set vertex count
     void setVertexCount(size_t val)
     {
@@ -353,16 +375,17 @@ class Mesh
         return _partitions[partIndex];
     }
 
-    /// Generate tangents and optionally bitangents for a given
-    /// set of positions, texture coordinates and normals.
-    /// @param positionStream Positions to use
-    /// @param texcoordStream Texture coordinates to use
-    /// @param normalStream Normals to use
-    /// @param tangentStream Tangents to produce
-    /// @param bitangentStream Bitangents to produce.
-    /// Returns true if successful.
-    bool generateTangents(MeshStreamPtr positionStream, MeshStreamPtr texcoordStream, MeshStreamPtr normalStream,
-                          MeshStreamPtr tangentStream, MeshStreamPtr bitangentStream);
+    /// Generate face normals from the given positions.
+    /// @param positionStream Input position stream
+    /// @return The generated normal stream
+    MeshStreamPtr generateNormals(MeshStreamPtr positionStream);
+
+    /// Generate tangents from the given positions, normals, and texture coordinates.
+    /// @param positionStream Input position stream
+    /// @param normalStream Input normal stream
+    /// @param texcoordStream Input texcoord stream
+    /// @return The generated tangent stream, on success; otherwise, a null pointer.
+    MeshStreamPtr generateTangents(MeshStreamPtr positionStream, MeshStreamPtr normalStream, MeshStreamPtr texcoordStream);
 
     /// Merge all mesh partitions into one.
     void mergePartitions();

--- a/source/MaterialXRender/TinyObjLoader.cpp
+++ b/source/MaterialXRender/TinyObjLoader.cpp
@@ -20,9 +20,21 @@
 #endif
 
 #include <iostream>
+#include <map>
 
 namespace MaterialX
 {
+
+namespace {
+
+const float MAX_FLOAT = std::numeric_limits<float>::max();
+const size_t FACE_VERTEX_COUNT = 3;
+
+} // anonymous namespace
+
+//
+// TinyObjLoader methods
+//
 
 bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
 {
@@ -37,10 +49,7 @@ bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
         std::cerr << err << std::endl;
         return false;
     }
-
-    size_t vertComponentCount = std::max(attrib.vertices.size(), attrib.normals.size());
-    size_t vertexCount = vertComponentCount / MeshStream::STRIDE_3D;
-    if (!vertexCount)
+    if (!attrib.vertices.size())
     {
         return false;
     }
@@ -48,46 +57,21 @@ bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
     MeshPtr mesh = Mesh::create(filePath);
     meshList.push_back(mesh);
     mesh->setSourceUri(filePath);
+
     MeshStreamPtr positionStream = MeshStream::create("i_" + MeshStream::POSITION_ATTRIBUTE, MeshStream::POSITION_ATTRIBUTE, 0);
-    MeshFloatBuffer& positions = positionStream->getData();
-    mesh->addStream(positionStream);
-
     MeshStreamPtr normalStream = MeshStream::create("i_" + MeshStream::NORMAL_ATTRIBUTE, MeshStream::NORMAL_ATTRIBUTE, 0);
-    MeshFloatBuffer& normals = normalStream->getData();
-    mesh->addStream(normalStream);
+    MeshStreamPtr texcoordStream = MeshStream::create("i_" + MeshStream::TEXCOORD_ATTRIBUTE + "_0", MeshStream::TEXCOORD_ATTRIBUTE, 0);
+    texcoordStream->setStride(MeshStream::STRIDE_2D);
 
-    MeshStreamPtr texCoordStream = MeshStream::create("i_" + MeshStream::TEXCOORD_ATTRIBUTE + "_0", MeshStream::TEXCOORD_ATTRIBUTE, 0);
-    texCoordStream->setStride(MeshStream::STRIDE_2D);
-    MeshFloatBuffer& texcoords = texCoordStream->getData();
-    mesh->addStream(texCoordStream);
+    using VertexTuple = std::tuple<Vector3, Vector3, Vector2>;
+    using VertexIndexMap = std::map<VertexTuple, uint32_t>;
+    VertexIndexMap vertexIndexMap;
 
-    MeshStreamPtr tangentStream = MeshStream::create("i_" + MeshStream::TANGENT_ATTRIBUTE, MeshStream::TANGENT_ATTRIBUTE, 0);
-    tangentStream->setStride(MeshStream::STRIDE_3D);
-    MeshFloatBuffer& tangents = tangentStream->getData();
-    mesh->addStream(tangentStream);
-
-    // Explode the geometry, since we may have unshared geometry
-    // in position, normal or uv
-    size_t totalIndexCount = 0;
-    for (const tinyobj::shape_t& shape : shapes)
-    {
-        totalIndexCount += shape.mesh.indices.size();
-    }
-    positions.resize(totalIndexCount * MeshStream::STRIDE_3D);
-    normals.resize(totalIndexCount * MeshStream::STRIDE_3D);
-    texcoords.resize(totalIndexCount * MeshStream::STRIDE_2D);
-    tangents.resize(totalIndexCount * MeshStream::STRIDE_3D);
-    mesh->setVertexCount(totalIndexCount);
-
-    const float MAX_FLOAT = std::numeric_limits<float>::max();
     Vector3 boxMin = { MAX_FLOAT, MAX_FLOAT, MAX_FLOAT };
     Vector3 boxMax = { -MAX_FLOAT, -MAX_FLOAT, -MAX_FLOAT };
 
-    uint32_t writeIndex0 = 0;
-    uint32_t writeIndex1 = 1;
-    uint32_t writeIndex2 = 2;
-
-    const size_t FACE_VERTEX_COUNT = 3;
+    uint32_t nextVertexIndex = 0;
+    bool normalsFound = false;
     for (const tinyobj::shape_t& shape : shapes)
     {
         size_t indexCount = shape.mesh.indices.size();
@@ -99,110 +83,88 @@ bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
 
         MeshPartitionPtr part = MeshPartition::create();
         part->setIdentifier(shape.name);
-        MeshIndexBuffer& indices = part->getIndices();
-        indices.resize(shape.mesh.indices.size());
         part->setFaceCount(faceCount);
         mesh->addPartition(part);
 
-        for (size_t faceIndex = 0; faceIndex < faceCount; faceIndex++)
-        {
-            const tinyobj::index_t& indexObj0 = shape.mesh.indices[faceIndex * 3 + 0];
-            const tinyobj::index_t& indexObj1 = shape.mesh.indices[faceIndex * 3 + 1];
-            const tinyobj::index_t& indexObj2 = shape.mesh.indices[faceIndex * 3 + 2];
- 
-            // Copy indices.
-            indices[faceIndex * MeshStream::STRIDE_3D + 0] = writeIndex0;
-            indices[faceIndex * MeshStream::STRIDE_3D + 1] = writeIndex1;
-            indices[faceIndex * MeshStream::STRIDE_3D + 2] = writeIndex2;
+        MeshIndexBuffer& indices = part->getIndices();
+        indices.resize(indexCount);
 
-            // Copy positions and compute bounding box.
-            Vector3 v[MeshStream::STRIDE_3D];
+        for (size_t i = 0; i < shape.mesh.indices.size(); i++)
+        {
+            const tinyobj::index_t& indexObj = shape.mesh.indices[i];
+
+            // Read vertex components.
+            Vector3 position, normal;
+            Vector2 texcoord;
             for (unsigned int k = 0; k < MeshStream::STRIDE_3D; k++)
             {
-                v[0][k] = attrib.vertices[indexObj0.vertex_index * MeshStream::STRIDE_3D + k];
-                v[1][k] = attrib.vertices[indexObj1.vertex_index * MeshStream::STRIDE_3D + k];
-                v[2][k] = attrib.vertices[indexObj2.vertex_index * MeshStream::STRIDE_3D + k];
-
-                boxMin[k] = std::min(v[0][k], boxMin[k]);
-                boxMin[k] = std::min(v[1][k], boxMin[k]);
-                boxMin[k] = std::min(v[2][k], boxMin[k]);
-
-                boxMax[k] = std::max(v[0][k], boxMax[k]);
-                boxMax[k] = std::max(v[1][k], boxMax[k]);
-                boxMax[k] = std::max(v[2][k], boxMax[k]);
-            }
-
-            Vector3* pos = reinterpret_cast<Vector3*>(&(positions[writeIndex0 * MeshStream::STRIDE_3D]));
-            *pos = v[0];
-            pos = reinterpret_cast<Vector3*>(&(positions[writeIndex1 * MeshStream::STRIDE_3D]));
-            *pos = v[1];
-            pos = reinterpret_cast<Vector3*>(&(positions[writeIndex2 * MeshStream::STRIDE_3D]));
-            *pos = v[2];
-
-            // Copy or compute normals
-            Vector3 n[3];
-            if (indexObj0.normal_index >= 0 &&
-                indexObj1.normal_index >= 0 &&
-                indexObj2.normal_index >= 0)
-            {
-                for (int k = 0; k < 3; k++)
+                position[k] = attrib.vertices[indexObj.vertex_index * MeshStream::STRIDE_3D + k];
+                if (indexObj.normal_index >= 0)
                 {
-                    n[0][k] = attrib.normals[indexObj0.normal_index * MeshStream::STRIDE_3D + k];
-                    n[1][k] = attrib.normals[indexObj1.normal_index * MeshStream::STRIDE_3D + k];
-                    n[2][k] = attrib.normals[indexObj2.normal_index * MeshStream::STRIDE_3D + k];
+                    normal[k] = attrib.normals[indexObj.normal_index * MeshStream::STRIDE_3D + k];
+                    normalsFound = true;
                 }
-            }
-            else
-            {
-                Vector3 faceNorm = (v[1] - v[0]).cross(v[2] - v[0]).getNormalized();
-                n[0] = faceNorm;
-                n[1] = faceNorm;
-                n[2] = faceNorm;
-            }
-
-            Vector3* norm = reinterpret_cast<Vector3*>(&(normals[writeIndex0 * MeshStream::STRIDE_3D]));
-            *norm = n[0];
-            norm = reinterpret_cast<Vector3*>(&(normals[writeIndex1 * MeshStream::STRIDE_3D]));
-            *norm = n[1];
-            norm = reinterpret_cast<Vector3*>(&(normals[writeIndex2 * MeshStream::STRIDE_3D]));
-            *norm = n[2];
-
-            // Copy texture coordinates.
-            Vector2 t[3];
-            if (indexObj0.texcoord_index >= 0 &&
-                indexObj1.texcoord_index >= 0 &&
-                indexObj2.texcoord_index >= 0)
-            {
-                for (int k = 0; k < 2; k++)
+                if (indexObj.texcoord_index >= 0 && k < MeshStream::STRIDE_2D)
                 {
-                    t[0][k] = attrib.texcoords[indexObj0.texcoord_index * MeshStream::STRIDE_2D + k];
-                    t[1][k] = attrib.texcoords[indexObj1.texcoord_index * MeshStream::STRIDE_2D + k];
-                    t[2][k] = attrib.texcoords[indexObj2.texcoord_index * MeshStream::STRIDE_2D + k];
+                    texcoord[k] = attrib.texcoords[indexObj.texcoord_index * MeshStream::STRIDE_2D + k];
                 }
             }
 
-            Vector2* texcoord = reinterpret_cast<Vector2*>(&(texcoords[writeIndex0 * MeshStream::STRIDE_2D]));
-            *texcoord = t[0];
-            texcoord = reinterpret_cast<Vector2*>(&(texcoords[writeIndex1 * MeshStream::STRIDE_2D]));
-            *texcoord = t[1];
-            texcoord = reinterpret_cast<Vector2*>(&(texcoords[writeIndex2 * MeshStream::STRIDE_2D]));
-            *texcoord = t[2];
+            // Check for duplicate vertices.
+            VertexTuple tuple(position, normal, texcoord);
+            VertexIndexMap::iterator it = vertexIndexMap.find(tuple);
+            if (it != vertexIndexMap.end())
+            {
+                indices[i] = it->second;
+                continue;
+            }
+            vertexIndexMap[tuple] = nextVertexIndex;
 
-            writeIndex0 += MeshStream::STRIDE_3D;
-            writeIndex1 += MeshStream::STRIDE_3D;
-            writeIndex2 += MeshStream::STRIDE_3D;
+            // Store vertex components.
+            for (unsigned int k = 0; k < MeshStream::STRIDE_3D; k++)
+            {
+                positionStream->getData().push_back(position[k]);
+                normalStream->getData().push_back(normal[k]);
+                if (k < MeshStream::STRIDE_2D)
+                {
+                    texcoordStream->getData().push_back(texcoord[k]);
+                }
+
+                // Update bounds.
+                boxMin[k] = std::min(position[k], boxMin[k]);
+                boxMax[k] = std::max(position[k], boxMax[k]);
+            }
+
+            // Store index data.
+            indices[i] = nextVertexIndex++;
         }
     }
 
+    // Generate normals if needed.
+    if (!normalsFound)
+    {
+        normalStream = mesh->generateNormals(positionStream);
+    }
+
+    // Generate tangents.
+    MeshStreamPtr tangentStream = mesh->generateTangents(positionStream, normalStream, texcoordStream);
+
+    // Assign streams to mesh.
+    mesh->addStream(positionStream);
+    mesh->addStream(normalStream);
+    mesh->addStream(texcoordStream);
+    if (tangentStream)
+    {
+        mesh->addStream(tangentStream);
+    }
+
+    // Assign properties to mesh.
+    mesh->setVertexCount(positionStream->getData().size() / MeshStream::STRIDE_3D);
     mesh->setMinimumBounds(boxMin);
     mesh->setMaximumBounds(boxMax);
     Vector3 sphereCenter = (boxMax + boxMin) * 0.5;
     mesh->setSphereCenter(sphereCenter);
     mesh->setSphereRadius((sphereCenter - boxMin).getMagnitude());
-
-    MeshStreamPtr bitangentStream = MeshStream::create("i_" + MeshStream::BITANGENT_ATTRIBUTE, MeshStream::BITANGENT_ATTRIBUTE, 0);
-    mesh->generateTangents(positionStream, texCoordStream, normalStream, tangentStream, bitangentStream);
-    mesh->addStream(bitangentStream);
 
     return true;
 }

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -445,13 +445,6 @@ void GlslProgram::bindStreams(MeshPtr mesh)
         bindAttribute(foundList, mesh);
     }
 
-    // Bind bitangents
-    findInputs(HW::IN_BITANGENT, attributeList, foundList, true);
-    if (foundList.size())
-    {
-        bindAttribute(foundList, mesh);
-    }
-
     // Bind colors
     // Search for anything that starts with the color prefix
     findInputs(HW::IN_COLOR + "_", attributeList, foundList, false);

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -223,13 +223,23 @@ void GlslShaderRenderTester::transformUVs(const mx::MeshList& meshes, const mx::
 {
     for(mx::MeshPtr mesh : meshes)
     {
+        // Transform texture coordinates.
         mx::MeshStreamPtr uvStream = mesh->getStream(mx::MeshStream::TEXCOORD_ATTRIBUTE, 0);
         uvStream->transform(matrixTransform);
-        mx::MeshStreamPtr positionStream = mesh->getStream(mx::MeshStream::POSITION_ATTRIBUTE, 0);
-        mx::MeshStreamPtr normalStream = mesh->getStream(mx::MeshStream::NORMAL_ATTRIBUTE, 0);
+
+        // Regenerate tangents
         mx::MeshStreamPtr tangentStream = mesh->getStream(mx::MeshStream::TANGENT_ATTRIBUTE, 0);
-        mx::MeshStreamPtr bitangentStream = mesh->getStream(mx::MeshStream::BITANGENT_ATTRIBUTE, 0);
-        mesh->generateTangents(positionStream, uvStream, normalStream, tangentStream, bitangentStream);
+        if (tangentStream)
+        {
+            mesh->removeStream(tangentStream);
+            tangentStream = mesh->generateTangents(mesh->getStream(mx::MeshStream::POSITION_ATTRIBUTE, 0),
+                                                   mesh->getStream(mx::MeshStream::NORMAL_ATTRIBUTE, 0),
+                                                   uvStream);
+            if (tangentStream)
+            {
+                mesh->addStream(tangentStream);
+            }
+        }
     }
 }
 

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -199,13 +199,6 @@ void Material::bindMesh(mx::MeshPtr mesh) const
         MatrixXfProxy tangents(&buffer[0], stream->getStride(), buffer.size() / stream->getStride());
         _glShader->uploadAttrib(mx::HW::IN_TANGENT, tangents);
     }
-    if (_glShader->attrib(mx::HW::IN_BITANGENT, false) != -1)
-    {
-        mx::MeshStreamPtr stream = mesh->getStream(mx::MeshStream::BITANGENT_ATTRIBUTE, 0);
-        mx::MeshFloatBuffer &buffer = stream->getData();
-        MatrixXfProxy bitangents(&buffer[0], stream->getStride(), buffer.size() / stream->getStride());
-        _glShader->uploadAttrib(mx::HW::IN_BITANGENT, bitangents);
-    }
     const std::string texcoord = mx::HW::IN_TEXCOORD + "_0";
     if (_glShader->attrib(texcoord, false) != -1)
     {


### PR DESCRIPTION
- Detect and skip duplicate vertices in TinyObjLoader::load, providing more accurate adjacency data for tangent frame generation.
- On hardware shading targets, generate bitangents in the vertex shader rather than storing them as an independent data stream.
- Refactor Mesh::generateTangents for improved robustness and clarity.

Supporting changes:

- Add a VectorN less-than operator, allowing vectors to be used as map keys.
- Add a MeshStream::getElement method to simplify geometry processing logic.