### PR TITLE
Change reference to latest nanogui

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source/MaterialXView/NanoGUI"]
 	path = source/MaterialXView/NanoGUI
-	url = https://github.com/wjakob/nanogui
+	url = https://github.com/mitsuba-renderer/nanogui.git


### PR DESCRIPTION
The new version of nanogui works as a simple drop-in after updating the gitmodule reference.