### PR TITLE
Additional improvements to texture baking

### DIFF
--- a/python/Scripts/baketextures.py
+++ b/python/Scripts/baketextures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 '''
-Generate baked versions of all materials in the input document, using the TextureBaker class in the MaterialXRenderGlsl library.
+Generate a baked version of each material in the input document, using the TextureBaker class in the MaterialXRenderGlsl library.
 '''
 
 import sys, os, string
@@ -12,12 +12,14 @@ from MaterialX import PyMaterialXRenderGlsl as mx_render_glsl
 from MaterialX import PyMaterialXGenShader as ms_gen_shader
 
 def main():
-    parser = argparse.ArgumentParser(description="Bake out MaterialX sharderref inputs into textures.")
-    parser.add_argument("--hdr", "--HDR", dest="hdr", action="store_true", help="Save images to hdr format.")
-    parser.add_argument("--incl", "--i", dest="include", default = "", help="Txt document with each library path on each line")
-    parser.add_argument("--tx", "--texResX", "--texresx", dest="tex_res_x", type=int, default=1024, help="X Resolution at which to save textures.")
-    parser.add_argument("--ty", "--texResY", "--texresy", dest="tex_res_y", type=int, default=1024, help="Y Resolution at which to save textures.")
-    parser.add_argument(dest="filename", help="Input mtlx filename.")
+    parser = argparse.ArgumentParser(description="Generate a baked version of each material in the input document.")
+    parser.add_argument("--width", dest="width", type=int, default=1024, help="Specify the width of baked textures.")
+    parser.add_argument("--height", dest="height", type=int, default=1024, help="Specify the height of baked textures.")
+    parser.add_argument("--hdr", dest="hdr", action="store_true", help="Save images to hdr format.")
+    parser.add_argument("--path", dest="paths", action='append', nargs='+', help="An additional absolute search path location (e.g. '/projects/MaterialX')")
+    parser.add_argument("--library", dest="libraries", action='append', nargs='+', help="An additional relative path to a custom data library folder (e.g. 'libraries/custom')")
+    parser.add_argument(dest="input_filename", help="Filename of the input document.")
+    parser.add_argument(dest="output_filename", help="Filename of the output document.")
 
     opts = parser.parse_args()
 
@@ -25,24 +27,24 @@ def main():
     mxversion = mx.getVersionString()
 
     try:
-        mx.readFromXmlFile(doc, opts.filename)
+        mx.readFromXmlFile(doc, opts.input_filename)
     except mx.ExceptionFileMissing as err:
         print(err)
         sys.exit(0)
 
     stdlib = mx.createDocument()
-    library_folder = [
-        mx.FilePath("../../libraries/stdlib"),
-        mx.FilePath("../../libraries/pbrlib"),
-        mx.FilePath("../../libraries/bxdf"), 
-        mx.FilePath("../../libraries/pbrlib/genglsl")
-        ]
-    if (opts.include != ""):
-        with open(opts.include) as f:
-            for line in f:
-                library_folder.append(mx.FilePath(line.rstrip()))
-    searchPath = mx.FileSearchPath(os.getcwd())
-    mx.loadLibraries(library_folder, searchPath, stdlib, set(), None)
+    search_path = mx.FileSearchPath()
+    library_folders = [ mx.FilePath("libraries") ]
+    if opts.paths:
+        for path_list in opts.paths:
+            for path in path_list:
+                search_path.append(path)
+    search_path.append(os.path.join(os.getcwd(), '../..'))
+    if opts.libraries:
+        for library_list in opts.libraries:
+            for library in library_list:
+                library_folders.append(library)
+    mx.loadLibraries(library_folders, search_path, stdlib, set(), None)
     doc.importLibrary(stdlib)
 
     valid, msg = doc.validate()
@@ -50,7 +52,9 @@ def main():
         print("Validation warnings for input document:")
         print(msg)
 
-    mx_render_glsl.TextureBaker.bakeAllShaders(doc, opts.filename, opts.hdr, opts.tex_res_x, opts.tex_res_y)
+    image_search_path = mx.FileSearchPath(os.path.dirname(opts.input_filename))
+    mx_render_glsl.TextureBaker.bakeAllMaterials(doc, image_search_path,
+                                                 opts.output_filename, opts.hdr, opts.width, opts.height)
 
 if __name__ == '__main__':
     main()

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -123,10 +123,10 @@ string Element::getNamePath(ConstElementPtr relativeTo) const
     return res;
 }
 
-ElementPtr Element::getDescendant(const string& namePath)
+ElementPtr Element::getDescendant(const string& namePath) const
 {
     const StringVec nameVec = splitString(namePath, NAME_PATH_SEPARATOR);
-    ElementPtr elem = getSelf();
+    ElementPtr elem = getSelfNonConst();
     for (const string& name : nameVec)
     {
         elem = elem->getChild(name);

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -136,7 +136,7 @@ class Element : public std::enable_shared_from_this<Element>
     /// current element is returned.  If no element is found at the given path,
     /// then an empty shared pointer is returned.
     /// @param namePath The relative name path of the specified element.
-    ElementPtr getDescendant(const string& namePath);
+    ElementPtr getDescendant(const string& namePath) const;
 
     /// @}
     /// @name File Prefix

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -59,8 +59,9 @@ class TextureBaker : public GlslRenderer
     /// Write out the baked material document based on a shader node
     void writeBakedDocument(NodePtr shader, const FilePath& filename, ValuePtr udimSetValue = nullptr);
     
-    /// Bake material and its inputs to textures 
-    static void bakeAllShaders(DocumentPtr& doc, string file, bool HDR = false, int texresx = 1024, int texresy = 1024);
+    /// Generate a baked version of each material in the input document
+    static void bakeAllMaterials(ConstDocumentPtr doc, const FileSearchPath& imageSearchPath,
+                                 const FilePath& outputFilename, bool hdr = false, int width = 1024, int height = 1024);
 
   protected:
     TextureBaker(unsigned int width, unsigned int height, Image::BaseType baseType);

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
@@ -15,5 +15,5 @@ void bindPyTextureBaker(py::module& mod)
 {
     py::class_<mx::TextureBaker, mx::GlslRenderer, mx::TextureBakerPtr>(mod, "TextureBaker")
         .def_static("create", &mx::TextureBaker::create)
-        .def_static("bakeAllShaders", &mx::TextureBaker::bakeAllShaders);
+        .def_static("bakeAllMaterials", &mx::TextureBaker::bakeAllMaterials);
 }


### PR DESCRIPTION
- Update argument names in baketextures.py to match those in MaterialXView (e.g. --width, --height, --library).
- Add arguments for input search path and output filename to baketextures.py.
- Rename TextureBaker::bakeAllShaders to TextureBaker::bakeAllMaterials.

Additional supporting changes:
- Emit warnings for missing textures in GlslProgram::bindTexture.
- Mark Element::getDescendant as a const method.