### PR TITLE
Add support for vector hashing

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -751,6 +751,17 @@ bool targetStringsMatch(const string& target1, const string& target2)
     return !matches.empty();
 }
 
+string prettyPrint(ConstElementPtr elem)
+{
+    string text;
+    for (TreeIterator it = elem->traverseTree().begin(); it != TreeIterator::end(); ++it)
+    {
+        string indent(it.getElementDepth() * 2, ' ');
+        text += indent + it.getElement()->asString() + "\n";
+    }
+    return text;
+}
+
 //
 // Element registry class
 //

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1403,6 +1403,10 @@ template<class T> shared_ptr<T> Element::addChild(const string& name)
 /// matches all targets.
 bool targetStringsMatch(const string& target1, const string& target2);
 
+/// Pretty print the given element tree, calling asString recursively on each
+/// element in depth-first order.
+string prettyPrint(ConstElementPtr elem);
+
 } // namespace MaterialX
 
 #endif

--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -70,6 +70,12 @@ class Exception : public std::exception
     string _msg;
 };
 
+/// Combine the hash of an arbitrary value with an existing seed.
+template<typename T> void hashCombine(size_t& seed, const T& value)
+{
+    seed ^= std::hash<T>()(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+} 
+
 } // namespace MaterialX
 
 #endif

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -240,7 +240,7 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
     ConstIterator end() const { return _arr.end(); }
 
     /// @}
-    /// @name Data Pointers
+    /// @name Utility
     /// @{
 
     /// Return a pointer to the underlying data array.
@@ -248,6 +248,19 @@ template <class V, class S, size_t N> class VectorN : public VectorBase
 
     /// Return a const pointer to the underlying data array.
     const S* data() const { return _arr.data(); }
+
+    /// Function object for hashing vectors.
+    class Hash
+    {
+      public:
+        size_t operator()(const V& v) const noexcept
+        {
+            size_t h = 0;
+            for (size_t i = 0; i < N; i++)
+                hashCombine(h, v[i]);
+            return h;
+        }
+    };
 
     /// @}
     /// @name Static Methods
@@ -549,7 +562,7 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
     ConstIterator end() const { return _arr.end(); }
 
     /// @}
-    /// @name Data Pointers
+    /// @name Utility
     /// @{
 
     /// Return a pointer to the underlying data array.

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXCore/Util.h>
 
-#include <MaterialXCore/Element.h>
-
 #include <cctype>
 
 namespace MaterialX
@@ -126,17 +124,6 @@ bool stringEndsWith(const string& str, const string& suffix)
         return !str.compare(str.length() - suffix.length(), suffix.length(), suffix);
     }
     return false;
-}
-
-string prettyPrint(ConstElementPtr elem)
-{
-    string text;
-    for (TreeIterator it = elem->traverseTree().begin(); it != TreeIterator::end(); ++it)
-    {
-        string indent(it.getElementDepth() * 2, ' ');
-        text += indent + it.getElement()->asString() + "\n";
-    }
-    return text;
 }
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -16,11 +16,6 @@ namespace MaterialX
 
 extern const string EMPTY_STRING;
 
-class Element;
-
-using ElementPtr = shared_ptr<Element>;
-using ConstElementPtr = shared_ptr<const Element>;
-
 /// Return the version of the MaterialX library as a string.
 string getVersionString();
 
@@ -49,10 +44,6 @@ string stringToLower(string str);
 
 /// Return true if the given string ends with the given suffix.
 bool stringEndsWith(const string& str, const string& suffix);
-
-/// Pretty print the given element tree, calling asString recursively on each
-/// element in depth-first order.
-string prettyPrint(ConstElementPtr elem);
 
 } // namespace MaterialX
 

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -223,4 +223,5 @@ void bindPyElement(py::module& mod)
     py::register_exception<mx::ExceptionOrphanedElement>(mod, "ExceptionOrphanedElement");
 
     mod.def("targetStringsMatch", &mx::targetStringsMatch);
+    mod.def("prettyPrint", &mx::prettyPrint);
 }

--- a/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
@@ -23,5 +23,4 @@ void bindPyUtil(py::module& mod)
     mod.def("splitString", &mx::splitString);
     mod.def("replaceSubstrings", &mx::replaceSubstrings);
     mod.def("stringEndsWith", &mx::stringEndsWith);
-    mod.def("prettyPrint", &mx::prettyPrint);
 }


### PR DESCRIPTION
- Add support for hashing instances of VectorN classes, enabling their use as keys in unordered containers.
- Optimize TinyObjLoader::load by tracking duplicate vertices in an unordered map.
- Refactor MaterialXCore to remove unneeded dependencies.