### PR TITLE
Improvements to shader translation

### DIFF
--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -7,8 +7,6 @@
 
 #include <MaterialXCore/Util.h>
 
-#include <iostream>
-
 namespace MaterialX
 {
 
@@ -16,34 +14,8 @@ namespace MaterialX
 // ShaderTranslator methods
 //
 
-ShaderTranslator::ShaderTranslator(ConstDocumentPtr doc) :
-    _doc(doc)
+ShaderTranslator::ShaderTranslator()
 {
-    loadShadingTranslations();
-}
-
-void ShaderTranslator::loadShadingTranslations()
-{
-    for (NodeDefPtr node : _doc->getNodeDefs())
-    {
-        if (node->getNodeGroup() == NodeDef::TRANSLATION_NODE_GROUP)
-        {
-            // Parsing translation nodes
-            size_t pos = node->getNodeString().find("_to_");
-            string start = node->getNodeString().substr(0, pos);
-            string end = node->getNodeString().substr(pos + 4);
-            std::unordered_map<string, StringSet>::const_iterator it = _shadingTranslations.find(start);
-
-            if (it != _shadingTranslations.end())
-            {
-                _shadingTranslations[start].insert(end);
-            }
-            else
-            {
-                _shadingTranslations[start] = { end };
-            }
-        }
-    }
 }
 
 void ShaderTranslator::connectToTranslationInputs(ShaderRefPtr shaderRef, NodeDefPtr translationNodeDef)
@@ -68,7 +40,7 @@ void ShaderTranslator::connectToTranslationInputs(ShaderRefPtr shaderRef, NodeDe
             }
             else
             {
-                std::cerr << "No associated output with " << bindInput->getName() << std::endl;
+                throw Exception("No associated output with " + bindInput->getName());
             }
         }
 
@@ -123,9 +95,14 @@ void ShaderTranslator::connectTranslationOutputs(ShaderRefPtr shaderRef)
     {
         // Updating the shaderref sockets
         string outputName = translationGraphOutput->getName();
-        outputName = outputName.substr(0, outputName.find("_out"));
-        OutputPtr translatedOutput = _graph->addOutput(outputName + "_out", translationGraphOutput->getType());
-        BindInputPtr translatedBindInput = shaderRef->addBindInput(outputName, translationGraphOutput->getType());
+        size_t pos = outputName.find("_out");
+        if (pos == string::npos)
+        {
+            throw Exception("Translation graph output " + outputName + " does not end with '_out'");
+        }
+        string inputName = outputName.substr(0, pos);
+        OutputPtr translatedOutput = _graph->addOutput(outputName, translationGraphOutput->getType());
+        BindInputPtr translatedBindInput = shaderRef->addBindInput(inputName, translationGraphOutput->getType());
         translatedBindInput->setConnectedOutput(translatedOutput);
         // if normals need to be transformed into world space
         if (connectsToNormalMapNode(translationGraphOutput))
@@ -135,7 +112,7 @@ void ShaderTranslator::connectTranslationOutputs(ShaderRefPtr shaderRef)
         else
         {
             // registering outputs from translation node
-            NodePtr outNode = _graph->addNode("dot", outputName + "_dot", translationGraphOutput->getType());
+            NodePtr outNode = _graph->addNode("dot", inputName + "_dot", translationGraphOutput->getType());
             translatedOutput->setConnectedNode(outNode);
 
             InputPtr dotNodeInput = outNode->addInput("in", translationGraphOutput->getType());
@@ -148,7 +125,7 @@ void ShaderTranslator::connectTranslationOutputs(ShaderRefPtr shaderRef)
             else
             {
                 dotNodeInput->setConnectedNode(_translationNode);
-                dotNodeInput->setOutputString(outputName + "_out");
+                dotNodeInput->setOutputString(outputName);
             }
         }
     }
@@ -160,10 +137,12 @@ void ShaderTranslator::translateShader(ShaderRefPtr shaderRef, string destShader
     {
         return;
     }
+    if (shaderRef->getNodeString() == destShader)
+    {
+        throw Exception("Both source and destination shader in translation are " + destShader);
+    }
 
     DocumentPtr doc = shaderRef->getDocument();
-    string translateNodeString = shaderRef->getNodeString() + "_to_" + destShader;
-
     vector<OutputPtr> referencedOutputs = shaderRef->getReferencedOutputs();
     if (!referencedOutputs.empty())
     {
@@ -174,46 +153,32 @@ void ShaderTranslator::translateShader(ShaderRefPtr shaderRef, string destShader
         _graph = doc->addNodeGraph();
     }
 
-    _translationNode = _graph->addNode(translateNodeString, "translation", MULTI_OUTPUT_TYPE_STRING);
-    NodeDefPtr translationNodeDef = _translationNode->getNodeDef();
-    if (!translationNodeDef)
+    string sourceShader = shaderRef->getNodeString();
+    string translateNodeString = sourceShader + "_to_" + destShader;
+    vector<NodeDefPtr> matchingNodeDefs = doc->getMatchingNodeDefs(translateNodeString);
+    if (matchingNodeDefs.empty())
     {
-        return;
+        throw Exception("Shader translation requires a translation nodedef named " + translateNodeString);
     }
+    NodeDefPtr translationNodeDef = matchingNodeDefs[0];
+    _translationNode = _graph->addNodeInstance(translationNodeDef);
 
     connectToTranslationInputs(shaderRef, translationNodeDef);
     shaderRef->setNodeString(destShader);
+    shaderRef->removeAttribute(ShaderRef::NODE_DEF_ATTRIBUTE);
     connectTranslationOutputs(shaderRef);
 }
 
-bool ShaderTranslator::translateAllMaterials(DocumentPtr doc, string destShader)
+void ShaderTranslator::translateAllMaterials(DocumentPtr doc, string destShader)
 {
-    ShaderTranslatorPtr translator = ShaderTranslator::create(doc);
     vector<TypedElementPtr> renderableShaderRefs;
     std::unordered_set<OutputPtr> outputs;
     findRenderableShaderRefs(doc, renderableShaderRefs, false, outputs);
     for (TypedElementPtr elem : renderableShaderRefs)
     {
-        ShaderRefPtr sr = elem ? elem->asA<ShaderRef>() : nullptr;
-        string sourceShader = sr->getNodeString();
-        string sourceName = sr->getName();
-        if (translator->getAvailableTranslations(sourceShader).count(destShader))
-        {
-            translator->translateShader(sr, destShader);
-            std::cout << "Successfully translated " << sourceName << " from " << sourceShader << 
-                " to " << destShader << std::endl;
-        }
-        else if (sourceShader == destShader)
-        {
-            std::cout << sourceName << " source and destination shaders are both " << destShader << std::endl;
-        }
-        else
-        {
-            std::cerr << "No valid translation from " << sourceShader << " to " << destShader << std::endl;
-            return false;
-        }
+        ShaderRefPtr shaderRef = elem ? elem->asA<ShaderRef>() : nullptr;
+        translateShader(shaderRef, destShader);
     }
-    return true;
 }
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/ShaderTranslator.h
+++ b/source/MaterialXGenShader/ShaderTranslator.h
@@ -20,51 +20,35 @@ using ShaderTranslatorPtr = shared_ptr<class ShaderTranslator>;
 class ShaderTranslator
 {
   public:
-    static ShaderTranslatorPtr create(ConstDocumentPtr doc)
+    static ShaderTranslatorPtr create()
     {
-        return ShaderTranslatorPtr(new ShaderTranslator(doc));
+        return ShaderTranslatorPtr(new ShaderTranslator());
     }
 
-    /// Translates shaderRef to the destShader shading model
+    /// Translate a shader reference to the destination shading model.
     void translateShader(ShaderRefPtr shaderRef, string destShader);
 
-    /// Translates all the materials to the destShader shading model if translation exists.
-    static bool translateAllMaterials(DocumentPtr doc, string destShader);
-
-    /// Returns set of all the available potential translations
-    StringSet getAvailableTranslations(string start)
-    {
-        return _shadingTranslations[start];
-    }
+    /// Translate each material in the input document to the destination
+    /// shading model.
+    void translateAllMaterials(DocumentPtr doc, string destShader);
 
   protected:
-    ShaderTranslator(ConstDocumentPtr doc);
+    ShaderTranslator();
 
-    /// Reads shading translation nodes from the document
-    void loadShadingTranslations();
-
-    /// Connects translation node inputs from the original shaderRef
+    // Connect translation node inputs from the original shaderRef
     void connectToTranslationInputs(ShaderRefPtr shaderRef, NodeDefPtr translationNodeDef);
 
-    /// Copies translation nodegraph upstream node dependencies over to the working nodegraph.
-    /// Used when normals need to be baked in tangent space but shaderref expects normals to 
-    /// be in world space.
+    // Copy translation nodegraph upstream node dependencies over to the working nodegraph.
+    // Used when normals need to be baked in tangent space but shaderref expects normals to 
+    // be in world space.
     void insertUpstreamDependencies(OutputPtr translatedOutput, OutputPtr ngOutput);
 
-    /// Connects translation node outputs to finalize shaderRef translation
+    // Connect translation node outputs to finalize shaderref translation
     void connectTranslationOutputs(ShaderRefPtr shaderRef);
 
-    /// Map that stores all the potential destination shading models for given shading model
-    std::unordered_map<string, StringSet> _shadingTranslations;
-
-    /// Saved document that contains library for shading translation
-    ConstDocumentPtr _doc;
-
-    /// The inserted translation node
-    NodePtr _translationNode;
-
-    /// The nodegraph where translation node will be inserted
+  protected:
     NodeGraphPtr _graph;
+    NodePtr _translationNode;
 };
 
 } // namespace MaterialX

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShaderTranslator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShaderTranslator.cpp
@@ -14,5 +14,6 @@ void bindPyShaderTranslator(py::module& mod)
 {
     py::class_<mx::ShaderTranslator, mx::ShaderTranslatorPtr>(mod, "ShaderTranslator")
         .def_static("create", &mx::ShaderTranslator::create)
-        .def_static("translateAllMaterials", &mx::ShaderTranslator::translateAllMaterials);
+        .def("translateShader", &mx::ShaderTranslator::translateShader)
+        .def("translateAllMaterials", &mx::ShaderTranslator::translateAllMaterials);
 }


### PR DESCRIPTION
- Make ShaderTranslator::translateAllShaders a non-static member function.
- Use exceptions rather than standard I/O to signal errors.
- Add error messages for common missing features in translation graphs.