### PR TITLE
Additional workflow fixes

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -81,6 +81,7 @@ string getValueStringFromColor(const Color4& color, const string& type)
 
 TextureBaker::TextureBaker(unsigned int width, unsigned int height, Image::BaseType baseType) :
     GlslRenderer(width, height, baseType),
+    _averageImages(false),
     _optimizeConstants(true),
     _generator(GlslShaderGenerator::create())
 {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1081,7 +1081,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
             {
                 continue;
             }
-            if (udimSetValue && udimSetValue->isA<mx::StringVec>())
+            if (typedElem->isA<mx::ShaderRef>() && udimSetValue && udimSetValue->isA<mx::StringVec>())
             {
                 for (const std::string& udim : udimSetValue->asA<mx::StringVec>())
                 {


### PR DESCRIPTION
- Add a missing variable initialization in TextureBaker.
- Restrict UDIM assignments to materials in the viewer.