### PR TITLE
Improvements to acquireImage

### DIFF
--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -8,6 +8,8 @@
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/Util.h>
 
+#include <iostream>
+
 namespace MaterialX
 {
 
@@ -92,7 +94,7 @@ bool ImageHandler::saveImage(const FilePath& filePath,
     return false;
 }
 
-ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4* fallbackColor, string* message)
+ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4* fallbackColor)
 {
     FilePath foundFilePath = _searchPath.find(filePath);
     string extension = stringToLower(foundFilePath.getExtension());
@@ -115,19 +117,19 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4
         }
     }
 
-    if (message && !filePath.isEmpty())
+    if (!filePath.isEmpty())
     {
         if (!foundFilePath.exists())
         {
-            *message = string("Image file not found: ") + filePath.asString();
+            std::cerr << string("Image file not found: ") + filePath.asString() << std::endl;
         }
         else if (!extensionSupported)
         {
-            *message = string("Unsupported image extension: ") + filePath.asString();
+            std::cerr << string("Unsupported image extension: ") + filePath.asString() << std::endl;
         }
         else
         {
-            *message = string("Image loader failed to parse image: ") + filePath.asString();
+            std::cerr << string("Image loader failed to parse image: ") + filePath.asString() << std::endl;
         }
     }
     if (fallbackColor)

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -177,13 +177,10 @@ class ImageHandler
     /// @param fallbackColor Optional uniform color of a fallback texture
     ///    to create when the image cannot be loaded from the file system.
     ///    By default, no fallback texture is created.
-    /// @param message Optional pointer to a message string, where any warning
-    ///    or error messages from the acquire operation will be stored.
     /// @return On success, a shared pointer to the acquired Image.
     virtual ImagePtr acquireImage(const FilePath& filePath,
-                                  bool generateMipMaps,
-                                  const Color4* fallbackColor = nullptr,
-                                  string* message = nullptr);
+                                  bool generateMipMaps = true,
+                                  const Color4* fallbackColor = nullptr);
 
     /// Bind an image for rendering.
     /// @param image The image to bind.

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -29,8 +29,7 @@ GLTextureHandler::GLTextureHandler(ImageLoaderPtr imageLoader) :
 
 ImagePtr GLTextureHandler::acquireImage(const FilePath& filePath,
                                         bool generateMipMaps,
-                                        const Color4* fallbackColor,
-                                        string* message)
+                                        const Color4* fallbackColor)
 {
     // Resolve the input filepath.
     FilePath resolvedFilePath = filePath;
@@ -47,7 +46,7 @@ ImagePtr GLTextureHandler::acquireImage(const FilePath& filePath,
     }
 
     // Call the base acquire method.
-    return ImageHandler::acquireImage(resolvedFilePath, generateMipMaps, fallbackColor, message);
+    return ImageHandler::acquireImage(resolvedFilePath, generateMipMaps, fallbackColor);
 }
 
 bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties)

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -30,9 +30,8 @@ class GLTextureHandler : public ImageHandler
     /// Acquire an image from the cache or file system.  If the image is not
     /// found in the cache, then each image loader will be applied in turn.
     ImagePtr acquireImage(const FilePath& filePath,
-                          bool generateMipMaps,
-                          const Color4* fallbackColor = nullptr,
-                          string* message = nullptr) override;
+                          bool generateMipMaps = true,
+                          const Color4* fallbackColor = nullptr) override;
 
     /// Bind an image. This method will bind the texture to an active texture
     /// unit as defined by the corresponding image description. The method

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -545,11 +545,7 @@ ImagePtr GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation,
     {
         // Acquire the image.
         string error;
-        ImagePtr image = imageHandler->acquireImage(filePath, generateMipMaps, &(samplingProperties.defaultColor), &error);
-        if (!error.empty())
-        {
-            std::cerr << error << std::endl;
-        }
+        ImagePtr image = imageHandler->acquireImage(filePath, generateMipMaps, &(samplingProperties.defaultColor));
         if (imageHandler->bindImage(image, samplingProperties))
         {
             GLTextureHandlerPtr textureHandler = std::static_pointer_cast<GLTextureHandler>(imageHandler);
@@ -690,7 +686,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
                 string filename = inputPtr->value->getValueString();
                 if (!filename.empty())
                 {
-                    image = imageHandler->acquireImage(filename, true);
+                    image = imageHandler->acquireImage(filename);
                 }
             }
             if (!image)

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -312,11 +312,7 @@ mx::ImagePtr Material::bindImage(const mx::FilePath& filePath, const std::string
 
     // Acquire the given image.
     std::string error;
-    mx::ImagePtr image = imageHandler->acquireImage(filePath, true, fallbackColor, &error);
-    if (!error.empty())
-    {
-        std::cerr << error << std::endl;
-    }
+    mx::ImagePtr image = imageHandler->acquireImage(filePath, true, fallbackColor);
     if (!image)
     {
         return nullptr;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -358,13 +358,11 @@ Viewer::Viewer(const std::string& materialFilename,
 
 void Viewer::loadEnvironmentLight()
 {
-    std::string message;
-
     // Load the requested radiance map.
-    mx::ImagePtr envRadianceMap = _imageHandler->acquireImage(_envRadiancePath, true, nullptr, &message);
+    mx::ImagePtr envRadianceMap = _imageHandler->acquireImage(_envRadiancePath);
     if (!envRadianceMap)
     {
-        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to load environment light", message);
+        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to load environment light");
         return;
     }
 
@@ -394,7 +392,7 @@ void Viewer::loadEnvironmentLight()
     if (!_normalizeEnvironment && !_splitDirectLight)
     {
         mx::FilePath envIrradiancePath = _envRadiancePath.getParentPath() / IRRADIANCE_MAP_FOLDER / _envRadiancePath.getBaseName();
-        envIrradianceMap = _imageHandler->acquireImage(envIrradiancePath, true, nullptr, &message);
+        envIrradianceMap = _imageHandler->acquireImage(envIrradiancePath);
     }
 
     // If not found, then generate an irradiance map via spherical harmonics.

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -73,7 +73,13 @@ void bindPyImageHandler(py::module& mod)
         .def("addLoader", &mx::ImageHandler::addLoader)
         .def("saveImage", &mx::ImageHandler::saveImage,
             py::arg("filePath"), py::arg("image"), py::arg("verticalFlip") = false)
-        .def("acquireImage", &mx::ImageHandler::acquireImage)
+        .def("acquireImage", &mx::ImageHandler::acquireImage,
+            py::arg("filePath"), py::arg("generateMipMaps") = true, py::arg("fallbackColor") = (mx::Color4*) nullptr)
+        .def("acquireImage", [](mx::ImageHandler& handler, const mx::FilePath& filePath, bool generateMipMaps, const mx::Color4* fallbackColor, const std::string*)
+            {
+                // Convert from v1.37.2 function signature.
+                return handler.acquireImage(filePath, generateMipMaps, fallbackColor);
+            })
         .def("bindImage", &mx::ImageHandler::bindImage)
         .def("unbindImage", &mx::ImageHandler::unbindImage)
         .def("setSearchPath", &mx::ImageHandler::setSearchPath)

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
@@ -14,7 +14,8 @@ void bindPyGLTextureHandler(py::module& mod)
 {
     py::class_<mx::GLTextureHandler, mx::ImageHandler, mx::GLTextureHandlerPtr>(mod, "GLTextureHandler")
         .def_static("create", &mx::GLTextureHandler::create)
-        .def("acquireImage", &mx::GLTextureHandler::acquireImage)
+        .def("acquireImage", &mx::GLTextureHandler::acquireImage,
+            py::arg("filePath"), py::arg("generateMipMaps") = true, py::arg("fallbackColor") = (mx::Color4*) nullptr)
         .def("bindImage", &mx::GLTextureHandler::bindImage)
         .def("mapAddressModeToGL", &mx::GLTextureHandler::mapAddressModeToGL)
         .def("mapFilterTypeToGL", &mx::GLTextureHandler::mapFilterTypeToGL);


### PR DESCRIPTION
- Remove the 'message' return value from ImageHandler::acquireImage, allowing for more straightforward Python bindings.
- Generate mipmaps by default in ImageHandler::acquireImage.