### PR TITLE
Unify search path generation

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -275,6 +275,29 @@ namespace
     }
 }
 
+FileSearchPath getDefaultSearchPath()
+{
+    FileSearchPath searchPath;
+
+    // Default search path for installed binaries.
+    FilePath installSearchPath = FilePath::getModulePath().getParentPath();
+    if (installSearchPath.exists())
+    {
+        searchPath.append(installSearchPath);
+        searchPath.append(installSearchPath / "libraries");
+    }
+
+    // Default search path for development environments.
+    FilePath devSearchPath = FilePath(__FILE__).getParentPath().getParentPath().getParentPath();
+    if (devSearchPath.exists())
+    {
+        searchPath.append(devSearchPath);
+        searchPath.append(devSearchPath / "libraries");
+    }
+
+    return searchPath;
+}
+
 bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
 {
     // Handle shader nodes

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -25,6 +25,9 @@ namespace MaterialX
 
 class ShaderGenerator;
 
+/// Return a default search path for binaries that leverage shader generation.
+FileSearchPath getDefaultSearchPath();
+
 /// Returns true if the given element is a surface shader with the potential
 /// of beeing transparent. This can be used by HW shader generators to determine
 /// if a shader will require transparency handling.

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -19,24 +19,6 @@ namespace MaterialX
 namespace
 {
 
-// Helper function to initialize file search path
-FileSearchPath initFileSearchPath()
-{
-    FilePath installSearchPath = FilePath::getModulePath().getParentPath();
-    FilePath devSearchPath = FilePath(__FILE__).getParentPath().getParentPath().getParentPath();
-    FileSearchPath searchPath = FileSearchPath(installSearchPath);
-    if (!devSearchPath.isEmpty() && devSearchPath.exists())
-    {
-        searchPath.append(devSearchPath);
-        devSearchPath = devSearchPath / "libraries";
-        if (devSearchPath.exists())
-        {
-            searchPath.append(devSearchPath);
-        }
-    }
-    return searchPath;
-}
-
 // Helper function to initialize shader generation context
 GenContext initGenContext()
 {
@@ -321,7 +303,7 @@ void TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileSearchPath& image
     GenContext genContext = initGenContext();
     DefaultColorManagementSystemPtr cms = DefaultColorManagementSystem::create(genContext.getShaderGenerator().getLanguage());
     cms->loadLibrary(doc);
-    FileSearchPath searchPath = initFileSearchPath();
+    FileSearchPath searchPath = getDefaultSearchPath();
     genContext.registerSourceCodeSearchPath(searchPath);
     genContext.getShaderGenerator().setColorManagementSystem(cms);
     StringResolverPtr resolver = StringResolver::create();

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* const argv[])
         "libraries",
     };
 
-    mx::FileSearchPath searchPath;
+    mx::FileSearchPath searchPath = mx::getDefaultSearchPath();
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx";
     std::string meshFilename = "resources/Geometry/shaderball.obj";
     mx::Vector3 meshRotation;
@@ -190,20 +190,6 @@ int main(int argc, char* const argv[])
         else
         {
             i++;
-        }
-    }
-
-    // Add default search paths for the viewer.
-    mx::FilePath installSearchPath = mx::FilePath::getModulePath().getParentPath();
-    mx::FilePath devSearchPath = mx::FilePath(__FILE__).getParentPath().getParentPath().getParentPath();
-    searchPath.append(installSearchPath);
-    if (!devSearchPath.isEmpty() && devSearchPath.exists())
-    {
-        searchPath.append(devSearchPath);
-        devSearchPath = devSearchPath / "libraries";
-        if (devSearchPath.exists())
-        {
-            searchPath.append(devSearchPath);
         }
     }
 


### PR DESCRIPTION
This changelist aligns search path generation between the viewer and texture baker, adding the MaterialX::getDefaultSearchPath method to define the expected behavior.