### PR TITLE
Shading model fixes and improvements

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -26,7 +26,7 @@ float mx_burley_diffuse(vec3 L, vec3 V, vec3 N, float NdotL, float roughness)
     float F90 = 0.5 + (2.0 * roughness * mx_square(LdotH));
     float refL = mx_fresnel_schlick(NdotL, 1.0, F90);
     float refV = mx_fresnel_schlick(NdotV, 1.0, F90);
-    return refL * refV * M_PI_INV;
+    return refL * refV;
 }
 
 // Compute the directional albedo component of Burley diffuse for the given

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -838,17 +838,17 @@ void Document::upgradeVersion(bool applyFutureUpdates)
             else if (nodeCategory == "compare")
             {
                 node->setCategory("ifgreatereq");
-                ParameterPtr cutoff = node->getParameter("cutoff");
-                if (cutoff)
-                {
-                    InputPtr value1 = node->addInput("value1");
-                    value1->copyContentFrom(cutoff);
-                    node->removeChild(cutoff->getName());
-                }
                 InputPtr intest = node->getInput("intest");
                 if (intest)
                 {
-                    intest->setName("value2");
+                    intest->setName("value1");
+                }
+                ParameterPtr cutoff = node->getParameter("cutoff");
+                if (cutoff)
+                {
+                    InputPtr value2 = node->addInput("value2");
+                    value2->copyContentFrom(cutoff);
+                    node->removeChild(cutoff->getName());
                 }
                 InputPtr in1 = node->getInput("in1");
                 InputPtr in2 = node->getInput("in2");

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -61,8 +61,8 @@ int main(int argc, char* const argv[])
     mx::Vector3 meshRotation;
     float meshScale = 1.0f;
     mx::Vector3 cameraPosition(DEFAULT_CAMERA_POSITION);
-    mx::Vector3 cameraTarget(0.0f);
-    float cameraViewAngle(45.0f);
+    mx::Vector3 cameraTarget;
+    float cameraViewAngle(DEFAULT_CAMERA_VIEW_ANGLE);
     std::string envRadiancePath = "resources/Lights/san_giuseppe_bridge_split.hdr";
     mx::HwSpecularEnvironmentMethod specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
     float lightRotation = 0.0f;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 
 const mx::Vector3 DEFAULT_CAMERA_POSITION(0.0f, 0.0f, 5.0f);
+const float DEFAULT_CAMERA_VIEW_ANGLE = 45.0f;
 
 namespace {
 
@@ -572,6 +573,7 @@ void Viewer::createLoadMeshInterface(Widget* parent, const std::string& label)
                 _meshScale = 1.0f;
                 _cameraPosition = DEFAULT_CAMERA_POSITION;
                 _cameraTarget = mx::Vector3();
+                _cameraViewAngle = DEFAULT_CAMERA_VIEW_ANGLE;
                 initCamera();
 
                 _imageHandler->releaseRenderResources(_shadowMap);

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -265,5 +265,6 @@ class Viewer : public ng::Screen
 };
 
 extern const mx::Vector3 DEFAULT_CAMERA_POSITION;
+extern const float DEFAULT_CAMERA_VIEW_ANGLE;
 
 #endif // MATERIALXVIEW_VIEWER_H


### PR DESCRIPTION
- Remove an extra factor of PI in the analytic Burley diffuse term for generated GLSL.
- Improve the robustness of the upgrade path for v1.36 compare nodes.
- Reset camera view angle when a new mesh is loaded into the viewer.