### PR TITLE
Image handling improvements

### DIFF
--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -178,7 +178,7 @@ class Image
 };
 
 /// Create a uniform-color image with the given properties.
-ImagePtr createUniformImage(unsigned int width, unsigned int height, const Color4& color);
+ImagePtr createUniformImage(unsigned int width, unsigned int height, unsigned int channelCount, Image::BaseType baseType, const Color4& color);
 
 /// Create a horizontal image strip from a vector of images with identical resolutions and formats.
 ImagePtr createImageStrip(vector<ImagePtr> imageVec);

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -40,7 +40,7 @@ const string ImageLoader::TXR_EXTENSION = "txr";
 ImageHandler::ImageHandler(ImageLoaderPtr imageLoader)
 {
     addLoader(imageLoader);
-    _zeroImage = createUniformImage(1, 1, Color4(0.0f));
+    _zeroImage = createUniformImage(1, 1, 4, Image::BaseType::UINT8, Color4(0.0f));
 }
 
 void ImageHandler::addLoader(ImageLoaderPtr loader)
@@ -106,6 +106,13 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4
             ImagePtr image = loader->loadImage(foundFilePath);
             if (image)
             {
+                // Workaround for sampling issues with 1x1 textures.
+                if (image->getWidth() == 1 && image->getHeight() == 1)
+                {
+                    image = createUniformImage(2, 2, image->getChannelCount(),
+                                               image->getBaseType(), image->getTexelColor(0, 0));
+                }
+
                 cacheImage(foundFilePath, image);
                 return image;
             }
@@ -129,7 +136,7 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4
     }
     if (fallbackColor)
     {
-        ImagePtr image = createUniformImage(1, 1, *fallbackColor);
+        ImagePtr image = createUniformImage(2, 2, 4, Image::BaseType::UINT8, *fallbackColor);
         if (image)
         {
             cacheImage(filePath, image);

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -124,7 +124,6 @@ bool GLTextureHandler::createRenderResources(ImagePtr image, bool generateMipMap
     if (image->getResourceId() == GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID)
     {
         unsigned int resourceId;
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
         glGenTextures(1, &resourceId);
         image->setResourceId(resourceId);
     }
@@ -141,6 +140,7 @@ bool GLTextureHandler::createRenderResources(ImagePtr image, bool generateMipMap
     int glType, glFormat, glInternalFormat;
     mapTextureFormatToGL(image->getBaseType(), image->getChannelCount(), false,
         glType, glFormat, glInternalFormat);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, glInternalFormat, image->getWidth(), image->getHeight(),
         0, glFormat, glType, image->getResourceBuffer());
 

--- a/source/MaterialXTest/MaterialXRender/Render.cpp
+++ b/source/MaterialXTest/MaterialXRender/Render.cpp
@@ -179,7 +179,7 @@ TEST_CASE("Render: Image Handler Load", "[rendercore]")
     try
     {
         mx::Color4 color(1.0f, 0.0f, 0.0f, 1.0f);
-        mx::ImagePtr uniformImage = createUniformImage(1, 1, color);
+        mx::ImagePtr uniformImage = createUniformImage(1, 1, 4, mx::Image::BaseType::UINT8, color);
         CHECK(uniformImage->getWidth() == 1);
         CHECK(uniformImage->getHeight() == 1);
         CHECK(uniformImage->getMaxMipCount() == 1);


### PR DESCRIPTION
- Add support for UINT8 textures in setTexelColor, getTexelColor, and createUniformImage.
- Make sure GLTextureHandler::createRenderResources sets the packing alignment in all code paths.
- Add a workaround for sampling issues with 1x1 textures.