### PR TITLE
Image loading improvements

### DIFF
--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -76,13 +76,12 @@ bool ImageHandler::saveImage(const FilePath& filePath,
     }
 
     string extension = foundFilePath.getExtension();
-    ImageLoaderMap::reverse_iterator iter;
-    for (iter = _imageLoaders.rbegin(); iter != _imageLoaders.rend(); ++iter)
+    for (const auto& pair : _imageLoaders)
     {
-        ImageLoaderPtr loader = iter->second;
+        ImageLoaderPtr loader = pair.second;
         if (loader && loader->supportedExtensions().count(extension))
         {
-            bool saved = iter->second->saveImage(foundFilePath, image, verticalFlip);
+            bool saved = pair.second->saveImage(foundFilePath, image, verticalFlip);
             if (saved)
             {
                 return true;
@@ -97,9 +96,9 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4
     FilePath foundFilePath = _searchPath.find(filePath);
     string extension = stringToLower(foundFilePath.getExtension());
     bool extensionSupported = false;
-    for (ImageLoaderMap::reverse_iterator iter = _imageLoaders.rbegin(); iter != _imageLoaders.rend(); ++iter)
+    for (const auto& pair : _imageLoaders)
     {
-        ImageLoaderPtr loader = iter->second;
+        ImageLoaderPtr loader = pair.second;
         if (loader && loader->supportedExtensions().count(extension))
         {
             extensionSupported = true;

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -5,6 +5,7 @@
 
 #include <MaterialXRenderGlsl/TextureBaker.h>
 
+#include <MaterialXRender/OiioImageLoader.h>
 #include <MaterialXRender/StbImageLoader.h>
 #include <MaterialXRender/Util.h>
 
@@ -291,6 +292,9 @@ void TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileSearchPath& image
     genContext.getShaderGenerator().setColorManagementSystem(cms);
     StringResolverPtr resolver = StringResolver::create();
     ImageHandlerPtr imageHandler = GLTextureHandler::create(StbImageLoader::create());
+#if MATERIALX_BUILD_OIIO
+    imageHandler->addLoader(OiioImageLoader::create());
+#endif
     StringVec renderablePaths = getRenderablePaths(doc);
 
     for (const string& renderablePath : renderablePaths)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -234,12 +234,10 @@ Viewer::Viewer(const std::string& materialFilename,
     _genContext.getOptions().fileTextureVerticalFlip = true;
 
     // Initialize image handler.
+    _imageHandler = mx::GLTextureHandler::create(mx::StbImageLoader::create());
 #if MATERIALX_BUILD_OIIO
-    mx::ImageLoaderPtr imageLoader = mx::OiioImageLoader::create();
-#else
-    mx::ImageLoaderPtr imageLoader = mx::StbImageLoader::create();
+    _imageHandler->addLoader(mx::OiioImageLoader::create());
 #endif
-    _imageHandler = mx::GLTextureHandler::create(imageLoader);
     _imageHandler->setSearchPath(_searchPath);
 
     // Initialize user interfaces.


### PR DESCRIPTION
- If an ImageHandler has multiple loaders, they are applied in the order they were added by the client.
- If MaterialX has been built with OpenImageIO support, make it available as a secondary loader in both MaterialXView and TextureBaker.