### PR TITLE
Use newer OpenImageIO interface

### DIFF
--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -46,7 +46,7 @@ bool OiioImageLoader::saveImage(const FilePath& filePath,
     }
 
     bool written = false;
-    auto imageOutput = OIIO::ImageOutput::create(filePath);
+    auto imageOutput = OIIO::ImageOutput::create(filePath.asString());
     if (imageOutput)
     {
         if (imageOutput->open(filePath, imageSpec))


### PR DESCRIPTION
OIIO dropped some implicit string conversions a while ago, so be more explicit.

@lgritz: CLA should be covered via Imageworks.
