### PR TITLE
Add GLSL subsurface scattering approximation

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -39,3 +39,46 @@ float mx_burley_diffuse_directional_albedo(float NdotV, float roughness)
     float fit1 = 1.55754 + (-2.02221 + (2.56283 - 1.06244 * x) * x) * x;
     return mix(fit0, fit1, roughness);
 }
+
+// Evaluate the Burley diffusion profile for the given distance and diffusion shape.
+// Based on https://graphics.pixar.com/library/ApproxBSSRDF/
+vec3 mx_burley_diffusion_profile(float dist, vec3 shape)
+{
+    vec3 num1 = exp(-shape * dist);
+    vec3 num2 = exp(-shape * dist / 3.0);
+    float denom = max(dist, M_FLOAT_EPS);
+    return (num1 + num2) / denom;
+}
+
+// Integrate the Burley diffusion profile over a sphere of the given radius.
+// Inspired by Eric Penner's presentation in http://advances.realtimerendering.com/s2011/
+vec3 mx_integrate_burley_diffusion(vec3 N, vec3 L, float radius, vec3 mfp)
+{
+    float theta = acos(dot(N, L));
+
+    // Estimate the Burley diffusion shape from mean free path.
+    vec3 shape = vec3(1.0) / max(mfp, 0.1);
+
+    // Integrate the profile over the sphere.
+    vec3 sumD = vec3(0.0);
+    vec3 sumR = vec3(0.0);
+    const int SAMPLE_COUNT = 32;
+    const float SAMPLE_WIDTH = (2.0 * M_PI) / SAMPLE_COUNT;
+    for (int i = 0; i < SAMPLE_COUNT; i++)
+    {
+        float x = -M_PI + (i + 0.5) * SAMPLE_WIDTH;
+        float dist = radius * abs(2.0 * sin(x * 0.5));
+        vec3 R = mx_burley_diffusion_profile(dist, shape);
+        sumD += R * max(cos(theta + x), 0.0);
+        sumR += R;
+    }
+
+    return sumD / sumR;
+}
+
+vec3 mx_subsurface_scattering_approx(vec3 N, vec3 L, vec3 P, vec3 albedo, vec3 mfp)
+{
+    float curvature = length(fwidth(N)) / length(fwidth(P));
+    float radius = 1.0 / max(curvature, 0.01);
+    return albedo * mx_integrate_burley_diffusion(N, L, radius, mfp) / vec3(M_PI);
+}

--- a/libraries/pbrlib/genglsl/mx_add_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_add_bsdf.glsl
@@ -1,4 +1,4 @@
-void mx_add_bsdf_reflection(vec3 L, vec3 V, BSDF in1, BSDF in2, out BSDF result)
+void mx_add_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, BSDF in1, BSDF in2, out BSDF result)
 {
     result = in1 + in2;
 }

--- a/libraries/pbrlib/genglsl/mx_burley_diffuse_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_burley_diffuse_brdf.glsl
@@ -1,6 +1,6 @@
 #include "pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
 
-void mx_burley_diffuse_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float roughness, vec3 normal, out BSDF result)
+void mx_burley_diffuse_brdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, out BSDF result)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -10,7 +10,7 @@ void mx_burley_diffuse_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color,
 
     float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
 
-    result = color * weight * NdotL * M_PI_INV;
+    result = color * occlusion * weight * NdotL * M_PI_INV;
     result *= mx_burley_diffuse(L, V, normal, NdotL, roughness);
     return;
 }

--- a/libraries/pbrlib/genglsl/mx_conductor_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_brdf.glsl
@@ -1,7 +1,7 @@
 #include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 #include "pbrlib/genglsl/lib/mx_refraction_index.glsl"
 
-void mx_conductor_brdf_reflection(vec3 L, vec3 V, float weight, vec3 reflectivity, vec3 edge_color, vec2 roughness, vec3 N, vec3 X, int distribution, out BSDF result)
+void mx_conductor_brdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 reflectivity, vec3 edge_color, vec2 roughness, vec3 N, vec3 X, int distribution, out BSDF result)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -29,7 +29,7 @@ void mx_conductor_brdf_reflection(vec3 L, vec3 V, float weight, vec3 reflectivit
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
 
     // Note: NdotL is cancelled out
-    result = D * F * G * comp * weight / (4 * NdotV);
+    result = D * F * G * comp * occlusion * weight / (4 * NdotV);
 }
 
 void mx_conductor_brdf_indirect(vec3 V, float weight, vec3 reflectivity, vec3 edge_color, vec2 roughness, vec3 N, vec3 X, int distribution, out BSDF result)

--- a/libraries/pbrlib/genglsl/mx_dielectric_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_brdf.glsl
@@ -1,6 +1,6 @@
 #include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
-void mx_dielectric_brdf_reflection(vec3 L, vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
+void mx_dielectric_brdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -27,8 +27,8 @@ void mx_dielectric_brdf_reflection(vec3 L, vec3 V, float weight, vec3 tint, floa
     float dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
 
     // Note: NdotL is cancelled out
-    result = D * F * G * comp * tint * weight / (4 * NdotV) // Top layer reflection
-           + base * (1.0 - dirAlbedo * weight);             // Base layer reflection attenuated by top layer
+    result = D * F * G * comp * tint * occlusion * weight / (4 * NdotV) // Top layer reflection
+           + base * (1.0 - dirAlbedo * weight);                         // Base layer reflection attenuated by top layer
 }
 
 void mx_dielectric_brdf_transmission(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)

--- a/libraries/pbrlib/genglsl/mx_diffuse_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_diffuse_brdf.glsl
@@ -1,6 +1,6 @@
 #include "pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
 
-void mx_diffuse_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float roughness, vec3 normal, out BSDF result)
+void mx_diffuse_brdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, out BSDF result)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -10,7 +10,7 @@ void mx_diffuse_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float 
 
     float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
 
-    result = color * weight * NdotL * M_PI_INV;
+    result = color * occlusion * weight * NdotL * M_PI_INV;
     if (roughness > 0.0)
     {
         result *= mx_oren_nayar_diffuse(L, V, normal, NdotL, roughness);

--- a/libraries/pbrlib/genglsl/mx_diffuse_btdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_diffuse_btdf.glsl
@@ -1,6 +1,6 @@
 // We fake diffuse transmission by using diffuse reflection from the opposite side.
 // So this BTDF is really a BRDF.
-void mx_diffuse_btdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3 normal, out BSDF result)
+void mx_diffuse_btdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, vec3 normal, out BSDF result)
 {
     // Invert normal since we're transmitting light from the other side
     float NdotL = dot(L, -normal);

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_brdf.glsl
@@ -1,6 +1,6 @@
 #include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
-void mx_generalized_schlick_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
+void mx_generalized_schlick_brdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -27,8 +27,8 @@ void mx_generalized_schlick_brdf_reflection(vec3 L, vec3 V, float weight, vec3 c
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
     // Note: NdotL is cancelled out
-    result = D * F * G * comp * weight / (4 * NdotV)    // Top layer reflection
-           + base * (1.0 - avgDirAlbedo * weight);      // Base layer reflection attenuated by top layer
+    result = D * F * G * comp * occlusion * weight / (4 * NdotV)    // Top layer reflection
+           + base * (1.0 - avgDirAlbedo * weight);                  // Base layer reflection attenuated by top layer
 }
 
 void mx_generalized_schlick_brdf_transmission(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, BSDF base, out BSDF result)

--- a/libraries/pbrlib/genglsl/mx_mix_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_mix_bsdf.glsl
@@ -1,4 +1,4 @@
-void mx_mix_bsdf_reflection(vec3 L, vec3 V, BSDF fg, BSDF bg, float w, out BSDF result)
+void mx_mix_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, BSDF fg, BSDF bg, float w, out BSDF result)
 {
     result = mix(bg, fg, clamp(w, 0.0, 1.0));
 }

--- a/libraries/pbrlib/genglsl/mx_multiply_bsdf_color.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_bsdf_color.glsl
@@ -1,4 +1,4 @@
-void mx_multiply_bsdf_color_reflection(vec3 L, vec3 V, BSDF in1, vec3 in2, out BSDF result)
+void mx_multiply_bsdf_color_reflection(vec3 L, vec3 V, vec3 P, float occlusion, BSDF in1, vec3 in2, out BSDF result)
 {
     result = in1 * clamp(in2, 0.0, 1.0);
 }

--- a/libraries/pbrlib/genglsl/mx_multiply_bsdf_float.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_bsdf_float.glsl
@@ -1,4 +1,4 @@
-void mx_multiply_bsdf_float_reflection(vec3 L, vec3 V, BSDF in1, float in2, out BSDF result)
+void mx_multiply_bsdf_float_reflection(vec3 L, vec3 V, vec3 P, float occlusion, BSDF in1, float in2, out BSDF result)
 {
     result = in1 * clamp(in2, 0.0, 1.0);
 }

--- a/libraries/pbrlib/genglsl/mx_sheen_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_brdf.glsl
@@ -1,6 +1,6 @@
 #include "pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
 
-void mx_sheen_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float roughness, vec3 N, BSDF base, out BSDF result)
+void mx_sheen_brdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 N, BSDF base, out BSDF result)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -25,8 +25,8 @@ void mx_sheen_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float ro
 
     // We need to include NdotL from the light integral here
     // as in this case it's not cancelled out by the BRDF denominator.
-    result = fr * NdotL * weight                // Top layer reflection
-           + base * (1.0 - dirAlbedo * weight); // Base layer reflection attenuated by top layer
+    result = fr * NdotL * occlusion * weight        // Top layer reflection
+           + base * (1.0 - dirAlbedo * weight);     // Base layer reflection attenuated by top layer
 }
 
 void mx_sheen_brdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 N, BSDF base, out vec3 result)

--- a/libraries/pbrlib/genglsl/mx_subsurface_brdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_subsurface_brdf.glsl
@@ -1,18 +1,19 @@
-// Fake with simple diffuse transmission
-void mx_subsurface_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out BSDF result)
+﻿#include "pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
+
+void mx_subsurface_brdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out BSDF result)
 {
-    // Invert normal since we're transmitting light from the other side
-    float NdotL = dot(L, -normal);
-    if (NdotL <= 0.0 || weight < M_FLOAT_EPS)
+    if (weight < M_FLOAT_EPS)
     {
         result = BSDF(0.0);
         return;
     }
 
-    result = color * weight * NdotL * M_PI_INV;
+    vec3 sss = mx_subsurface_scattering_approx(normal, L, P, color, radius);
+    float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
+    float visibleOcclusion = 1.0 - NdotL * (1.0 - occlusion);
+    result = sss * visibleOcclusion * weight;
 }
 
-// Fake with simple diffuse transmission
 void mx_subsurface_brdf_indirect(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out BSDF result)
 {
     if (weight < M_FLOAT_EPS)
@@ -21,7 +22,7 @@ void mx_subsurface_brdf_indirect(vec3 V, float weight, vec3 color, vec3 radius, 
         return;
     }
 
-    // Invert normal since we're transmitting light from the other side
-    vec3 Li = mx_environment_irradiance(-normal);
+    // For now, we render indirect subsurface as simple indirect diffuse.
+    vec3 Li = mx_environment_irradiance(normal);
     result = Li * color * weight;
 }

--- a/resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx
@@ -3,13 +3,12 @@
   <material name="Jade">
     <shaderref name="SR_jade" node="standard_surface">
       <bindinput name="base" type="float" value="0.5" />
-      <bindinput name="base_color" type="color3" value="0.0603, 0.43979999, 0.19159999" />
+      <bindinput name="base_color" type="color3" value="0.0603, 0.4398, 0.1916" />
       <bindinput name="specular_roughness" type="float" value="0.25" />
-      <bindinput name="specular_IOR" type="float" value="2.4179999828338623" />
+      <bindinput name="specular_IOR" type="float" value="2.418" />
       <bindinput name="specular_anisotropy" type="float" value="0.5" />
       <bindinput name="subsurface" type="float" value="0.4" />
-      <bindinput name="subsurface_color" type="color3" value="0.0603, 0.43979999, 0.19159999" />
-      <bindinput name="subsurface_scale" type="float" value="0.10000000149011612" />
+      <bindinput name="subsurface_color" type="color3" value="0.0603, 0.4398, 0.1916" />
     </shaderref>
   </material>
 </materialx>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx
@@ -61,6 +61,8 @@
       <bindinput name="base_color" type="color3" nodegraph="NG_marble1" output="out" />
       <bindinput name="specular_color" type="color3" value="1, 1, 1" />
       <bindinput name="specular_roughness" type="float" value="0.1" />
+      <bindinput name="subsurface" type="float" value="0.4" />
+      <bindinput name="subsurface_color" type="color3" nodegraph="NG_marble1" output="out" />
     </shaderref>
   </material>
 </materialx>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_metal_brushed.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_metal_brushed.mtlx
@@ -9,7 +9,7 @@
       <bindinput name="specular_roughness" type="float" value="0.25" />
       <bindinput name="specular_IOR" type="float" value="1.52" />
       <bindinput name="specular_anisotropy" type="float" value="0.65" />
-      <bindinput name="specular_rotation" type="float" value="0.5" />
+      <bindinput name="specular_rotation" type="float" value="0.0" />
       <bindinput name="metalness" type="float" value="1" />
     </shaderref>
   </material>

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -20,6 +20,8 @@ SurfaceNodeGlsl::SurfaceNodeGlsl()
     _callReflection->setSuffix("_reflection");
     _callReflection->addArgument(Type::VECTOR3, HW::DIR_L);
     _callReflection->addArgument(Type::VECTOR3, HW::DIR_V);
+    _callReflection->addArgument(Type::VECTOR3, HW::WORLD_POSITION);
+    _callReflection->addArgument(Type::FLOAT, HW::OCCLUSION);
     // Transmission context
     _callTransmission = HwClosureContext::create(HwClosureContext::TRANSMISSION);
     _callTransmission->setSuffix("_transmission");
@@ -128,17 +130,18 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
             shadergen.emitLine("vec3 shadowCoord = (" + HW::T_SHADOW_MATRIX + " * vec4(" + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_POSITION_WORLD + ", 1.0)).xyz", stage);
             shadergen.emitLine("shadowCoord = shadowCoord * 0.5 + 0.5", stage);
             shadergen.emitLine("vec2 shadowMoments = texture(" + HW::T_SHADOW_MAP + ", shadowCoord.xy).xy", stage);
-            shadergen.emitLine("float shadowOcc = mx_variance_shadow_occlusion(shadowMoments, shadowCoord.z)", stage);
+            shadergen.emitLine("float occlusion = mx_variance_shadow_occlusion(shadowMoments, shadowCoord.z)", stage);
         }
         else
         {
-            shadergen.emitLine("float shadowOcc = 1.0", stage);
+            shadergen.emitLine("float occlusion = 1.0", stage);
         }
         shadergen.emitLineBreak(stage);
 
         shadergen.emitComment("Light loop", stage);
         shadergen.emitLine("vec3 N = normalize(" + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_NORMAL_WORLD + ")", stage);
         shadergen.emitLine("vec3 V = normalize(" + HW::T_VIEW_POSITION + " - " + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_POSITION_WORLD + ")", stage);
+        shadergen.emitLine("vec3 P = " + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_POSITION_WORLD, stage);
         shadergen.emitLine("int numLights = numActiveLightSources()", stage);
         shadergen.emitLine("lightshader lightShader", stage);
         shadergen.emitLine("for (int activeLightIndex = 0; activeLightIndex < numLights; ++activeLightIndex)", stage, false);
@@ -155,7 +158,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         shadergen.emitLineBreak(stage);
 
         shadergen.emitComment("Accumulate the light's contribution", stage);
-        shadergen.emitLine(outColor + " += lightShader.intensity * shadowOcc * " + bsdf, stage);
+        shadergen.emitLine(outColor + " += lightShader.intensity * " + bsdf, stage);
 
         shadergen.emitScopeEnd(stage);
         shadergen.emitLineBreak(stage);
@@ -169,11 +172,11 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         {
             ShaderPort* texcoord = vertexData[HW::T_TEXCOORD + "_0"];
             shadergen.emitLine("vec2 ambOccUv = mx_transform_uv(" + prefix + texcoord->getVariable() + ", vec2(1.0), vec2(0.0))", stage);
-            shadergen.emitLine("float ambOcc = mix(1.0, texture(" + HW::T_AMB_OCC_MAP + ", ambOccUv).x, " + HW::T_AMB_OCC_GAIN + ")", stage);
+            shadergen.emitLine("occlusion = mix(1.0, texture(" + HW::T_AMB_OCC_MAP + ", ambOccUv).x, " + HW::T_AMB_OCC_GAIN + ")", stage);
         }
         else
         {
-            shadergen.emitLine("float ambOcc = 1.0", stage);
+            shadergen.emitLine("occlusion = 1.0", stage);
         }
         shadergen.emitLineBreak(stage);
 
@@ -189,7 +192,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         shadergen.emitScopeBegin(stage);
         shadergen.emitBsdfNodes(graph, node, _callIndirect, context, stage, bsdf);
         shadergen.emitLineBreak(stage);
-        shadergen.emitLine(outColor + " += ambOcc * " + bsdf, stage);
+        shadergen.emitLine(outColor + " += occlusion * " + bsdf, stage);
         shadergen.emitScopeEnd(stage);
         shadergen.emitLineBreak(stage);
 

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -130,6 +130,8 @@ namespace HW
     const string DIR_N                            = "N";
     const string DIR_L                            = "L";
     const string DIR_V                            = "V";
+    const string WORLD_POSITION                   = "P";
+    const string OCCLUSION                        = "occlusion";
     const string ATTR_TRANSPARENT                 = "transparent";
     const string USER_DATA_CLOSURE_CONTEXT        = "udcc";
     const string USER_DATA_LIGHT_SHADERS          = "udls";
@@ -207,6 +209,8 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax) :
     _defReflection->setSuffix("_reflection");
     _defReflection->addArgument(Type::VECTOR3, HW::DIR_L);
     _defReflection->addArgument(Type::VECTOR3, HW::DIR_V);
+    _defReflection->addArgument(Type::VECTOR3, HW::WORLD_POSITION);
+    _defReflection->addArgument(Type::FLOAT, HW::OCCLUSION);
     // Transmission context
     _defTransmission = HwClosureContext::create(HwClosureContext::TRANSMISSION);
     _defTransmission->setSuffix("_transmission");

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -195,10 +195,12 @@ namespace HW
     extern const string LIGHT_DATA;       // Uniform inputs for light sources.
     extern const string PIXEL_OUTPUTS;    // Outputs from the main/pixel stage.
 
-    /// Variable names for direction vectors.
+    /// Variable names for lighting parameters.
     extern const string DIR_N;
     extern const string DIR_L;
     extern const string DIR_V;
+    extern const string WORLD_POSITION;
+    extern const string OCCLUSION;
 
     /// Attribute names.
     extern const string ATTR_TRANSPARENT;

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -309,9 +309,9 @@ class ShaderNode
         static const unsigned int CONDITIONAL = 1 << 4;  /// A conditional node
         static const unsigned int CONSTANT    = 1 << 5;  /// A constant node
         // Specific closure types
-        static const unsigned int BSDF        = 1 << 6;  /// A BDFS node
-        static const unsigned int BSDF_R      = 1 << 7;  /// A BDFS node only for reflection
-        static const unsigned int BSDF_T      = 1 << 8;  /// A BDFS node only for transmission
+        static const unsigned int BSDF        = 1 << 6;  /// A BSDF node
+        static const unsigned int BSDF_R      = 1 << 7;  /// A BSDF node only for reflection
+        static const unsigned int BSDF_T      = 1 << 8;  /// A BSDF node only for transmission
         static const unsigned int EDF         = 1 << 9;  /// A EDF node
         static const unsigned int VDF         = 1 << 10; /// A VDF node
         // Specific shader types

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -346,24 +346,6 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
             }
         }
 
-        // Check subsurface
-        InputPtr subsurface = shaderNode->getActiveInput("subsurface");
-        if (subsurface)
-        {
-            if (subsurface->getConnectedOutput())
-            {
-                return true;
-            }
-            else
-            {
-                ValuePtr value = subsurface->getValue();
-                if (value && !isZero(value))
-                {
-                    return true;
-                }
-            }
-        }
-
         // Check for a transparent graph.
         InterfaceElementPtr impl = nodeDef->getImplementation(shadergen.getTarget(), shadergen.getLanguage());
         if (!impl)
@@ -476,24 +458,6 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
             else
             {
                 ValuePtr value = transmission->getValue();
-                if (value && !isZero(value))
-                {
-                    return true;
-                }
-            }
-        }
-
-        // Check subsurface
-        BindInputPtr subsurface = shaderRef->getBindInput("subsurface");
-        if (subsurface)
-        {
-            if (subsurface->getConnectedOutput())
-            {
-                return true;
-            }
-            else
-            {
-                ValuePtr value = subsurface->getValue();
                 if (value && !isZero(value))
                 {
                     return true;


### PR DESCRIPTION
This changelist adds a simple subsurface scattering approximation to MaterialX GLSL.  The high-level approach is to integrate Burley's diffusion profile over the sphere using Eric Penner's curvature-based approximation.  While this ignores the thickness of the scattering volume, it keeps the implementation within a single shading pass and provides a meaningful visual interpretation of the subsurface scattering inputs.