### PR TITLE
Add command-line options for camera position and target

### DIFF
--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -193,7 +193,7 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
     }
 
     /// Unary negation of a vector.
-    V operator-()
+    V operator-() const
     {
         V res(Uninit{});
         for (size_t i = 0; i < N; i++)

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -9,6 +9,9 @@ const std::string options =
 "    --material [FILENAME]          Specify the displayed material\n"
 "    --mesh [FILENAME]              Specify the displayed geometry\n"
 "    --meshRotation [VECTOR3]       Specify the rotation of the displayed geometry as three comma-separated floats (e.g. '0,90,0'), representing rotations in degrees about the X, Y, and Z axes.\n"
+"    --meshScale [FLOAT]            Specify the scale of the displayed geometry.\n"
+"    --cameraPosition [VECTOR3]     Specify the position of the camera as three comma-separated floats.\n"
+"    --cameraTarget [VECTOR3]       Specify the position of the camera target as three comma-separated floats.\n"
 "    --envRad [FILENAME]            Specify the displayed environment light, stored as HDR environment radiance in the latitude-longitude format\n"
 "    --envMethod [INTEGER]          Specify the environment lighting method (0 = filtered importance sampling, 1 = prefiltered environment maps, Default is 0)\n"
 "    --lightRotation [FLOAT]        Specify the rotation in degrees of the lighting environment about the Y axis.\n"
@@ -35,12 +38,15 @@ int main(int argc, char* const argv[])
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx";
     std::string meshFilename = "resources/Geometry/shaderball.obj";
     mx::Vector3 meshRotation;
+    float meshScale = 1.0f;
+    mx::Vector3 cameraPosition(DEFAULT_CAMERA_POSITION);
+    mx::Vector3 cameraTarget(0.0f);
     std::string envRadiancePath = "resources/Lights/san_giuseppe_bridge_split.hdr";
+    mx::HwSpecularEnvironmentMethod specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
     float lightRotation = 0.0f;
     DocumentModifiers modifiers;
     int multiSampleCount = 0;
     int refresh = 50;
-    mx::HwSpecularEnvironmentMethod specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
 
     for (size_t i = 0; i < tokens.size(); i++)
     {
@@ -60,6 +66,42 @@ int main(int argc, char* const argv[])
             if (value)
             {
                 meshRotation = value->asA<mx::Vector3>();
+            }
+            else if (!nextToken.empty())
+            {
+                std::cout << "Unable to parse token following command-line option: " << token << std::endl;
+            }
+        }
+        else if (token == "--meshScale")
+        {
+            mx::ValuePtr value = mx::Value::createValueFromStrings(nextToken, "float");
+            if (value)
+            {
+                meshScale = value->asA<float>();
+            }
+            else if (!nextToken.empty())
+            {
+                std::cout << "Unable to parse token following command-line option: " << token << std::endl;
+            }
+        }
+        else if (token == "--cameraPosition")
+        {
+            mx::ValuePtr value = mx::Value::createValueFromStrings(nextToken, "vector3");
+            if (value)
+            {
+                cameraPosition = value->asA<mx::Vector3>();
+            }
+            else if (!nextToken.empty())
+            {
+                std::cout << "Unable to parse token following command-line option: " << token << std::endl;
+            }
+        }
+        else if (token == "--cameraTarget")
+        {
+            mx::ValuePtr value = mx::Value::createValueFromStrings(nextToken, "vector3");
+            if (value)
+            {
+                cameraTarget = value->asA<mx::Vector3>();
             }
             else if (!nextToken.empty())
             {
@@ -162,12 +204,15 @@ int main(int argc, char* const argv[])
             ng::ref<Viewer> viewer = new Viewer(materialFilename,
                                                 meshFilename,
                                                 meshRotation,
+                                                meshScale,
+                                                cameraPosition,
+                                                cameraTarget,
+                                                envRadiancePath,
+                                                specularEnvironmentMethod,
+                                                lightRotation,
                                                 libraryFolders,
                                                 searchPath,
                                                 modifiers,
-                                                specularEnvironmentMethod,
-                                                envRadiancePath,
-                                                lightRotation,
                                                 multiSampleCount);
             viewer->setVisible(true);
             ng::mainloop(refresh);

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -2,17 +2,17 @@
 
 #include <MaterialXRenderGlsl/GLTextureHandler.h>
 
-#include <MaterialXGenShader/HwShaderGenerator.h>
-#include <MaterialXGenShader/Shader.h>
-
 #include <MaterialXRender/Util.h>
 
-#include <MaterialXFormat/File.h>
+#include <MaterialXGenShader/Shader.h>
+
 #include <MaterialXFormat/Util.h>
 
 #include <nanogui/messagedialog.h>
 
 #include <iostream>
+
+namespace {
 
 using MatrixXfProxy = Eigen::Map<const ng::MatrixXf>;
 using MatrixXuProxy = Eigen::Map<const ng::MatrixXu>;
@@ -20,6 +20,8 @@ using MatrixXuProxy = Eigen::Map<const ng::MatrixXu>;
 const mx::Color4 IMAGE_DEFAULT_COLOR(0, 0, 0, 1);
 
 const float PI = std::acos(-1.0f);
+
+} // anonymous namespace
 
 //
 // Material methods

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -23,12 +23,15 @@ class Viewer : public ng::Screen
     Viewer(const std::string& materialFilename,
            const std::string& meshFilename,
            const mx::Vector3& meshRotation,
+           float meshScale,
+           const mx::Vector3& cameraPosition,
+           const mx::Vector3& cameraTarget,
+           const std::string& envRadiancePath,
+           mx::HwSpecularEnvironmentMethod specularEnvironmentMethod,
+           float lightRotation,
            const mx::FilePathVec& libraryFolders,
            const mx::FileSearchPath& searchPath,
            const DocumentModifiers& modifiers,
-           mx::HwSpecularEnvironmentMethod specularEnvironmentMethod,
-           const std::string& envRadiancePath,
-           float lightRotation,
            int multiSampleCount);
     ~Viewer() { }
 
@@ -137,23 +140,23 @@ class Viewer : public ng::Screen
     ng::Window* _window;
     ng::Arcball _arcball;
 
-    mx::Vector3 _eye;
-    mx::Vector3 _center;
-    mx::Vector3 _up;
-    float _viewAngle;
-    float _nearDist;
-    float _farDist;
-    float _cameraYaw;
-
-    float _meshZoom;
     mx::Vector3 _meshTranslation;
     mx::Vector3 _meshRotation;
+    float _meshScale;
 
-    float _userZoom;
+    mx::Vector3 _cameraPosition;
+    mx::Vector3 _cameraTarget;
+    mx::Vector3 _cameraUp;
+    float _cameraViewAngle;
+    float _cameraNearDist;
+    float _cameraFarDist;
+
+    bool _userCameraEnabled;
     mx::Vector3 _userTranslation;
     mx::Vector3 _userTranslationStart;
     bool _userTranslationActive;
     ng::Vector2i _userTranslationPixel;
+    float _userScale;
 
     // Document management
     mx::FilePathVec _libraryFolders;
@@ -256,5 +259,7 @@ class Viewer : public ng::Screen
     bool _bakeRequested;
     mx::FilePath _bakeFilename;
 };
+
+extern const mx::Vector3 DEFAULT_CAMERA_POSITION;
 
 #endif // MATERIALXVIEW_VIEWER_H


### PR DESCRIPTION
- Add command-line options '--cameraPosition', '--cameraTarget', and '--meshScale' to the viewer.
- Generalize shadow transform for arbitrary camera placement.
- Mark the vector negation operator as const.