### PR TITLE
Align behaviors of setConnectedNode methods

### DIFF
--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -217,7 +217,8 @@ class PortElement : public ValueElement
     /// @{
 
     /// Set the node to which this element is connected.  The given node must
-    /// belong to the same node graph.
+    /// belong to the same node graph.  If the node argument is null, then
+    /// any existing node connection will be cleared.
     void setConnectedNode(NodePtr node);
 
     /// Return the node, if any, to which this element is connected.

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -27,15 +27,12 @@ void Node::setConnectedNode(const string& inputName, NodePtr node)
     if (!input)
     {
         input = addInput(inputName);
-        if (node)
-        {
-            input->setType(node->getType());
-        }
     }
     if (node)
     {
-        input->setConnectedNode(node);
+        input->setType(node->getType());
     }
+    input->setConnectedNode(node);
 }
 
 NodePtr Node::getConnectedNode(const string& inputName) const

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -58,8 +58,9 @@ class Node : public InterfaceElement
     /// @name Connections
     /// @{
 
-    /// Set the Node connected to the given input, creating a child element
-    /// for the input if needed.
+    /// Set the node to which the given input is connected, creating a
+    /// child input if needed.  If the node argument is null, then any
+    /// existing node connection on the input will be cleared.
     void setConnectedNode(const string& inputName, NodePtr node);
 
     /// Return the Node connected to the given input.  If the given input is


### PR DESCRIPTION
Align the behaviors of PortElement::setConnectedNode and Node::setConnectedNode, clarifying that a null NodePtr argument will clear any existing node connection.