### PR TITLE
Add support for floating-point render targets

### DIFF
--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -52,6 +52,9 @@ class Image
 
     ~Image();
 
+    /// @name Property Accessors
+    /// @{
+
     /// Return the width of the image.
     unsigned int getWidth() const
     {
@@ -82,6 +85,36 @@ class Image
     /// Return the maximum number of mipmaps for this image.
     unsigned int getMaxMipCount() const;
 
+    /// @}
+    /// @name Texel Accessors
+    /// @{
+
+    /// Set the texel color at the given coordinates.  If the coordinates
+    /// or image resource buffer are invalid, then an exception is thrown.
+    void setTexelColor(unsigned int x, unsigned int y, const Color4& color);
+
+    /// Return the texel color at the given coordinates.  If the coordinates
+    /// or image resource buffer are invalid, then an exception is thrown.
+    Color4 getTexelColor(unsigned int x, unsigned int y) const;
+
+    /// @}
+    /// @name Image Processing
+    /// @{
+
+    /// Apply a 3x3 box blur to this image, returning a new blurred image.
+    ImagePtr applyBoxBlur();
+
+    /// Apply a 7x7 Gaussian blur to this image, returning a new blurred image.
+    ImagePtr applyGaussianBlur();
+
+    /// Split this image by the given luminance threshold, returning the
+    /// resulting underflow and overflow images.
+    ImagePair splitByLuminance(float luminance);
+
+    /// @}
+    /// @name Resource Buffers
+    /// @{
+
     /// Set the resource buffer for this image.
     void setResourceBuffer(void* buffer)
     {
@@ -93,6 +126,12 @@ class Image
     {
         return _resourceBuffer;
     }
+
+    /// Allocate a resource buffer for this image that matches its properties.
+    void createResourceBuffer();
+
+    /// Release the resource buffer for this image.
+    void releaseResourceBuffer();
 
     /// Set the resource buffer deallocator for this image.
     void setResourceBufferDeallocator(ImageBufferDeallocator deallocator)
@@ -106,6 +145,10 @@ class Image
         return _resourceBufferDeallocator;
     }
 
+    /// @}
+    /// @name Resource IDs
+    /// @{
+
     /// Set the resource ID for this image.
     void setResourceId(unsigned int id)
     {
@@ -118,29 +161,7 @@ class Image
         return _resourceId;
     }
 
-    /// Set the texel color at the given coordinates.  If the coordinates
-    /// or image resource buffer are invalid, then an exception is thrown.
-    void setTexelColor(unsigned int x, unsigned int y, const Color4& color);
-
-    /// Return the texel color at the given coordinates.  If the coordinates
-    /// or image resource buffer are invalid, then an exception is thrown.
-    Color4 getTexelColor(unsigned int x, unsigned int y) const;
-
-    /// Apply a 3x3 box blur to this image, returning a new blurred image.
-    ImagePtr applyBoxBlur();
-
-    /// Apply a 7x7 Gaussian blur to this image, returning a new blurred image.
-    ImagePtr applyGaussianBlur();
-
-    /// Split this image by the given luminance threshold, returning the
-    /// resulting underflow and overflow images.
-    ImagePair splitByLuminance(float luminance);
-
-    /// Allocate a resource buffer for this image that matches its properties.
-    void createResourceBuffer();
-
-    /// Release the resource buffer for this image.
-    void releaseResourceBuffer();
+    /// @}
 
   protected:
     Image(unsigned int width, unsigned int height, unsigned int channelCount, BaseType baseType);

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -126,17 +126,20 @@ class ShaderRenderer
     // Protected constructor
     ShaderRenderer() :
         _width(0),
-        _height(0)
+        _height(0),
+        _baseType(Image::BaseType::UINT8)
     { }
 
-    ShaderRenderer(unsigned int width, unsigned int height) :
+    ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
         _width(width),
-        _height(height)
+        _height(height),
+        _baseType(baseType)
     { }
 
   protected:
     unsigned int _width;
     unsigned int _height;
+    Image::BaseType _baseType;
 
     ImageHandlerPtr _imageHandler;
     GeometryHandlerPtr _geometryHandler;

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -25,13 +25,13 @@ const float FAR_PLANE_PERSP = 100.0f;
 // GlslRenderer methods
 //
 
-GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height)
+GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height, Image::BaseType baseType)
 {
-    return GlslRendererPtr(new GlslRenderer(width, height));
+    return GlslRendererPtr(new GlslRenderer(width, height, baseType));
 }
 
-GlslRenderer::GlslRenderer(unsigned int width, unsigned int height) :
-    ShaderRenderer(width, height),
+GlslRenderer::GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
+    ShaderRenderer(width, height, baseType),
     _initialized(false),
     _eye(0.0f, 0.0f, 4.0f),
     _center(0.0f, 0.0f, 0.0f),
@@ -126,7 +126,7 @@ void GlslRenderer::initialize()
             glClearColor(0.4f, 0.4f, 0.4f, 1.0f);
             glClearStencil(0);
 
-            _frameBuffer = GLFramebuffer::create(_width, _height, 4, Image::BaseType::UINT8);
+            _frameBuffer = GLFramebuffer::create(_width, _height, 4, _baseType);
 
             _initialized = true;
         }

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -41,7 +41,7 @@ class GlslRenderer : public ShaderRenderer
 {
   public:
     /// Create a GLSL renderer instance
-    static GlslRendererPtr create(unsigned int width = 512, unsigned int height = 512);
+    static GlslRendererPtr create(unsigned int width = 512, unsigned int height = 512, Image::BaseType baseType = Image::BaseType::UINT8);
 
     /// Destructor
     virtual ~GlslRenderer();
@@ -108,7 +108,7 @@ class GlslRenderer : public ShaderRenderer
     /// @}
 
   protected:
-    GlslRenderer(unsigned int width, unsigned int height);
+    GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType);
 
     virtual void updateViewInformation();
     virtual void updateWorldInformation();

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -10,11 +10,16 @@
 namespace MaterialX
 {
 
-TextureBaker::TextureBaker(unsigned int width, unsigned int height) :
-    GlslRenderer(width, height),
-    _generator(GlslShaderGenerator::create()),
-    _extension(ImageLoader::PNG_EXTENSION)
+TextureBaker::TextureBaker(unsigned int width, unsigned int height, Image::BaseType baseType) :
+    GlslRenderer(width, height, baseType),
+    _generator(GlslShaderGenerator::create())
 {
+    // Assign a default extension for texture baking.
+    _extension = (baseType == Image::BaseType::UINT8) ?
+                 ImageLoader::PNG_EXTENSION :
+                 ImageLoader::HDR_EXTENSION;
+
+    // Initialize the underlying renderer.
     initialize();
 }
 
@@ -88,7 +93,10 @@ void TextureBaker::writeBakedDocument(ShaderRefPtr shaderRef, const FilePath& fi
     NodeGraphPtr bakedNodeGraph = bakedTextureDoc->addNodeGraph("NG_baked");
     MaterialPtr bakedMaterial = bakedTextureDoc->addMaterial("M_baked");
     ShaderRefPtr bakedShaderRef = bakedMaterial->addShaderRef(shaderRef->getName() + "_baked", shaderRef->getAttribute("node"));
-    bakedNodeGraph->setColorSpace("srgb_texture");
+    if (_baseType == Image::BaseType::UINT8)
+    {
+        bakedNodeGraph->setColorSpace("srgb_texture");
+    }
 
     // Create bind elements on the baked shader reference.
     for (ValueElementPtr valueElem : shaderRef->getChildrenOfType<ValueElement>())

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -24,9 +24,9 @@ using TextureBakerPtr = shared_ptr<class TextureBaker>;
 class TextureBaker : public GlslRenderer
 {
   public:
-    static TextureBakerPtr create(unsigned int width = 1024, unsigned int height = 1024)
+    static TextureBakerPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
     {
-        return TextureBakerPtr(new TextureBaker(width, height));
+        return TextureBakerPtr(new TextureBaker(width, height, baseType));
     }
 
     /// Set the file extension for baked textures.
@@ -57,7 +57,7 @@ class TextureBaker : public GlslRenderer
     void writeBakedDocument(NodePtr shader, const FilePath& filename);
 
   protected:
-    TextureBaker(unsigned int width, unsigned int height);
+    TextureBaker(unsigned int width, unsigned int height, Image::BaseType baseType);
 
     // Generate a texture filename for the given graph output.
     FilePath generateTextureFilename(OutputPtr output);

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -23,13 +23,13 @@ string OslRenderer::OSL_CLOSURE_COLOR_STRING("closure color");
 // OslRenderer methods
 //
 
-OslRendererPtr OslRenderer::create(unsigned int width, unsigned int height)
+OslRendererPtr OslRenderer::create(unsigned int width, unsigned int height, Image::BaseType baseType)
 {
-    return std::shared_ptr<OslRenderer>(new OslRenderer(width, height));
+    return std::shared_ptr<OslRenderer>(new OslRenderer(width, height, baseType));
 }
 
-OslRenderer::OslRenderer(unsigned int width, unsigned int height) :
-    ShaderRenderer(width, height),
+OslRenderer::OslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
+    ShaderRenderer(width, height, baseType),
     _useTestRender(true) // By default use testrender
 {
 }

--- a/source/MaterialXRenderOsl/OslRenderer.h
+++ b/source/MaterialXRenderOsl/OslRenderer.h
@@ -32,7 +32,7 @@ class OslRenderer : public ShaderRenderer
 {
   public:
     /// Create an OSL renderer instance
-    static OslRendererPtr create(unsigned int width = 512, unsigned int height = 512);
+    static OslRendererPtr create(unsigned int width = 512, unsigned int height = 512, Image::BaseType baseType = Image::BaseType::UINT8);
 
     /// Destructor
     virtual ~OslRenderer();
@@ -226,7 +226,7 @@ class OslRenderer : public ShaderRenderer
     void renderOSL(const FilePath& dirPath, const string& shaderName, const string& outputName);
 
     /// Constructor
-    OslRenderer(unsigned int width, unsigned int height);
+    OslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType);
 
   private:
     /// Path to "oslc" executable`


### PR DESCRIPTION
This changelist adds support for floating-point render targets in ShaderRenderer and its subclasses, allowing for HDR texture baking with TextureBaker.