### PR TITLE
Improve CMake backwards compatibility

### DIFF
--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -1,3 +1,10 @@
+file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
+list(APPEND materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/Catch/catch.hpp")
+
+assign_source_group("Source Files" ${materialx_source})
+assign_source_group("Header Files" ${materialx_headers})
+
 set(MATERIALX_TEST_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 # Discover all tests and allow them to be run in parallel (ctest -j20):
@@ -15,21 +22,11 @@ function(add_tests _sources)
   endforeach()
 endfunction()
 
-add_executable(MaterialXTest)
+add_executable(MaterialXTest ${materialx_source} ${materialx_headers})
 
 target_include_directories( MaterialXTest PUBLIC
     ${EXTERNAL_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../)
-
-file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
-file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
-
-list(APPEND materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/Catch/catch.hpp")
-
-assign_source_group("Source Files" ${materialx_source})
-assign_source_group("Header Files" ${materialx_headers})
-
-target_sources(MaterialXTest PUBLIC ${materialx_source} ${materialx_headers})
 
 add_subdirectory(MaterialXCore)
 target_link_libraries(MaterialXTest MaterialXCore)


### PR DESCRIPTION
This changelist updates the CMakeLists.txt file in MaterialXTest to use patterns supported by earlier versions of CMake in addition to the latest version.