### PR TITLE
Fix bug with codegen of custom BSDF/EDF graphs.

### DIFF
--- a/resources/Materials/TestSuite/pbrlib/bsdf/bsdf_graph.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/bsdf_graph.mtlx
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
   <!--
-    Declare a custom bsdf node mixing diffuse reflection 
-    and straight transmission.
+    Define a custom bsdf node.
   -->
   <nodedef name="ND_mybsdf" node="mybsdf">
     <input name="diffuse" type="float" value="0.8" />
@@ -12,8 +11,9 @@
     <output name="out" type="BSDF"/>
   </nodedef>
   <nodegraph name="IMP_mybsdf" nodedef="ND_mybsdf">
+    <noise2d name="noise1" type="float"/>
     <diffuse_brdf name="diffuse_brdf1" type="BSDF">
-      <input name="weight" type="float" interfacename="diffuse" />
+      <input name="weight" type="float" nodename="noise1" />
       <input name="color" type="color3" interfacename="diffuseColor" />
     </diffuse_brdf>
     <dielectric_brdf name="dielectric_brdf1" type="BSDF">

--- a/resources/Materials/TestSuite/pbrlib/edf/edf_graph.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/edf/edf_graph.mtlx
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<materialx version="1.37">
+  <!--
+    Define a custom edf node.
+  -->
+  <nodedef name="ND_myedf" node="myedf">
+    <input name="intensity1" type="float" value="1.0" />
+    <input name="color1" type="color3" value="1.0, 0.0, 0.0"/>
+    <input name="intensity2" type="float" value="1.0" />
+    <input name="color2" type="color3" value="0.0, 1.0, 0.0"/>
+    <output name="out" type="EDF"/>
+  </nodedef>
+  <nodegraph name="IMP_myedf" nodedef="ND_myedf">
+    <multiply name="col1" type="color3">
+      <input name="in1" type="color3" interfacename="color1"/>
+      <input name="in2" type="float" interfacename="intensity1" />
+    </multiply>
+    <uniform_edf name="edf1" type="EDF">
+      <input name="color" type="color3" nodename="col1" />
+    </uniform_edf>
+    <multiply name="col2" type="color3">
+      <input name="in1" type="color3" interfacename="color2"/>
+      <input name="in2" type="float" interfacename="intensity2" />
+    </multiply>
+    <uniform_edf name="edf2" type="EDF">
+      <input name="color" type="color3" nodename="col2" />
+    </uniform_edf>
+    <texcoord name="t1" type="vector2"/>
+    <multiply name="m1" type="vector2">
+      <input name="in1" type="vector2" nodename="t1"/>
+      <input name="in2" type="float" value="16"/>
+    </multiply>
+    <noise2d name="noise1" type="float">
+      <input name="texcoord" type="vector2" nodename="m1"/>
+    </noise2d>
+    <mix name="mixer" type="EDF">
+      <input name="fg" type="EDF" nodename="edf1" />
+      <input name="bg" type="EDF" nodename="edf2" />
+      <input name="mix" type="float" nodename="noise1" />
+    </mix>
+    <output name="out" type="EDF" nodename="mixer" />
+  </nodegraph>
+  <!--
+    Use the edf node above in a surface shader.
+  -->
+  <nodegraph name="test_mybsdf" type="surfaceshader">
+    <myedf name="myedf1" type="EDF">
+      <input name="intensity1" type="float" value="1.0" />
+      <input name="color1" type="color3" value="1.0, 0.0, 0.0"/>
+      <input name="intensity2" type="float" value="1.0" />
+      <input name="color2" type="color3" value="0.0, 1.0, 0.0"/>
+    </myedf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="edf" type="EDF" nodename="myedf1" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+</materialx>

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -104,7 +104,10 @@ void LightCompoundNodeGlsl::emitFunctionDefinition(HwClosureContextPtr ccx, GenC
     // Emit function signature
     if (ccx)
     {
-        shadergen.emitLine("void " + _functionName + ccx->getSuffix() + "(LightData light, vec3 position, out lightshader result)", stage, false);
+        // Use the first output for classifying node type for the closure context.
+        // This is only relevent for closures, and they only have a single output.
+        const TypeDesc* nodeType = _rootGraph->getOutputSocket()->getType();
+        shadergen.emitLine("void " + _functionName + ccx->getSuffix(nodeType) + "(LightData light, vec3 position, out lightshader result)", stage, false);
     }
     else
     {

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -23,8 +23,8 @@ LightNodeGlsl::LightNodeGlsl()
 {
     // Emission context
     _callEmission = HwClosureContext::create(HwClosureContext::EMISSION);
-    _callEmission->addArgument(Type::VECTOR3, "light.direction");
-    _callEmission->addArgument(Type::VECTOR3, "-L");
+    _callEmission->addArgument(Type::EDF, HwClosureContext::Argument(Type::VECTOR3, "light.direction"));
+    _callEmission->addArgument(Type::EDF, HwClosureContext::Argument(Type::VECTOR3, "-L"));
 }
 
 ShaderNodeImplPtr LightNodeGlsl::create()

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -17,23 +17,23 @@ SurfaceNodeGlsl::SurfaceNodeGlsl()
     //
     // Reflection context
     _callReflection = HwClosureContext::create(HwClosureContext::REFLECTION);
-    _callReflection->setSuffix("_reflection");
-    _callReflection->addArgument(Type::VECTOR3, HW::DIR_L);
-    _callReflection->addArgument(Type::VECTOR3, HW::DIR_V);
-    _callReflection->addArgument(Type::VECTOR3, HW::WORLD_POSITION);
-    _callReflection->addArgument(Type::FLOAT, HW::OCCLUSION);
+    _callReflection->setSuffix(Type::BSDF, HwShaderGenerator::CLOSURE_CONTEXT_SUFFIX_REFLECTION);
+    _callReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_L));
+    _callReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_V));
+    _callReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::WORLD_POSITION));
+    _callReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::FLOAT, HW::OCCLUSION));
     // Transmission context
     _callTransmission = HwClosureContext::create(HwClosureContext::TRANSMISSION);
-    _callTransmission->setSuffix("_transmission");
-    _callTransmission->addArgument(Type::VECTOR3, HW::DIR_V);
+    _callTransmission->setSuffix(Type::BSDF, HwShaderGenerator::CLOSURE_CONTEXT_SUFFIX_TRANSMISSIION);
+    _callTransmission->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_V));
     // Indirect context
     _callIndirect = HwClosureContext::create(HwClosureContext::INDIRECT);
-    _callIndirect->setSuffix("_indirect");
-    _callIndirect->addArgument(Type::VECTOR3, HW::DIR_V);
+    _callIndirect->setSuffix(Type::BSDF, HwShaderGenerator::CLOSURE_CONTEXT_SUFFIX_INDIRECT);
+    _callIndirect->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_V));
     // Emission context
     _callEmission = HwClosureContext::create(HwClosureContext::EMISSION);
-    _callEmission->addArgument(Type::VECTOR3, HW::DIR_N);
-    _callEmission->addArgument(Type::VECTOR3, HW::DIR_V);
+    _callEmission->addArgument(Type::EDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_N));
+    _callEmission->addArgument(Type::EDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_V));
 }
 
 ShaderNodeImplPtr SurfaceNodeGlsl::create()

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -142,9 +142,16 @@ namespace Stage
     const string VERTEX = "vertex";
 }
 
+const HwClosureContext::Arguments HwClosureContext::EMPTY_ARGUMENTS;
+
+
 //
 // HwShaderGenerator methods
 //
+
+const string HwShaderGenerator::CLOSURE_CONTEXT_SUFFIX_REFLECTION("_reflection");
+const string HwShaderGenerator::CLOSURE_CONTEXT_SUFFIX_TRANSMISSIION("_transmission");
+const string HwShaderGenerator::CLOSURE_CONTEXT_SUFFIX_INDIRECT("_indirect");
 
 HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax) :
     ShaderGenerator(syntax)
@@ -206,23 +213,23 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax) :
     //
     // Reflection context
     _defReflection = HwClosureContext::create(HwClosureContext::REFLECTION);
-    _defReflection->setSuffix("_reflection");
-    _defReflection->addArgument(Type::VECTOR3, HW::DIR_L);
-    _defReflection->addArgument(Type::VECTOR3, HW::DIR_V);
-    _defReflection->addArgument(Type::VECTOR3, HW::WORLD_POSITION);
-    _defReflection->addArgument(Type::FLOAT, HW::OCCLUSION);
+    _defReflection->setSuffix(Type::BSDF, CLOSURE_CONTEXT_SUFFIX_REFLECTION);
+    _defReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_L));
+    _defReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_V));
+    _defReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::WORLD_POSITION));
+    _defReflection->addArgument(Type::BSDF, HwClosureContext::Argument(Type::FLOAT, HW::OCCLUSION));
     // Transmission context
     _defTransmission = HwClosureContext::create(HwClosureContext::TRANSMISSION);
-    _defTransmission->setSuffix("_transmission");
-    _defTransmission->addArgument(Type::VECTOR3, HW::DIR_V);
+    _defTransmission->setSuffix(Type::BSDF, CLOSURE_CONTEXT_SUFFIX_TRANSMISSIION);
+    _defTransmission->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_V));
     // Indirect context
     _defIndirect = HwClosureContext::create(HwClosureContext::INDIRECT);
-    _defIndirect->setSuffix("_indirect");
-    _defIndirect->addArgument(Type::VECTOR3, HW::DIR_V);
+    _defIndirect->setSuffix(Type::BSDF, CLOSURE_CONTEXT_SUFFIX_INDIRECT);
+    _defIndirect->addArgument(Type::BSDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_V));
     // Emission context
     _defEmission = HwClosureContext::create(HwClosureContext::EMISSION);
-    _defEmission->addArgument(Type::VECTOR3, HW::DIR_N);
-    _defEmission->addArgument(Type::VECTOR3, HW::DIR_L);
+    _defEmission->addArgument(Type::EDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_N));
+    _defEmission->addArgument(Type::EDF, HwClosureContext::Argument(Type::VECTOR3, HW::DIR_L));
 }
 
 ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element, GenContext& context) const

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -230,7 +230,7 @@ using HwShaderGeneratorPtr = shared_ptr<class HwShaderGenerator>;
 /// @class HwClosureContext
 /// Class representing a context for closure evaluation on hardware targets.
 /// On hardware BSDF closures are evaluated differently in reflection, transmission
-/// or environment/indirect contexts. This class represents with context we are in
+/// or environment/indirect contexts. This class represents the context we are in
 /// and if extra arguments and function decorators are needed for that context.
 class HwClosureContext : public GenUserData
 {
@@ -263,25 +263,37 @@ public:
     /// Return the identifier for this context.
     int getType() const { return _type; }
 
-    /// Add an extra argument to be used for functions in this context.
-    void addArgument(const TypeDesc* type, const string& name)
+    /// For the given node type add an extra argument to be used for the function in this context.
+    void addArgument(const TypeDesc* nodeType, const Argument& arg)
     {
-        _arguments.emplace_back(type, name);
+        _arguments[nodeType].push_back(arg);
     }
 
-    /// Return a list of extra argument to be used for functions in this context.
-    const Arguments& getArguments() const { return _arguments; }
+    /// Return a list of extra argument to be used for the given node in this context.
+    const Arguments& getArguments(const TypeDesc* nodeType) const
+    {
+        auto it = _arguments.find(nodeType);
+        return it != _arguments.end() ? it->second : EMPTY_ARGUMENTS;
+    }
 
-    /// Set a function name suffix to be used for the function in this context.
-    void setSuffix(const string& suffix) { _suffix = suffix; }
+    /// For the given node type set a function name suffix to be used for the function in this context.
+    void setSuffix(const TypeDesc* nodeType, const string& suffix)
+    {
+        _suffix[nodeType] = suffix;
+    }
 
-    /// Return the function name suffix to be used for the function in this context.
-    const string& getSuffix() const { return _suffix; }
+    /// Return the function name suffix to be used for the given node in this context.
+    const string& getSuffix(const TypeDesc* nodeType) const
+    {
+        auto it = _suffix.find(nodeType);
+        return it != _suffix.end() ? it->second : EMPTY_STRING;
+    }
 
 protected:
     const int _type;
-    Arguments _arguments;
-    string _suffix;
+    std::unordered_map<const TypeDesc*, Arguments> _arguments;
+    std::unordered_map<const TypeDesc*, string> _suffix;
+    static const Arguments EMPTY_ARGUMENTS;
 };
 
 /// @class HwLightShaders 
@@ -370,6 +382,11 @@ public:
 
     /// Unbind all light shaders previously bound.
     static void unbindLightShaders(GenContext& context);
+
+    /// String constants for closure context suffixes.
+    static const string CLOSURE_CONTEXT_SUFFIX_REFLECTION;
+    static const string CLOSURE_CONTEXT_SUFFIX_TRANSMISSIION;
+    static const string CLOSURE_CONTEXT_SUFFIX_INDIRECT;
 
 protected:
     HwShaderGenerator(SyntaxPtr syntax);

--- a/source/MaterialXGenShader/Nodes/HwCompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwCompoundNode.cpp
@@ -52,10 +52,14 @@ void HwCompoundNode::emitFunctionDefinition(HwClosureContextPtr ccx, GenContext&
     shadergen.emitLineBegin(stage);
     if (ccx)
     {
-        shadergen.emitString("void " + _functionName + ccx->getSuffix() + "(", stage);
+        // Use the first output for classifying node type for the closure context.
+        // This is only relevent for closures, and they only have a single output.
+        const TypeDesc* nodeType = _rootGraph->getOutputSocket()->getType();
+
+        shadergen.emitString("void " + _functionName + ccx->getSuffix(nodeType) + "(", stage);
 
         // Add any extra argument inputs first
-        for (const HwClosureContext::Argument& arg : ccx->getArguments())
+        for (const HwClosureContext::Argument& arg : ccx->getArguments(nodeType))
         {
             const string& type = syntax.getTypeName(arg.first);
             shadergen.emitString(delim + type + " " + arg.second, stage);
@@ -138,11 +142,15 @@ void HwCompoundNode::emitFunctionCall(const ShaderNode& node, GenContext& contex
 
         if (ccx)
         {
+            // Use the first output for classifying node type for the closure context.
+            // This is only relevent for closures, and they only have a single output.
+            const TypeDesc* nodeType = _rootGraph->getOutputSocket()->getType();
+
             // Emit function name.
-            shadergen.emitString(_functionName + ccx->getSuffix() + "(", stage);
+            shadergen.emitString(_functionName + ccx->getSuffix(nodeType) + "(", stage);
 
             // Emit extra argument.
-            for (const HwClosureContext::Argument& arg : ccx->getArguments())
+            for (const HwClosureContext::Argument& arg : ccx->getArguments(nodeType))
             {
                 shadergen.emitString(delim + arg.second, stage);
                 delim = ", ";

--- a/source/MaterialXGenShader/Nodes/HwSourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwSourceCodeNode.cpp
@@ -41,11 +41,15 @@ void HwSourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext& cont
 
             if (ccx)
             {
+                // Use the first output for classifying node type for the closure context.
+                // This is only relevent for closures, and they only have a single output.
+                const TypeDesc* nodeType = node.getOutput()->getType();
+
                 // Emit function name.
-                shadergen.emitString(_functionName + ccx->getSuffix() + "(", stage);
+                shadergen.emitString(_functionName + ccx->getSuffix(nodeType) + "(", stage);
 
                 // Emit extra argument.
-                for (const HwClosureContext::Argument& arg : ccx->getArguments())
+                for (const HwClosureContext::Argument& arg : ccx->getArguments(nodeType))
                 {
                     shadergen.emitString(delim + arg.second, stage);
                     delim = ", ";


### PR DESCRIPTION
This changelist addresses a problem in codegen of nodegraphs of BSDF and EDF type. For HW shaders the suffixes used for functions, depending on closure context, was being applied to _all_ functions, not just BSDF/EDF functions. This change makes the use of suffixes and extra arguments depend on node type so it only applies to BSDF/EDF functions.