### PR TITLE
Initial material unit tests

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -141,22 +141,21 @@ void convertMaterialsToNodes(DocumentPtr doc)
             // add a reference from the material node to the new shader node
             if (!materialNode)
             {
-                // Set the type of material based on current assumption that
-                // surfaceshaders + displacementshaders result in a surfacematerial
-                // while a volumeshader means a volumematerial needs to be created.
-                string materialNodeCategory =
-                    (shaderNodeType != VOLUME_SHADER_TYPE_STRING) ? SURFACE_MATERIAL_NODE_STRING
-                    : VOLUME_MATERIAL_NODE_STRING;
-                materialNode = doc->addNode(materialNodeCategory, materialName, MATERIAL_TYPE_STRING);
+                materialNode = doc->addMaterialNode(materialName, shaderNode);
                 materialNode->setSourceUri(mat->getSourceUri());
                 // Note: Inheritance does not get transfered to the node we do
                 // not perform the following:
                 //      - materialNode->setInheritString(mat->getInheritString());
             }
+
             // Create input to replace each shaderref. Use shaderref name as unique
             // input name.
-            InputPtr shaderInput = materialNode->addInput(shaderNodeType, shaderNodeType);
-            shaderInput->setNodeName(shaderNode->getName());
+            InputPtr shaderInput = materialNode->getInput(shaderNodeType);
+            if (!shaderInput)
+            {
+                shaderInput = materialNode->addInput(shaderNodeType, shaderNodeType);
+                shaderInput->setNodeName(shaderNode->getName());
+            }
             // Make sure to copy over any target and version information from the shaderref.
             if (!shaderRef->getTarget().empty())
             {

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -496,12 +496,6 @@ string ValueElement::getResolvedValueString(StringResolverPtr resolver) const
 
 ValuePtr ValueElement::getDefaultValue() const
 {
-    if (hasValue())
-    {
-        return getValue();
-    }
-
-    // Return the value, if any, stored in our declaration.
     ConstElementPtr parent = getParent();
     ConstInterfaceElementPtr interface = parent ? parent->asA<InterfaceElement>() : nullptr;
     if (interface)

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1070,7 +1070,8 @@ class ValueElement : public TypedElement
         return Value::createValueFromStrings(getResolvedValueString(resolver), getType());
     }
 
-    /// Return the default value for this element.
+    /// Return the default value for this element as a generic value object, which
+    /// may be queried to access its data.
     ///
     /// @return A shared pointer to a typed value, or an empty shared pointer if
     ///    no default value was found.

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -65,6 +65,30 @@ string Node::getConnectedNodeName(const string& inputName) const
     return input->getNodeName();
 }
 
+void Node::setConnectedOutput(const string& inputName, OutputPtr output)
+{
+    InputPtr input = getInput(inputName);
+    if (!input)
+    {
+        input = addInput(inputName, DEFAULT_TYPE_STRING);
+    }
+    if (output)
+    {
+        input->setType(output->getType());
+    }
+    input->setConnectedOutput(output);
+}
+
+OutputPtr Node::getConnectedOutput(const string& inputName) const
+{
+    InputPtr input = getInput(inputName);
+    if (!input)
+    {
+        return OutputPtr();
+    }
+    return input->getConnectedOutput();    
+}
+
 NodeDefPtr Node::getNodeDef(const string& target) const
 {
     if (hasNodeDefString())
@@ -168,6 +192,25 @@ bool Node::validate(string* message) const
 //
 // GraphElement methods
 //
+
+NodePtr GraphElement::addMaterialNode(const string& name, ConstNodePtr shaderNode)
+{
+    string category = SURFACE_MATERIAL_NODE_STRING;
+    if (shaderNode)
+    {
+        if (shaderNode->getType() == VOLUME_MATERIAL_NODE_STRING)
+        {
+            category = VOLUME_SHADER_TYPE_STRING;
+        }
+    }
+    NodePtr materialNode = addNode(category, name, MATERIAL_TYPE_STRING);
+    if (shaderNode)
+    {
+        InputPtr input = materialNode->addInput(shaderNode->getType(), shaderNode->getType());
+        input->setNodeName(shaderNode->getName());
+    }
+    return materialNode;
+}
 
 void GraphElement::flattenSubgraphs(const string& target, NodePredicate filter)
 {

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -79,6 +79,15 @@ class Node : public InterfaceElement
     /// input is not present, then an empty string is returned.
     string getConnectedNodeName(const string& inputName) const;
 
+    /// Set the output to which the given input is connected, creating a
+    /// child input if needed.  If the node argument is null, then any
+    /// existing output connection on the input will be cleared.
+    void setConnectedOutput(const string& inputName, OutputPtr output);
+
+    /// Return the output connected to the given input.  If the given input is
+    /// not present, then an empty OutputPtr is returned.
+    OutputPtr getConnectedOutput(const string& inputName) const;
+
     /// @}
     /// @name NodeDef References
     /// @{
@@ -242,11 +251,9 @@ class GraphElement : public InterfaceElement
     /// @name Material Nodes
     /// @{
 
-    /// Return the material node, if any, with the given name.
-    NodePtr getMaterialNode(const string& name) const
-    {
-        return getNode(name);
-    }
+    /// Add a material node to the graph, optionally connecting it to the given
+    /// shader node.
+    NodePtr addMaterialNode(const string& name = EMPTY_STRING, ConstNodePtr shaderNode = nullptr);
 
     /// Return a vector of all material nodes.
     vector<NodePtr> getMaterialNodes() const

--- a/source/MaterialXTest/MaterialXCore/Material.cpp
+++ b/source/MaterialXTest/MaterialXCore/Material.cpp
@@ -17,9 +17,9 @@ TEST_CASE("Material", "[material]")
     // Create a base shader nodedef.
     mx::NodeDefPtr simpleSrf = doc->addNodeDef("ND_simpleSrf", "surfaceshader", "simpleSrf");
     simpleSrf->setInputValue("diffColor", mx::Color3(1.0f));
-    mx::InputPtr specColor = simpleSrf->setInputValue("specColor", mx::Color3(0.0f));
-    mx::InputPtr roughness = simpleSrf->setInputValue("roughness", 0.25f);
-    mx::TokenPtr texId = simpleSrf->setTokenValue("texId", "01");
+    simpleSrf->setInputValue("specColor", mx::Color3(0.0f));
+    simpleSrf->setInputValue("roughness", 0.25f);
+    simpleSrf->setTokenValue("texId", "01");
     REQUIRE(simpleSrf->getInputValue("diffColor")->asA<mx::Color3>() == mx::Color3(1.0f));
     REQUIRE(simpleSrf->getInputValue("specColor")->asA<mx::Color3>() == mx::Color3(0.0f));
     REQUIRE(simpleSrf->getInputValue("roughness")->asA<float>() == 0.25f);

--- a/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
@@ -19,6 +19,8 @@ void bindPyNode(py::module& mod)
         .def("getConnectedNode", &mx::Node::getConnectedNode)
         .def("setConnectedNodeName", &mx::Node::setConnectedNodeName)
         .def("getConnectedNodeName", &mx::Node::getConnectedNodeName)
+        .def("setConnectedOutput", &mx::Node::setConnectedOutput)
+        .def("getConnectedOutput", &mx::Node::getConnectedOutput)
         .def("getNodeDef", &mx::Node::getNodeDef,
             py::arg("target") = mx::EMPTY_STRING)
         .def("getImplementation", &mx::Node::getImplementation,
@@ -36,7 +38,7 @@ void bindPyNode(py::module& mod)
         .def("getNodes", &mx::GraphElement::getNodes,
             py::arg("category") = mx::EMPTY_STRING)
         .def("removeNode", &mx::GraphElement::removeNode)
-        .def("getMaterialNode", &mx::GraphElement::getMaterialNode)
+        .def("addMaterialNode", &mx::GraphElement::addMaterialNode)
         .def("getMaterialNodes", &mx::GraphElement::getMaterialNodes)
         .def("addBackdrop", &mx::GraphElement::addBackdrop,
             py::arg("name") = mx::EMPTY_STRING)


### PR DESCRIPTION
- Add initial C++ unit tests for the v1.38 material interface.
- Add helper methods Node::setConnectedOutput, Node::getConnectedOutput, and GraphElement::addMaterialNode.