### PR TITLE
Align variable names

### DIFF
--- a/python/Scripts/baketextures.py
+++ b/python/Scripts/baketextures.py
@@ -21,8 +21,6 @@ def main():
     opts = parser.parse_args()
 
     doc = mx.createDocument()
-    mxversion = mx.getVersionString()
-
     try:
         mx.readFromXmlFile(doc, opts.input_filename)
     except mx.ExceptionFileMissing as err:
@@ -35,8 +33,8 @@ def main():
     searchPath.append(os.path.dirname(opts.input_filename))
     libraryFolders = [ "libraries" ]
     if opts.paths:
-        for path_list in opts.paths:
-            for path in path_list:
+        for pathList in opts.paths:
+            for path in pathList:
                 searchPath.append(path)
     if opts.libraries:
         for libraryList in opts.libraries:
@@ -46,7 +44,7 @@ def main():
     doc.importLibrary(stdlib)
 
     valid, msg = doc.validate()
-    if (not valid):
+    if not valid:
         print("Validation warnings for input document:")
         print(msg)
 

--- a/source/MaterialXFormat/Util.h
+++ b/source/MaterialXFormat/Util.h
@@ -37,9 +37,9 @@ void loadLibrary(const FilePath& file,
                  const FileSearchPath& searchPath = FileSearchPath(), 
                  XmlReadOptions* readOptions = nullptr);
 
-/// Load all MaterialX files with given library names in given search paths.
-/// Note that all library files will have a URI set on them.
-StringSet loadLibraries(const FilePathVec& libraryNames,
+/// Load all MaterialX files within the given library folders into a document,
+/// using the given search path to locate the folders on the file system.
+StringSet loadLibraries(const FilePathVec& libraryFolders,
                         const FileSearchPath& searchPath,
                         DocumentPtr doc,
                         const StringSet& excludeFiles = StringSet(),

--- a/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
@@ -21,5 +21,5 @@ void bindPyUtil(py::module& mod)
     mod.def("loadLibrary", &mx::loadLibrary,
         py::arg("file"), py::arg("doc"), py::arg("searchPath") = mx::FileSearchPath(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("loadLibraries", &mx::loadLibraries,
-        py::arg("libraryNames"), py::arg("searchPath"), py::arg("doc"), py::arg("excludeFiles") = mx::StringSet(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
+        py::arg("libraryFolders"), py::arg("searchPath"), py::arg("doc"), py::arg("excludeFiles") = mx::StringSet(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
 }


### PR DESCRIPTION
- Align variable names between interface and implementation in loadLibraries.
- Use a single variable name convention in baketextures.py.
- Additional script cleanup in baketextures.py.