### PR TITLE
Wedge updates for v1.38.

### DIFF
--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -7,21 +7,21 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 <p float="left">
   <img src="/documents/Images/MaterialXView_Marble.png" width="213" />
-  <img src="/documents/Images/MaterialXView_Copper.png" width="213" /> 
-  <img src="/documents/Images/MaterialXView_Plastic.png" width="213" /> 
-  <img src="/documents/Images/MaterialXView_Carpaint.png" width="213" /> 
+  <img src="/documents/Images/MaterialXView_Copper.png" width="213" />
+  <img src="/documents/Images/MaterialXView_Plastic.png" width="213" />
+  <img src="/documents/Images/MaterialXView_Carpaint.png" width="213" />
 </p>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 <p float="left">
   <img src="/documents/Images/MaterialXView_TiledBrass.png" width="430" />
-  <img src="/documents/Images/MaterialXView_TiledWood.png" width="430" /> 
+  <img src="/documents/Images/MaterialXView_TiledWood.png" width="430" />
 </p>
 
 **Figure 3:** Droid character materials in the MaterialX viewer. © & TM Lucasfilm Ltd. Used with permission.
 <p float="left">
   <img src="/documents/Images/MaterialXView_BB8.png" width="430" />
-  <img src="/documents/Images/MaterialXView_R2D2.png" width="430" /> 
+  <img src="/documents/Images/MaterialXView_R2D2.png" width="430" />
 </p>
 
 ## Building The MaterialX Viewer
@@ -64,17 +64,41 @@ By default, the MaterialX viewer loads and saves image files using `stb_image`, 
 ### Keyboard Shortcuts
 
 - `R`: Reload the current material from file.  Hold `SHIFT` to reload all standard libraries as well.
-- `S`: Save the current shader source to file.
+- `S`: Save the current GLSL shader source to file.
+- `O`: Save the current OSL shader source to file.
+- `M`: Save the current MDL shader source to file.
 - `L`: Load shader source from file.  Editing the source files before loading provides a way to debug and experiment with shader source code.
 - `D`: Save each node graph in the current material as a DOT file.  See www.graphviz.org for more details on this format.
 - `F`: Capture the current frame and save to file.
+- `W`: Create a wedge rendering and save to file.
+- `RIGHT` : Switch to next material
+- `LEFT` : Switch to previous material  
+- `UP` : Zoom in with the camera.  
+- `DOWN` : Zoom out with the camera.
 
 ### Command-Line Options
 
 The following are common command-line options for MaterialXView, and a complete list can be displayed with the `--help` option.
-- `--material [FILENAME]`: Specify the displayed material
-- `--mesh [FILENAME]`: Specify the displayed geometry
-- `--envRad [FILENAME]`: Specify the displayed environment light, stored as HDR environment radiance in the latitude-longitude format
-- `--path [FILEPATH]`: Specify an additional absolute search path location
-- `--library [FILEPATH]`: Specify an additional relative path to a custom data library folder
-- `--help`: Display the complete list of command-line options
+- `--material [FILENAME]` : Specify the filename of the MTLX document to be displayed in the viewer
+- `--mesh [FILENAME]` : Specify the filename of the OBJ mesh to be displayed in the viewer
+- `--meshRotation [VECTOR3]` : Specify the rotation of the displayed mesh as three comma-separated floats, representing rotations in degrees about the X, Y, and Z axes (defaults to 0,0,0)
+- `--meshScale [FLOAT]` : Specify the uniform scale of the displayed mesh
+- `--cameraPosition [VECTOR3]` : Specify the position of the camera as three comma-separated floats (defaults to 0,0,5)
+- `--cameraTarget [VECTOR3]` : Specify the position of the camera target as three comma-separated floats (defaults to 0,0,0)
+- `--cameraViewAngle [FLOAT]` : Specify the view angle of the camera (defaults to 45)
+- `--cameraZoom [FLOAT]` : Specify the amount to zoom the camera. (defaults to 1.0)
+- `--envRad [FILENAME]` : Specify the filename of the environment light to display, stored as HDR environment radiance in the latitude-longitude format
+- `--envMethod [INTEGER]` : Specify the environment lighting method (0 = filtered importance sampling, 1 = prefiltered environment maps, defaults to 0)
+- `--envSampleCount [INTEGER]` :  Specify the environment sample count (defaults to 16)
+- `--lightRotation [FLOAT]` : Specify the rotation in degrees of the lighting environment about the Y axis (defaults to 0)
+- `--path [FILEPATH]` : Specify an additional absolute search path location (e.g. '/projects/MaterialX').  This path will be queried when locating standard data libraries, XInclude references, and referenced images.
+- `--library [FILEPATH]` : Specify an additional relative path to a custom data library folder (e.g. 'libraries/custom').  MaterialX files at the root of this folder will be included in all content documents.
+- `--screenWidth [INTEGER]` : Specify the width of the screen image in pixels (defaults to 1280)
+- `--screenHeight [INTEGER]` : Specify the height of the screen image in pixels (defaults to 960)
+- `--screenColor [VECTOR3]` : Specify the background color of the viewer as three comma-separated floats (defaults to 0.3,0.3,0.32)
+- `--msaa [INTEGER]` : Specify the multisampling count for screen anti-aliasing (defaults to 0)
+- `--refresh [INTEGER]` : Specify the refresh period for the viewer in milliseconds (defaults to 50, set to -1 to disable)
+- `--remap [TOKEN1:TOKEN2]` : Specify the remapping from one token to another when MaterialX document is loaded
+- `--skip [NAME]` : Specify to skip elements matching the given name attribute
+- `--terminator [STRING]` : Specify to enforce the given terminator string for file prefixes
+- `--help` : Display the complete list of command-line options

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -486,13 +486,20 @@ ValueElementPtr Node::addInputFromNodeDef(const string& name)
     if (elemNodeDef)
     {
         ValueElementPtr nodeDefElem = elemNodeDef->getChildOfType<ValueElement>(name);
+        const string& inputName = nodeDefElem->getName();
+        ElementPtr existingElement = getChild(inputName);
+        if (existingElement && existingElement->isA<ValueElement>())
+        {
+            return existingElement->asA<ValueElement>();
+        }
+
         if (nodeDefElem->isA<Input>())
         {
-            newChild = addInput(nodeDefElem->getName());
+            newChild = addInput(inputName);
         }
         else if (nodeDefElem->isA<Parameter>())
         {
-            newChild = addParameter(nodeDefElem->getName());
+            newChild = addParameter(inputName);
         }
         if (newChild)
         {

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -145,6 +145,7 @@ class Node : public InterfaceElement
     }
 
     /// Add an input based on the corresponding input for the associated node definition.
+    /// If the input already exists on the node it will just be returned.
     ValueElementPtr addInputFromNodeDef(const string& name);
 
     /// @}

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <MaterialXCore/Util.h>
+#include <MaterialXCore/Types.h>
 
 #include <cctype>
 
@@ -124,6 +125,33 @@ bool stringEndsWith(const string& str, const string& suffix)
         return !str.compare(str.length() - suffix.length(), suffix.length(), suffix);
     }
     return false;
+}
+
+StringVec splitNamePath(const string& namePath)
+{
+    StringVec nameVec = splitString(namePath, NAME_PATH_SEPARATOR);
+    return nameVec;
+}
+
+string createNamePath(const StringVec& nameVec)
+{
+    string res;
+    for (const string& name : nameVec)
+    {
+        res = res.empty() ? name: res + NAME_PATH_SEPARATOR + name;
+    }
+    return res;
+}
+
+string parentNamePath(const string& namePath)
+{
+    StringVec nameVec = splitNamePath(namePath);
+    if (!nameVec.empty())
+    {
+        nameVec.pop_back();
+        return createNamePath(nameVec);
+    }
+    return EMPTY_STRING;
 }
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -3,7 +3,6 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
-#include <MaterialXCore/Util.h>
 #include <MaterialXCore/Types.h>
 
 #include <cctype>

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -51,6 +51,15 @@ template<typename T> void hashCombine(size_t& seed, const T& value)
     seed ^= std::hash<T>()(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 } 
 
+/// Split a name path into string vector
+StringVec splitNamePath(const string& namePath);
+
+/// Create a name path from a string vector
+string createNamePath(const StringVec& nameVec);
+
+/// Given a name path, return the parent name path
+string parentNamePath(const string& namePath);
+
 } // namespace MaterialX
 
 #endif

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -5,6 +5,7 @@
 
 #include <MaterialXRender/Util.h>
 
+#include <MaterialXCore/Util.h>
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 
@@ -287,14 +288,37 @@ void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocume
 }
 
 void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
-                            const string& pathSeparator, UIPropertyGroup& groups, UIPropertyGroup& unnamedGroups)
+                            const string& pathSeparator, UIPropertyGroup& groups, UIPropertyGroup& unnamedGroups, bool addFromDefinition)
 {
-    for (const auto& uniform : block.getVariableOrder())
+    const vector<ShaderPort*>& blockVariables = block.getVariableOrder();
+    for (const auto& blockVariable : blockVariables)
     {
-        if (!uniform->getPath().empty() && uniform->getValue())
+        const string& path = blockVariable->getPath();
+
+        if (!blockVariable->getPath().empty())
         {
-            ElementPtr uniformElement = contentDocument->getDescendant(uniform->getPath());
-            createUIPropertyGroups(uniformElement, contentDocument, materialElement, pathSeparator, groups, unnamedGroups, uniform);
+            // Optionally add the input if it does not exist
+            ElementPtr uniformElement = contentDocument->getDescendant(path);
+            if (!uniformElement && addFromDefinition)
+            {
+                string nodePath = parentNamePath(path);
+                ElementPtr uniformParent = contentDocument->getDescendant(nodePath);
+                if (uniformParent)
+                {
+                    NodePtr uniformNode = uniformParent->asA<Node>();
+                    if (uniformNode)
+                    {
+                        StringVec pathVec = splitNamePath(path);
+                        uniformNode->addInputFromNodeDef(pathVec[pathVec.size() - 1]);
+                    }
+                }
+            }
+
+            uniformElement = contentDocument->getDescendant(path);
+            if (uniformElement && blockVariable->getValue())
+            {
+                createUIPropertyGroups(uniformElement, contentDocument, materialElement, pathSeparator, groups, unnamedGroups, blockVariable);
+            }
         }
     }
 }

--- a/source/MaterialXRender/Util.h
+++ b/source/MaterialXRender/Util.h
@@ -119,7 +119,7 @@ void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocume
 /// Returns a list of named and unnamed groups.
 void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
                             const string& pathSeparator, UIPropertyGroup& groups,
-                            UIPropertyGroup& unnamedGroups);
+                            UIPropertyGroup& unnamedGroups, bool addFromDefinition);
 
 /// @}
 

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -826,7 +826,6 @@ ng::FloatBox<float>* createFloatWidget(ng::Widget* parent, const std::string& la
     return box;
 }
 
-
 ng::IntBox<int>* createIntWidget(ng::Widget* parent, const std::string& label, unsigned int value,
     const mx::UIProperties* ui, std::function<void(int)> callback)
 {

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -724,7 +724,7 @@ void PropertyEditor::updateContents(Viewer* viewer)
         mx::UIPropertyGroup unnamedGroups;
         const std::string pathSeparator(":");
         mx::createUIPropertyGroups(*publicUniforms, doc, material->getElement(),
-                                    pathSeparator, groups, unnamedGroups); 
+                                    pathSeparator, groups, unnamedGroups, true); 
 
         std::string previousFolder;
         // Make all inputs editable for now. Could make this read-only as well.
@@ -820,6 +820,67 @@ ng::FloatBox<float>* createFloatWidget(ng::Widget* parent, const std::string& la
     box->setCallback([slider, callback](float value)
     {
         slider->setValue(value);
+        callback(value);
+    });
+
+    return box;
+}
+
+
+ng::IntBox<int>* createIntWidget(ng::Widget* parent, const std::string& label, unsigned int value,
+    const mx::UIProperties* ui, std::function<void(int)> callback)
+{
+    new ng::Label(parent, label);
+
+    ng::Slider *slider = new ng::Slider(parent);
+    slider->setValue((float)value);
+
+    ng::IntBox<int>* box = new ng::IntBox<int>(parent, value);
+    box->setFixedWidth(60);
+    box->setFontSize(15);
+    box->setAlignment(ng::TextBox::Alignment::Right);
+    if (ui)
+    {
+        std::pair<int, int> range(0, 1);
+        if (ui->uiMin)
+        {
+            box->setMinValue(ui->uiMin->asA<int>());
+            range.first = ui->uiMin->asA<int>();
+        }
+        if (ui->uiMax)
+        {
+            box->setMaxValue(ui->uiMax->asA<int>());
+            range.second = ui->uiMax->asA<int>();
+        }
+        if (ui->uiSoftMin)
+        {
+            range.first = ui->uiSoftMin->asA<int>();
+        }
+        if (ui->uiSoftMax)
+        {
+            range.second = ui->uiSoftMax->asA<int>();
+        }
+        if (range.first != range.second)
+        {
+            std::pair<float, float> float_range((float)range.first, (float)range.second);
+            slider->setRange(float_range);
+        }
+        if (ui->uiStep)
+        {
+            box->setValueIncrement(ui->uiStep->asA<int>());
+            box->setSpinnable(true);
+            box->setEditable(true);
+        }
+    }
+
+    slider->setCallback([box, callback](float value)
+    {
+        box->setValue((int)value);
+        callback((int)value);
+    });
+    box->setCallback([slider, callback](int value)
+    {
+        slider->setValue((float)value);
         callback(value);
     });
 

--- a/source/MaterialXView/Editor.h
+++ b/source/MaterialXView/Editor.h
@@ -54,5 +54,7 @@ class PropertyEditor
 
 ng::FloatBox<float>* createFloatWidget(ng::Widget* parent, const std::string& label, float value,
                                        const mx::UIProperties*ui, std::function<void(float)> callback = nullptr);
+ng::IntBox<int>* createIntWidget(ng::Widget* parent, const std::string& label, unsigned int value,
+                                 const mx::UIProperties* ui, std::function<void(int)> callback);
 
 #endif // MATERIALXVIEW_EDITOR_H

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -6,27 +6,29 @@ NANOGUI_FORCE_DISCRETE_GPU();
 
 const std::string options = 
 " Options: \n"
-"    --material [FILENAME]          The filename of the MTLX document to be displayed in the viewer\n"
-"    --mesh [FILENAME]              The filename of the OBJ mesh to be displayed in the viewer\n"
-"    --meshRotation [VECTOR3]       The rotation of the displayed mesh as three comma-separated floats, representing rotations in degrees about the X, Y, and Z axes (defaults to 0,0,0)\n"
-"    --meshScale [FLOAT]            The uniform scale of the displayed mesh\n"
-"    --cameraPosition [VECTOR3]     The position of the camera as three comma-separated floats (defaults to 0,0,5)\n"
-"    --cameraTarget [VECTOR3]       The position of the camera target as three comma-separated floats (defaults to 0,0,0)\n"
-"    --cameraViewAngle [FLOAT]      The view angle of the camera (defaults to 45)\n"
-"    --envRad [FILENAME]            The filename of the environment light to display, stored as HDR environment radiance in the latitude-longitude format\n"
-"    --envMethod [INTEGER]          The environment lighting method (0 = filtered importance sampling, 1 = prefiltered environment maps, defaults to 0)\n"
-"    --lightRotation [FLOAT]        The rotation in degrees of the lighting environment about the Y axis (defaults to 0)\n"
-"    --path [FILEPATH]              An additional absolute search path location (e.g. '/projects/MaterialX').  This path will be queried when locating standard data libraries, XInclude references, and referenced images.\n"
-"    --library [FILEPATH]           An additional relative path to a custom data library folder (e.g. 'libraries/custom').  MaterialX files at the root of this folder will be included in all content documents.\n"
-"    --screenWidth [INTEGER]        The width of the screen image in pixels (defaults to 1280)\n"
-"    --screenHeight [INTEGER]       The height of the screen image in pixels (defaults to 960)\n"
-"    --screenColor [VECTOR3]        The background color of the viewer as three comma-separated floats (defaults to 0.3,0.3,0.32)\n"
-"    --msaa [INTEGER]               The multisampling count for screen anti-aliasing (defaults to 0)\n"
-"    --refresh [INTEGER]            The refresh period for the viewer in milliseconds (defaults to 50, set to -1 to disable)\n"
-"    --remap [TOKEN1:TOKEN2]        Remap one token to another when MaterialX document is loaded\n"
-"    --skip [NAME]                  Skip elements matching the given name attribute\n"
-"    --terminator [STRING]          Enforce the given terminator string for file prefixes\n"
-"    --help                         Print this list\n";
+"    --material [FILENAME]          Specify the filename of the MTLX document to be displayed in the viewer\n"
+"    --mesh [FILENAME]              Specify the filename of the OBJ mesh to be displayed in the viewer\n"
+"    --meshRotation [VECTOR3]       Specify the rotation of the displayed mesh as three comma-separated floats, representing rotations in degrees about the X, Y, and Z axes (defaults to 0,0,0)\n"
+"    --meshScale [FLOAT]            Specify the uniform scale of the displayed mesh\n"
+"    --cameraPosition [VECTOR3]     Specify the position of the camera as three comma-separated floats (defaults to 0,0,5)\n"
+"    --cameraTarget [VECTOR3]       Specify the position of the camera target as three comma-separated floats (defaults to 0,0,0)\n"
+"    --cameraViewAngle [FLOAT]      Specify the view angle of the camera (defaults to 45)\n"
+"    --cameraZoom [FLOAT]           Specify the amount to zoom the camera. (defaults to 1.0)\n"
+"    --envRad [FILENAME]            Specify the filename of the environment light to display, stored as HDR environment radiance in the latitude-longitude format\n"
+"    --envMethod [INTEGER]          Specify the environment lighting method (0 = filtered importance sampling, 1 = prefiltered environment maps, defaults to 0)\n"
+"    --envSampleCount [INTEGER]     Specify the environment sample count (defaults to 16)\n"
+"    --lightRotation [FLOAT]        Specify the rotation in degrees of the lighting environment about the Y axis (defaults to 0)\n"
+"    --path [FILEPATH]              Specify an additional absolute search path location (e.g. '/projects/MaterialX').  This path will be queried when locating standard data libraries, XInclude references, and referenced images.\n"
+"    --library [FILEPATH]           Specify an additional relative path to a custom data library folder (e.g. 'libraries/custom').  MaterialX files at the root of this folder will be included in all content documents.\n"
+"    --screenWidth [INTEGER]        Specify the width of the screen image in pixels (defaults to 1280)\n"
+"    --screenHeight [INTEGER]       Specify the height of the screen image in pixels (defaults to 960)\n"
+"    --screenColor [VECTOR3]        Specify the background color of the viewer as three comma-separated floats (defaults to 0.3,0.3,0.32)\n"
+"    --msaa [INTEGER]               Specify the multisampling count for screen anti-aliasing (defaults to 0)\n"
+"    --refresh [INTEGER]            Specify the refresh period for the viewer in milliseconds (defaults to 50, set to -1 to disable)\n"
+"    --remap [TOKEN1:TOKEN2]        Specify the remapping from one token to another when MaterialX document is loaded\n"
+"    --skip [NAME]                  Specify to skip elements matching the given name attribute\n"
+"    --terminator [STRING]          Specify to enforce the given terminator string for file prefixes\n"
+"    --help                         Display the complete list of command-line options\n";
 
 template<class T> void parseToken(std::string token, std::string type, T& res)
 {
@@ -66,8 +68,10 @@ int main(int argc, char* const argv[])
     mx::Vector3 cameraPosition(DEFAULT_CAMERA_POSITION);
     mx::Vector3 cameraTarget;
     float cameraViewAngle(DEFAULT_CAMERA_VIEW_ANGLE);
+    float cameraZoom(DEFAULT_CAMERA_ZOOM);
     std::string envRadiancePath = "resources/Lights/san_giuseppe_bridge_split.hdr";
     mx::HwSpecularEnvironmentMethod specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
+    int envSampleCount = DEFAULT_ENV_SAMPLES;
     float lightRotation = 0.0f;
     DocumentModifiers modifiers;
     int screenWidth = 1280;
@@ -108,6 +112,10 @@ int main(int argc, char* const argv[])
         {
             parseToken(nextToken, "float", cameraViewAngle);
         }
+        else if (token == "--cameraZoom")
+        {
+            parseToken(nextToken, "float", cameraZoom);
+        }
         else if (token == "--envRad")
         {
             envRadiancePath = nextToken;
@@ -119,6 +127,10 @@ int main(int argc, char* const argv[])
                 specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_PREFILTER;
             }
         }
+        else if (token == "--envSampleCount")
+        {
+            parseToken(nextToken, "integer", envSampleCount);
+        }       
         else if (token == "--lightRotation")
         {
             parseToken(nextToken, "float", lightRotation);
@@ -204,8 +216,10 @@ int main(int argc, char* const argv[])
                                                 cameraPosition,
                                                 cameraTarget,
                                                 cameraViewAngle,
+                                                cameraZoom,
                                                 envRadiancePath,
                                                 specularEnvironmentMethod,
+                                                envSampleCount,
                                                 lightRotation,
                                                 libraryFolders,
                                                 searchPath,

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1605,6 +1605,10 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
             _captureFilename = ng::file_dialog(filetypes, true);
             if (!_captureFilename.isEmpty())
             {
+                if (_captureFilename.getExtension().empty())
+                {
+                    _captureFilename.addExtension(mx::ImageLoader::TGA_EXTENSION);
+                }
                 _captureRequested = true;
             }
         }
@@ -1613,6 +1617,18 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
             _wedgeFilename = ng::file_dialog(filetypes, true);
             if (!_wedgeFilename.isEmpty())
             {
+                // There are issues with using the STB loader and png files
+                // so use another format if PNG specified or if no extension specified
+                const std::string extension = _wedgeFilename.getExtension();
+                if (extension.empty())
+                {                    
+                    _wedgeFilename.addExtension(mx::ImageLoader::TGA_EXTENSION);
+                }
+                else if (extension == mx::ImageLoader::PNG_EXTENSION)
+                {
+                    _wedgeFilename.removeExtension();
+                    _wedgeFilename.addExtension(mx::ImageLoader::TGA_EXTENSION);
+                }
                 _wedgeRequested = true;
             }
         }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -31,12 +31,13 @@
 
 const mx::Vector3 DEFAULT_CAMERA_POSITION(0.0f, 0.0f, 5.0f);
 const float DEFAULT_CAMERA_VIEW_ANGLE = 45.0f;
+const float DEFAULT_CAMERA_ZOOM = 1.0f;
+const int DEFAULT_ENV_SAMPLES = 16;
 
 namespace {
 
 const int MIN_ENV_SAMPLES = 4;
 const int MAX_ENV_SAMPLES = 1024;
-const int DEFAULT_ENV_SAMPLES = 16;
 
 const int SHADOW_MAP_SIZE = 2048;
 const int ALBEDO_TABLE_SIZE = 64;
@@ -157,8 +158,10 @@ Viewer::Viewer(const std::string& materialFilename,
                const mx::Vector3& cameraPosition,
                const mx::Vector3& cameraTarget,
                float cameraViewAngle,
+               float cameraZoom,    
                const std::string& envRadiancePath,
                mx::HwSpecularEnvironmentMethod specularEnvironmentMethod,
+               int envSampleCount,
                float lightRotation,
                const mx::FilePathVec& libraryFolders,
                const mx::FileSearchPath& searchPath,
@@ -182,7 +185,7 @@ Viewer::Viewer(const std::string& materialFilename,
     _userCameraEnabled(true),
     _userTranslationActive(false),
     _userTranslationPixel(0, 0),
-    _userScale(1.0f),
+    _userScale(cameraZoom),
     _libraryFolders(libraryFolders),
     _searchPath(searchPath),
     _materialFilename(materialFilename),
@@ -217,7 +220,7 @@ Viewer::Viewer(const std::string& materialFilename,
     _bakeHdr(false),
     _bakeTextureRes(DEFAULT_TEXTURE_RES),
     _outlineSelection(false),
-    _envSamples(DEFAULT_ENV_SAMPLES),
+    _envSamples(envSampleCount),
     _drawEnvironment(false),
     _captureRequested(false),
     _wedgeRequested(false),
@@ -695,7 +698,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
     advancedPopupParent->setLayout(new ng::GroupLayout());
 
     ng::VScrollPanel* scrollPanel = new ng::VScrollPanel(advancedPopupParent);
-    scrollPanel->setFixedHeight(400);
+    scrollPanel->setFixedHeight(500);
     ng::Widget* advancedPopup = new ng::Widget(scrollPanel);
     advancedPopup->setLayout(new ng::GroupLayout(13));
 
@@ -863,7 +866,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
         }
         ng::ComboBox* sampleBox = new ng::ComboBox(sampleGroup, sampleOptions);
         sampleBox->setChevronIcon(-1);
-        sampleBox->setSelectedIndex((int)std::log2(DEFAULT_ENV_SAMPLES / MIN_ENV_SAMPLES) / 2);
+        sampleBox->setSelectedIndex((int)std::log2(_envSamples / MIN_ENV_SAMPLES) / 2);
         sampleBox->setCallback([this](int index)
         {
             _envSamples = MIN_ENV_SAMPLES * (int) std::pow(4, index);
@@ -905,6 +908,47 @@ void Viewer::createAdvancedSettings(Widget* parent)
     {
         _bakeTextureRes = MIN_TEXTURE_RES * (int) std::pow(2, index);
     });
+
+    ng::Label* wedgeLabel = new ng::Label(advancedPopup, "Wedge Rendering Options");
+    wedgeLabel->setFontSize(20);
+    wedgeLabel->setFont("sans-bold");
+
+    ng::Widget* wedgeMin = new ng::Widget(advancedPopup);
+    wedgeMin->setLayout(new ng::BoxLayout(ng::Orientation::Horizontal));
+    mx::UIProperties wedgeProp;
+    wedgeProp.uiSoftMin = mx::Value::createValue(0.0f);
+    wedgeProp.uiSoftMax = mx::Value::createValue(1.0f);
+    ng::FloatBox<float>* wedgeMinBox = createFloatWidget(wedgeMin, "Minimum Wedge Multiplier:",
+        _wedgePropertyMax, &wedgeProp, [this](float value)
+    {
+        _wedgePropertyMin = value;
+    });
+    wedgeMinBox->setValue(0.0);
+    wedgeMinBox->setEditable(true);
+
+    ng::Widget* wedgeMax = new ng::Widget(advancedPopup);
+    wedgeMax->setLayout(new ng::BoxLayout(ng::Orientation::Horizontal));
+    ng::FloatBox<float>* wedgeMaxBox = createFloatWidget(wedgeMax, "Maximum Wedge Multiplier:",
+        _wedgePropertyMax, &wedgeProp, [this](float value)
+    {
+        _wedgePropertyMax = value;
+    });
+    wedgeMaxBox->setValue(1.0);
+    wedgeMaxBox->setEditable(true);
+
+    ng::Widget* wedgeCount = new ng::Widget(advancedPopup);
+    wedgeCount->setLayout(new ng::BoxLayout(ng::Orientation::Horizontal));
+    mx::UIProperties wedgeCountProp;
+    wedgeCountProp.uiMin = mx::Value::createValue(1);
+    wedgeCountProp.uiSoftMax = mx::Value::createValue(8);
+    wedgeCountProp.uiStep = mx::Value::createValue(1);
+    ng::IntBox<int>* wedgeCountBox = createIntWidget(wedgeCount, "Wedge Count:",
+        _wedgeImageCount, &wedgeCountProp, [this](int value)
+    {
+        _wedgeImageCount = value;
+    });
+    wedgeCountBox->setValue(8);
+    wedgeCountBox->setEditable(true);
 }
 
 void Viewer::updateGeometrySelections()
@@ -1547,31 +1591,30 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         return true;
     }
 
-    // Capture the current frame and save as an image file.
-    if (key == GLFW_KEY_F && action == GLFW_PRESS)
+    // Capture the current frame or render wedge and save as an image file.
+    if ((key == GLFW_KEY_F || key == GLFW_KEY_W) && action == GLFW_PRESS)
     {
-        _captureFilename = ng::file_dialog({ { mx::ImageLoader::TGA_EXTENSION, mx::ImageLoader::TGA_EXTENSION } }, true);
-        if (!_captureFilename.isEmpty())
+        mx::StringSet extensions = _imageHandler->supportedExtensions();
+        std::vector<std::pair<std::string, std::string>> filetypes;
+        for (const auto& extension : extensions)
         {
-            if (_captureFilename.getExtension() != mx::ImageLoader::TGA_EXTENSION)
-            {
-                _captureFilename.addExtension(mx::ImageLoader::TGA_EXTENSION);
-            }
-            _captureRequested = true;
+            filetypes.push_back(std::make_pair(extension, extension));
         }
-    }
-
-    // Render a wedge for the current material.
-    if (key == GLFW_KEY_W && action == GLFW_PRESS)
-    {
-        _wedgeFilename = ng::file_dialog({ { mx::ImageLoader::TGA_EXTENSION, mx::ImageLoader::TGA_EXTENSION } }, true);
-        if (!_wedgeFilename.isEmpty())
+        if (key == GLFW_KEY_F)
         {
-            if (_wedgeFilename.getExtension() != mx::ImageLoader::TGA_EXTENSION)
+            _captureFilename = ng::file_dialog(filetypes, true);
+            if (!_captureFilename.isEmpty())
             {
-                _wedgeFilename.addExtension(mx::ImageLoader::TGA_EXTENSION);
+                _captureRequested = true;
             }
-            _wedgeRequested = true;
+        }
+        else
+        {
+            _wedgeFilename = ng::file_dialog(filetypes, true);
+            if (!_wedgeFilename.isEmpty())
+            {
+                _wedgeRequested = true;
+            }
         }
     }
 
@@ -1753,46 +1796,109 @@ mx::ImagePtr Viewer::renderWedge()
         return nullptr;
     }
 
-    mx::ValuePtr origValue = uniform->getValue();
-    if (!origValue->isA<float>() && !origValue->isA<mx::Color3>())
+    mx::ValuePtr origPropertyValue = uniform->getValue();
+    if (origPropertyValue)
     {
-        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Material property type not supported", _wedgePropertyName);
-        return nullptr;
-    }
+        if (!origPropertyValue->isA<int>() && !origPropertyValue->isA<float>() &&
+            !origPropertyValue->isA<mx::Vector2>() &&
+            !origPropertyValue->isA<mx::Color3>() && !origPropertyValue->isA<mx::Vector3>() &&
+            !origPropertyValue->isA<mx::Color4>() && !origPropertyValue->isA<mx::Vector4>())
+        {
+            new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Material property type not supported", _wedgePropertyName);
+            return nullptr;
+        }
 
-    std::vector<mx::ImagePtr> imageVec;
-    float wedgePropertyStep = (_wedgePropertyMax - _wedgePropertyMin) / (_wedgeImageCount - 1);
-    for (unsigned int i = 0; i < _wedgeImageCount; i++)
-    {
+        std::vector<mx::ImagePtr> imageVec;
+        float wedgePropertyStep = (_wedgePropertyMax - _wedgePropertyMin) / (_wedgeImageCount - 1);
+        for (unsigned int i = 0; i < _wedgeImageCount; i++)
+        {
+            bool setValue = false;
+            if (material)
+            {
+                float propertyValue = (i == _wedgeImageCount - 1) ? _wedgePropertyMax : _wedgePropertyMin + wedgePropertyStep * i;
+                if (origPropertyValue->isA<int>())
+                {
+                    material->setUniformInt(_wedgePropertyName, static_cast<int>(propertyValue));
+                    setValue = true;
+                }
+                else if (origPropertyValue->isA<float>())
+                {
+                    material->setUniformFloat(_wedgePropertyName, propertyValue);
+                    setValue = true;
+                }
+                else if (origPropertyValue->isA<mx::Vector2>())
+                {
+                    ng::Vector2f val(propertyValue, propertyValue);
+                    material->setUniformVec2(_wedgePropertyName, val);
+                    setValue = true;
+                }
+                else if (origPropertyValue->isA<mx::Color3>() ||
+                    origPropertyValue->isA<mx::Vector3>())
+                {
+                    ng::Vector3f val(propertyValue, propertyValue, propertyValue);
+                    material->setUniformVec3(_wedgePropertyName, val);
+                    setValue = true;
+                }
+                else if (origPropertyValue->isA<mx::Color4>() ||
+                    origPropertyValue->isA<mx::Vector4>())
+                {
+                    ng::Vector4f val(propertyValue, propertyValue, propertyValue, origPropertyValue->isA<mx::Color4>() ? 1.0f : propertyValue);
+                    material->setUniformVec4(_wedgePropertyName, val);
+                    setValue = true;
+                }
+            }
+            if (setValue)
+            {
+                renderFrame();
+                imageVec.push_back(getFrameImage());
+            }
+        }
+
         if (material)
         {
-            float renderValue = (i == _wedgeImageCount - 1) ? _wedgePropertyMax : _wedgePropertyMin + wedgePropertyStep * i;
-            if (origValue->isA<float>())
+            if (origPropertyValue->isA<int>())
             {
-                material->setUniformFloat(_wedgePropertyName, renderValue);
+                material->setUniformInt(_wedgePropertyName, origPropertyValue->asA<int>());
             }
-            else if (origValue->isA<mx::Color3>())
+            else if (origPropertyValue->isA<float>())
             {
-                material->setUniformVec3(_wedgePropertyName, ng::Vector3f(renderValue, renderValue, renderValue));
+                material->setUniformFloat(_wedgePropertyName, origPropertyValue->asA<float>());
+            }
+            else if (origPropertyValue->isA<mx::Color3>())
+            {
+                const mx::Color3& val =  origPropertyValue->asA<mx::Color3>();
+                ng::Vector3f ngval(val[0], val[1], val[2]);
+                material->setUniformVec3(_wedgePropertyName, ngval);
+            }
+            else if (origPropertyValue->isA<mx::Vector2>())
+            {
+                const mx::Vector2& val = origPropertyValue->asA<mx::Vector2>();
+                ng::Vector2f ngval(val[0], val[1]);
+                material->setUniformVec2(_wedgePropertyName, ngval);
+            }
+            else if (origPropertyValue->isA<mx::Vector3>())
+            {
+                const mx::Vector3& val = origPropertyValue->asA<mx::Vector3>();
+                ng::Vector3f ngval(val[0], val[1], val[2]);
+                material->setUniformVec3(_wedgePropertyName, ngval);
+            }
+            else if (origPropertyValue->isA<mx::Color4>())
+            {
+                const mx::Color4& val = origPropertyValue->asA<mx::Color4>();
+                ng::Vector4f ngval(val[0], val[1], val[1], val[2]);
+                material->setUniformVec4(_wedgePropertyName, ngval);
+            }
+            else if (origPropertyValue->isA<mx::Vector4>())
+            {
+                const mx::Vector4& val = origPropertyValue->asA<mx::Vector4>();
+                ng::Vector4f ngval(val[0], val[1], val[1], val[2]);
+                material->setUniformVec4(_wedgePropertyName, ngval);
             }
         }
-        renderFrame();
-        imageVec.push_back(getFrameImage());
-    }
 
-    if (material)
-    {
-        if (origValue->isA<float>())
-        {
-            material->setUniformFloat(_wedgePropertyName, origValue->asA<float>());
-        }
-        else if (origValue->isA<mx::Color3>())
-        {
-            material->setUniformVec3(_wedgePropertyName, ng::Vector3f(origValue->asA<mx::Color3>().data()));
-        }
+        return mx::createImageStrip(imageVec);
     }
-
-    return mx::createImageStrip(imageVec);
+    return nullptr;
 }
 
 void Viewer::bakeTextures()
@@ -2076,10 +2182,87 @@ void Viewer::updateViewHandlers()
     }
 }
 
+void Viewer::createWedgeParameterInterface(Widget* parent, const std::string& label)
+{
+    ng::Label* wedgeLabel = new ng::Label(parent, label);
+    _wedgeSelectionBox = new ng::ComboBox(parent, { "None" });
+    _wedgeSelectionBox->setChevronIcon(-1);
+    _wedgeSelectionBox->setFontSize(15);
+    _wedgeSelectionBox->setCallback([this](int choice)
+    {
+        size_t index = (size_t)choice;
+        const std::vector<std::string> &wedgeItems = this->_wedgeSelectionBox->items();
+        if (!wedgeItems.empty())
+        {
+            this->_wedgePropertyName = wedgeItems[index];
+        }
+    });
+
+    std::vector<std::string> wedgeItems;
+    MaterialPtr material = getSelectedMaterial();
+    if (material)
+    {
+        mx::DocumentPtr doc = material->getDocument();
+
+        const mx::VariableBlock* publicUniforms = material->getPublicUniforms();
+        if (publicUniforms)
+        {
+            mx::UIPropertyGroup groups;
+            mx::UIPropertyGroup unnamedGroups;
+            const std::string pathSeparator(":");
+            mx::createUIPropertyGroups(*publicUniforms, doc, material->getElement(),
+                pathSeparator, groups, unnamedGroups, true);
+
+            for (auto it = groups.begin(); it != groups.end(); ++it)
+            {
+                const mx::UIPropertyItem& item = it->second;
+                if (material->findUniform(item.variable->getPath()) &&
+                    (item.value->isA<float>() ||
+                    item.value->isA<int>() ||
+                    item.value->isA<mx::Vector2>() ||
+                    item.value->isA<mx::Vector3>() ||
+                    item.value->isA<mx::Color3>() ||
+                    item.value->isA<mx::Vector4>() ||
+                    item.value->isA<mx::Color4>()))
+                {
+                    wedgeItems.push_back(item.variable->getPath());
+                }
+            }
+            for (auto it2 = unnamedGroups.begin(); it2 != unnamedGroups.end(); ++it2)
+            {
+                const mx::UIPropertyItem& item = it2->second;
+                if (material->findUniform(item.variable->getPath()) &&
+                    (item.value->isA<float>() ||
+                    item.value->isA<int>() ||
+                    item.value->isA<mx::Vector2>() ||
+                    item.value->isA<mx::Vector3>() ||
+                    item.value->isA<mx::Color3>() ||
+                    item.value->isA<mx::Vector4>() ||
+                    item.value->isA<mx::Color4>()))
+                {
+                    wedgeItems.push_back(item.variable->getPath());
+                }
+            }
+            _wedgeSelectionBox->setItems(wedgeItems);
+        }
+    }
+
+    _wedgePropertyName.clear();
+    bool haveItems = !wedgeItems.empty();
+    if (haveItems)
+    {
+        _wedgePropertyName = wedgeItems[0];
+    }
+    wedgeLabel->setVisible(haveItems);
+    _wedgeSelectionBox->setVisible(haveItems);
+}
+
 void Viewer::updateDisplayedProperties()
 {
     _propertyEditor.updateContents(this);
     createSaveMaterialsInterface(_propertyEditor.getWindow(), "Save Material");
+    createWedgeParameterInterface(_propertyEditor.getWindow(), "Wedge Parameter");
+    performLayout();
 }
 
 mx::ImagePtr Viewer::getAmbientOcclusionImage(MaterialPtr material)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -918,7 +918,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
     mx::UIProperties wedgeProp;
     wedgeProp.uiSoftMin = mx::Value::createValue(0.0f);
     wedgeProp.uiSoftMax = mx::Value::createValue(1.0f);
-    ng::FloatBox<float>* wedgeMinBox = createFloatWidget(wedgeMin, "Minimum Wedge Multiplier:",
+    ng::FloatBox<float>* wedgeMinBox = createFloatWidget(wedgeMin, "Wedge Minimum Value:",
         _wedgePropertyMax, &wedgeProp, [this](float value)
     {
         _wedgePropertyMin = value;
@@ -928,7 +928,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
 
     ng::Widget* wedgeMax = new ng::Widget(advancedPopup);
     wedgeMax->setLayout(new ng::BoxLayout(ng::Orientation::Horizontal));
-    ng::FloatBox<float>* wedgeMaxBox = createFloatWidget(wedgeMax, "Maximum Wedge Multiplier:",
+    ng::FloatBox<float>* wedgeMaxBox = createFloatWidget(wedgeMax, "Wedge Maximum Value:",
         _wedgePropertyMax, &wedgeProp, [this](float value)
     {
         _wedgePropertyMax = value;

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -282,5 +282,4 @@ extern const float DEFAULT_CAMERA_VIEW_ANGLE;
 extern const float DEFAULT_CAMERA_ZOOM;
 extern const int DEFAULT_ENV_SAMPLES;
 
-
 #endif // MATERIALXVIEW_VIEWER_H

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -27,8 +27,10 @@ class Viewer : public ng::Screen
            const mx::Vector3& cameraPosition,
            const mx::Vector3& cameraTarget,
            float cameraViewAngle,
+           float cameraZoom,
            const std::string& envRadiancePath,
            mx::HwSpecularEnvironmentMethod specularEnvironmentMethod,
+           int envSampleCount,
            float lightRotation,
            const mx::FilePathVec& libraryFolders,
            const mx::FileSearchPath& searchPath,
@@ -122,6 +124,7 @@ class Viewer : public ng::Screen
     void createLoadMaterialsInterface(Widget* parent, const std::string& label);
     void createLoadEnvironmentInterface(Widget* parent, const std::string& label);
     void createSaveMaterialsInterface(Widget* parent, const std::string& label);
+    void createWedgeParameterInterface(Widget* parent, const std::string& label);
     void createPropertyEditorInterface(Widget* parent, const std::string& label);
     void createAdvancedSettings(Widget* parent);
 
@@ -267,6 +270,7 @@ class Viewer : public ng::Screen
     float _wedgePropertyMin;
     float _wedgePropertyMax;
     unsigned int _wedgeImageCount;
+    ng::ComboBox* _wedgeSelectionBox;
 
     // Texture baking
     bool _bakeRequested;
@@ -275,5 +279,8 @@ class Viewer : public ng::Screen
 
 extern const mx::Vector3 DEFAULT_CAMERA_POSITION;
 extern const float DEFAULT_CAMERA_VIEW_ANGLE;
+extern const float DEFAULT_CAMERA_ZOOM;
+extern const int DEFAULT_ENV_SAMPLES;
+
 
 #endif // MATERIALXVIEW_VIEWER_H

--- a/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
@@ -23,4 +23,7 @@ void bindPyUtil(py::module& mod)
     mod.def("splitString", &mx::splitString);
     mod.def("replaceSubstrings", &mx::replaceSubstrings);
     mod.def("stringEndsWith", &mx::stringEndsWith);
+    mod.def("splitNamePath", &mx::splitNamePath);
+    mod.def("createNamePath", &mx::createNamePath);
+    mod.def("parentNamePath", &mx::parentNamePath);
 }


### PR DESCRIPTION
- Expose general parameters in advanced.
- Expose choice of parameter to sample (supports int, float, vec2, vec3, color3, vec4, color4) now vs only float before.
- Support more than tga in file dialog.
- Add in additional command line arguments to avoid having to interactively perform this:
  --cameraZoom <float> : Amount of user zoom to apply 1.3 seems to get a close fit.
  --envSampleCount <int> : Default is 16 but 64 is a good fidelity number.

Snapshot of new UI with sample material:
![image](https://user-images.githubusercontent.com/14275104/93219811-c051bc00-f739-11ea-8bc6-6b1361d3009d.png)

Sample result:
![image](https://user-images.githubusercontent.com/14275104/93219828-c6479d00-f739-11ea-8522-cb97f5d3e931.png)
