### PR TITLE
Initial look unit tests

### DIFF
--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -221,10 +221,6 @@ class TestMaterialX(unittest.TestCase):
         custom.setInputValue('octaves', 5)
         self.assertTrue(custom.getInputValue('octaves') == 5)
 
-        # Validate the document.
-        valid, message = doc.validate()
-        self.assertTrue(valid, 'Document returned validation warnings: ' + message)
-
         # Test scoped attributes.
         nodeGraph.setFilePrefix('folder/')
         nodeGraph.setColorSpace('lin_rec709')
@@ -232,19 +228,47 @@ class TestMaterialX(unittest.TestCase):
         self.assertTrue(constant.getActiveColorSpace() == 'lin_rec709')
 
         # Create a simple shader interface.
-        shaderDef = doc.addNodeDef('shader1', 'surfaceshader', 'simpleSrf')
-        diffColor = shaderDef.setInputValue('diffColor', mx.Color3(1.0))
-        specColor = shaderDef.setInputValue('specColor', mx.Color3(0.0))
-        roughness = shaderDef.setInputValue('roughness', 0.25)
-        texId = shaderDef.setTokenValue('texId', '01')
-        self.assertTrue(roughness.getValue() == 0.25)
+        simpleSrf = doc.addNodeDef('', 'surfaceshader', 'simpleSrf')
+        simpleSrf.setInputValue('diffColor', mx.Color3(1.0))
+        simpleSrf.setInputValue('specColor', mx.Color3(0.0))
+        roughness = simpleSrf.setInputValue('roughness', 0.25)
         self.assertTrue(roughness.getIsUniform() == False)
         roughness.setIsUniform(True);
         self.assertTrue(roughness.getIsUniform() == True)
 
-        # Create a look.
+        # Instantiate shader and material nodes.
+        shaderNode = doc.addNodeInstance(simpleSrf)
+        materialNode = doc.addMaterialNode('', shaderNode)
+
+        # Bind the diffuse color input to the constant color output.
+        shaderNode.setConnectedOutput('diffColor', output1)
+        self.assertTrue(shaderNode.getUpstreamElement() == constant)
+
+        # Bind the roughness input to a value.
+        instanceRoughness = shaderNode.setInputValue('roughness', 0.5)
+        self.assertTrue(instanceRoughness.getValue() == 0.5)
+        self.assertTrue(instanceRoughness.getDefaultValue() == 0.25)
+
+        # Create a look for the material.
         look = doc.addLook()
         self.assertTrue(len(doc.getLooks()) == 1)
+
+        # Bind the material to a geometry string.
+        matAssign1 = look.addMaterialAssign("matAssign1", materialNode.getName())
+        matAssign1.setGeom("/robot1")
+        self.assertTrue(matAssign1.getReferencedMaterial() == materialNode)
+        self.assertTrue(len(mx.getGeometryBindings(materialNode, "/robot1")) == 1)
+        self.assertTrue(len(mx.getGeometryBindings(materialNode, "/robot2")) == 0)
+
+        # Bind the material to a collection.
+        matAssign2 = look.addMaterialAssign("matAssign2", materialNode.getName())
+        collection = doc.addCollection()
+        collection.setIncludeGeom("/robot2")
+        collection.setExcludeGeom("/robot2/left_arm")
+        matAssign2.setCollection(collection)
+        self.assertTrue(len(mx.getGeometryBindings(materialNode, "/robot2")) == 1)
+        self.assertTrue(len(mx.getGeometryBindings(materialNode, "/robot2/right_arm")) == 1)
+        self.assertTrue(len(mx.getGeometryBindings(materialNode, "/robot2/left_arm")) == 0)
 
         # Create a property assignment.
         propertyAssign = look.addPropertyAssign()
@@ -270,6 +294,10 @@ class TestMaterialX(unittest.TestCase):
         variantSet.addVariant("original")
         variantSet.addVariant("damaged")
         self.assertTrue(len(variantSet.getVariants()) == 2)
+
+        # Validate the document.
+        valid, message = doc.validate()
+        self.assertTrue(valid, 'Document returned validation warnings: ' + message)
 
         # Disconnect outputs from sources.
         output1.setConnectedNode(None)

--- a/source/MaterialXCore/Look.cpp
+++ b/source/MaterialXCore/Look.cpp
@@ -28,7 +28,7 @@ vector<MaterialAssignPtr> getGeometryBindings(const NodePtr& materialNode, const
     {
         for (MaterialAssignPtr matAssign : look->getMaterialAssigns())
         {
-            if (matAssign->getReferencedMaterialNode() == materialNode)
+            if (matAssign->getReferencedMaterial() == materialNode)
             {
                 if (geomStringsMatch(geom, matAssign->getActiveGeom()))
                 {
@@ -120,7 +120,7 @@ vector<VisibilityPtr> Look::getActiveVisibilities() const
 // MaterialAssign methods
 //
 
-NodePtr MaterialAssign::getReferencedMaterialNode() const
+NodePtr MaterialAssign::getReferencedMaterial() const
 {
     return resolveRootNameReference<Node>(getMaterial());
 }

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -63,7 +63,7 @@ class Look : public Element
     ///     If no name is specified, then a unique name will automatically be
     ///     generated.
     /// @param material An optional material string, which should match the
-    ///     name of the Material element to be assigned.
+    ///     name of the material node to be assigned.
     /// @return A shared pointer to the new MaterialAssign.
     MaterialAssignPtr addMaterialAssign(const string& name = EMPTY_STRING,
                                         const string& material = EMPTY_STRING);
@@ -333,8 +333,8 @@ class MaterialAssign : public GeomElement
     /// @name Material References
     /// @{
 
-    /// Return the Material node, if any, referenced by the MaterialAssign.
-    NodePtr getReferencedMaterialNode() const;
+    /// Return the material node, if any, referenced by the MaterialAssign.
+    NodePtr getReferencedMaterial() const;
 
     /// @}
     /// @name VariantAssign Elements

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -62,7 +62,6 @@ TEST_CASE("Document", "[document]")
     // Bind the diffuse color input to the constant color output.
     shaderNode->setConnectedOutput("diffColor", output);
     REQUIRE(shaderNode->getUpstreamElement() == constant);
-    REQUIRE(doc->validate());
 
     // Bind the roughness input to a value.
     mx::InputPtr instanceRoughness = shaderNode->setInputValue("roughness", 0.5f);

--- a/source/MaterialXTest/MaterialXCore/Look.cpp
+++ b/source/MaterialXTest/MaterialXCore/Look.cpp
@@ -13,14 +13,27 @@ TEST_CASE("Look", "[look]")
 {
     mx::DocumentPtr doc = mx::createDocument();
 
-    // Create a look.
+    // Create a material and look.
+    mx::NodePtr shaderNode = doc->addNode("standard_surface", "", "surfaceshader");
+    mx::NodePtr materialNode = doc->addMaterialNode("", shaderNode);
     mx::LookPtr look = doc->addLook();
-    REQUIRE(doc->getLooks().size() == 1);
 
-    // Create a geometric collection.
+    // Bind the material to a geometry string.
+    mx::MaterialAssignPtr matAssign1 = look->addMaterialAssign("matAssign1", materialNode->getName());
+    matAssign1->setGeom("/robot1");
+    REQUIRE(matAssign1->getReferencedMaterial() == materialNode);
+    REQUIRE(getGeometryBindings(materialNode, "/robot1").size() == 1);
+    REQUIRE(getGeometryBindings(materialNode, "/robot2").size() == 0);
+
+    // Bind the material to a geometric collection.
+    mx::MaterialAssignPtr matAssign2 = look->addMaterialAssign("matAssign2", materialNode->getName());
     mx::CollectionPtr collection = doc->addCollection();
     collection->setIncludeGeom("/robot2");
     collection->setExcludeGeom("/robot2/left_arm");
+    matAssign2->setCollection(collection);
+    REQUIRE(getGeometryBindings(materialNode, "/robot2").size() == 1);
+    REQUIRE(getGeometryBindings(materialNode, "/robot2/right_arm").size() == 1);
+    REQUIRE(getGeometryBindings(materialNode, "/robot2/left_arm").size() == 0);
 
     // Create a property assignment.
     mx::PropertyAssignPtr propertyAssign = look->addPropertyAssign();

--- a/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
@@ -63,7 +63,7 @@ void bindPyLook(py::module& mod)
         .def("getMaterial", &mx::MaterialAssign::getMaterial)
         .def("setExclusive", &mx::MaterialAssign::setExclusive)
         .def("getExclusive", &mx::MaterialAssign::getExclusive)
-        .def("getReferencedMaterialNode", &mx::MaterialAssign::getReferencedMaterialNode)
+        .def("getReferencedMaterial", &mx::MaterialAssign::getReferencedMaterial)
         .def_readonly_static("CATEGORY", &mx::MaterialAssign::CATEGORY);
 
     py::class_<mx::Visibility, mx::VisibilityPtr, mx::GeomElement>(mod, "Visibility")


### PR DESCRIPTION
- Add initial C++ unit tests for looks and material assignments.
- Extend material and look unit tests to Python.
- Rename Look::getReferencedMaterialNode to Look::getReferencedMaterial for simplicity.