### PR TITLE
Add command-line options for mesh and light rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,20 @@
 ## [1.37.1] - Development
 
 ### Added
+- Added command-line options '--meshRotation' and '--lightRotation' to the viewer.
+- Added a Light Rotation slider to the Advanced Settings panel of the viewer.
 - Added initial support for wedge rendering in the viewer.
 - Added utility methods Backdrop\:\:setContainsElements and Backdrop\:\:getContainsElements.
 - Added backwards compatibility for OpenImageIO 1.x.
 
 ### Changed
-- Updated the GLSL implementation of Smith masking-shadowing from uncorrelated to height-correlated forms.
+- Improved energy compensation and preservation computations in generated GLSL.
+- Upgraded Smith masking-shadowing to height-correlated form in generated GLSL.
+- Improved the robustness of tangent frame computations in MaterialXRender.
 - Renamed Backdrop\:\:setContains and getContains to Backdrop\:\:setContainsString and getContainsString for consistency.
+
+### Fixed
+- Fixed comparison order in the upgrade path for compare nodes in v1.36 documents.
 
 ## [1.37.0] - 2020-03-20
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -38,6 +38,7 @@ The following is the layout of the definitions and implementations provided as p
 
 ## Support Notes:
 - GLSL language support is for version 4.0 or higher.
+- OSL language support is for version 1.9.10 or higher.
 - "default" color management support includes OSL and GLSL implementations for the following non-LUT transforms:
     - lin_rec709, gamma18, gamma22, gamma24, acescg, srgb_texture
 - Basic GLSL `lightshader` node definitions and implementations are provided for the following light types:

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -192,6 +192,15 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
         return *this;
     }
 
+    /// Unary negation of a vector.
+    V operator-()
+    {
+        V res(Uninit{});
+        for (size_t i = 0; i < N; i++)
+            res[i] = -_arr[i];
+        return res;
+    }
+
     /// @}
     /// @name Geometric Methods
     /// @{

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -32,6 +32,15 @@ class DocumentModifiers
     std::string filePrefixTerminator;
 };
 
+class LightingState
+{
+  public:
+    mx::Matrix44 lightTransform;
+    bool directLighting = true;
+    bool indirectLighting = true;
+    int envSamples = 16;
+};
+
 class ShadowState
 {
   public:
@@ -160,7 +169,7 @@ class Material
 
     /// Bind lights to shader.
     void bindLights(const mx::GenContext& genContext, mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr imageHandler,
-                    bool directLighting, bool indirectLighting, const ShadowState& shadowState, int envSamples);
+                    const LightingState& lightingState, const ShadowState& shadowState);
 
     /// Bind units.
     void bindUnits(mx::UnitConverterRegistryPtr& registry, const mx::GenContext& context);

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -22,11 +22,13 @@ class Viewer : public ng::Screen
   public:
     Viewer(const std::string& materialFilename,
            const std::string& meshFilename,
+           const mx::Vector3& meshRotation,
            const mx::FilePathVec& libraryFolders,
            const mx::FileSearchPath& searchPath,
            const DocumentModifiers& modifiers,
            mx::HwSpecularEnvironmentMethod specularEnvironmentMethod,
            const std::string& envRadiancePath,
+           float lightRotation,
            int multiSampleCount);
     ~Viewer() { }
 
@@ -143,9 +145,9 @@ class Viewer : public ng::Screen
     float _farDist;
     float _cameraYaw;
 
-    float _modelZoom;
-    mx::Vector3 _modelTranslation;
-    float _modelYaw;
+    float _meshZoom;
+    mx::Vector3 _meshTranslation;
+    mx::Vector3 _meshRotation;
 
     float _userZoom;
     mx::Vector3 _userTranslation;
@@ -165,6 +167,7 @@ class Viewer : public ng::Screen
     mx::FilePath _envRadiancePath;
     mx::FilePath _lightRigFilename;
     mx::DocumentPtr _lightRigDoc;
+    float _lightRotation;
     bool _directLighting;
     bool _indirectLighting;
 
@@ -236,7 +239,6 @@ class Viewer : public ng::Screen
     bool _outlineSelection;
     int _envSamples;
     bool _drawEnvironment;
-    mx::Matrix44 _envMatrix;
 
     // Frame capture
     bool _captureRequested;


### PR DESCRIPTION
- Add command-line options '--meshRotation' and '--lightRotation' to the viewer.
- Add a Light Rotation slider to the Advanced Settings panel of the viewer.

Supporting changes:

- Add support for unary negation of a VectorN.
- Add error reporting for viewer command-line options.