### PR TITLE
OpenGL improvements for software rendering

### DIFF
--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -5,7 +5,7 @@ assign_source_group("Source Files" ${materialx_source})
 assign_source_group("Header Files" ${materialx_headers})
 
 if(POLICY CMP0072)
-    cmake_policy(SET CMP0072 OLD)
+    cmake_policy(SET CMP0072 NEW)
 endif()
 
 if(APPLE)

--- a/source/MaterialXRenderGlsl/GLContext.cpp
+++ b/source/MaterialXRenderGlsl/GLContext.cpp
@@ -18,7 +18,7 @@
 #endif
 
 #include <MaterialXRenderGlsl/External/GLew/glew.h>
-#include <MaterialXRenderGlsl/GLUtilityContext.h>
+#include <MaterialXRenderGlsl/GLContext.h>
 
 namespace MaterialX
 {
@@ -26,7 +26,7 @@ namespace MaterialX
 //
 // Windows implementation
 //
-GLUtilityContext::GLUtilityContext(const WindowWrapper& /*windowWrapper*/, HardwareContextHandle sharedWithContext) :
+GLContext::GLContext(const WindowWrapper& /*windowWrapper*/, HardwareContextHandle sharedWithContext) :
     _contextHandle(nullptr),
     _isValid(false)
 {
@@ -74,7 +74,7 @@ GLUtilityContext::GLUtilityContext(const WindowWrapper& /*windowWrapper*/, Hardw
     }
 }
 
-void GLUtilityContext::shareLists(HardwareContextHandle context)
+void GLContext::shareLists(HardwareContextHandle context)
 {
     if (_isValid)
     {
@@ -86,7 +86,7 @@ void GLUtilityContext::shareLists(HardwareContextHandle context)
 //
 // Linux context implementation
 //
-GLUtilityContext::GLUtilityContext(const WindowWrapper& windowWrapper,
+GLContext::GLContext(const WindowWrapper& windowWrapper,
     HardwareContextHandle sharedWithContext)
 {
     _isValid = false;
@@ -230,7 +230,7 @@ GLUtilityContext::GLUtilityContext(const WindowWrapper& windowWrapper,
 //
 #elif defined(__APPLE__)
 
-GLUtilityContext::GLUtilityContext(const WindowWrapper& /*windowWrapper*/, HardwareContextHandle sharedWithContext)
+GLContext::GLContext(const WindowWrapper& /*windowWrapper*/, HardwareContextHandle sharedWithContext)
 {
     _isValid = false;
 
@@ -253,7 +253,7 @@ GLUtilityContext::GLUtilityContext(const WindowWrapper& /*windowWrapper*/, Hardw
 #endif
 
 // Destroy the startup context.
-GLUtilityContext::~GLUtilityContext()
+GLContext::~GLContext()
 {
     // Only do this portion if the context is valid
     if (_isValid)
@@ -287,7 +287,7 @@ GLUtilityContext::~GLUtilityContext()
     }
 }
 
-int GLUtilityContext::makeCurrent()
+int GLContext::makeCurrent()
 {
     if (!_isValid)
     {
@@ -314,9 +314,9 @@ int GLUtilityContext::makeCurrent()
 //
 // Creator
 //
-GLUtilityContextPtr GLUtilityContext::create(const WindowWrapper& windowWrapper, HardwareContextHandle context)
+GLContextPtr GLContext::create(const WindowWrapper& windowWrapper, HardwareContextHandle context)
 {
-    return std::shared_ptr<GLUtilityContext>(new GLUtilityContext(windowWrapper, context));
+    return std::shared_ptr<GLContext>(new GLContext(windowWrapper, context));
 }
 
 }

--- a/source/MaterialXRenderGlsl/GLContext.h
+++ b/source/MaterialXRenderGlsl/GLContext.h
@@ -3,11 +3,11 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
-#ifndef MATERIALX_GLUTILITYCONTEXT_H
-#define MATERIALX_GLUTILITYCONTEXT_H
+#ifndef MATERIALX_GLCONTEXT_H
+#define MATERIALX_GLCONTEXT_H
 
 /// @file
-/// OpenGL utility context
+/// OpenGL context class
 
 #include <MaterialXRenderHw/WindowWrapper.h>
 #include <memory>
@@ -33,23 +33,23 @@ using HardwareContextHandle = void*;
 using HardwareContextHandle = void*;
 #endif
 
-/// GLUtilityContext shared pointer
-using GLUtilityContextPtr = std::shared_ptr<class GLUtilityContext>;
+/// GLContext shared pointer
+using GLContextPtr = std::shared_ptr<class GLContext>;
 
-/// @class GLUtilityContext
+/// @class GLContext
 /// Base OpenGL context singleton.
 /// Used as a utility context to perform OpenGL operations from,
 /// and context for resource sharing between contexts.
 ///
-class GLUtilityContext
+class GLContext
 {
   public:
 
     /// Create a utility context
-    static GLUtilityContextPtr create(const WindowWrapper& windowWrapper, HardwareContextHandle context = 0);
+    static GLContextPtr create(const WindowWrapper& windowWrapper, HardwareContextHandle context = 0);
 
     /// Default destructor
-    virtual ~GLUtilityContext();
+    virtual ~GLContext();
 
     /// Return OpenGL context handle
     HardwareContextHandle contextHandle() const
@@ -78,7 +78,7 @@ class GLUtilityContext
 
   protected:
     /// Create the base context. A OpenGL context to share with can be passed in.
-    GLUtilityContext(const WindowWrapper& windowWrapper, HardwareContextHandle context = 0);
+    GLContext(const WindowWrapper& windowWrapper, HardwareContextHandle context = 0);
 
 #if defined(_WIN32)
     /// Offscreen window required for context operations

--- a/source/MaterialXRenderGlsl/GLUtil.cpp
+++ b/source/MaterialXRenderGlsl/GLUtil.cpp
@@ -1,0 +1,23 @@
+//
+// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXRenderGlsl/External/GLew/glew.h>
+
+#include <MaterialXRenderGlsl/GLUtil.h>
+
+#include <iostream>
+
+namespace MaterialX
+{
+
+void checkGlErrors(const string& context)
+{
+    for (GLenum error = glGetError(); error; error = glGetError())
+    {
+        std::cerr << "OpenGL error " << context << ": " << std::to_string(error) << std::endl;
+    }
+}
+
+} // namespace MaterialX

--- a/source/MaterialXRenderGlsl/GLUtil.h
+++ b/source/MaterialXRenderGlsl/GLUtil.h
@@ -1,0 +1,21 @@
+//
+// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_GLUTIL_H
+#define MATERIALX_GLUTIL_H
+
+/// @file
+/// OpenGL utilities
+
+#include <MaterialXCore/Library.h>
+
+namespace MaterialX
+{
+
+void checkGlErrors(const string& context);
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -6,6 +6,7 @@
 #include <MaterialXRenderGlsl/External/GLew/glew.h>
 #include <MaterialXRenderGlsl/GlslProgram.h>
 #include <MaterialXRenderGlsl/GLTextureHandler.h>
+#include <MaterialXRenderGlsl/GLUtil.h>
 
 #include <MaterialXRender/ShaderRenderer.h>
 
@@ -248,7 +249,7 @@ bool GlslProgram::bind()
     if (_programId > UNDEFINED_OPENGL_RESOURCE_ID)
     {
         glUseProgram(_programId);
-        checkErrors();
+        checkGlErrors("after program bind");
         return true;
     }
     return false;
@@ -268,7 +269,7 @@ void GlslProgram::bindInputs(ViewHandlerPtr viewHandler,
         throw ExceptionShaderRenderError(errorType, errors);
     }
 
-    checkErrors();
+    checkGlErrors("after program bind inputs");
 
     // Parse for uniforms and attributes
     getUniformsList();
@@ -491,7 +492,7 @@ void GlslProgram::bindStreams(MeshPtr mesh)
         }
     }
 
-    checkErrors();
+    checkGlErrors("after program bind streams");
 }
 
 void GlslProgram::unbindGeometry()
@@ -533,7 +534,7 @@ void GlslProgram::unbindGeometry()
     glDeleteVertexArrays(1, &_vertexArray);
     _vertexArray = GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
 
-    checkErrors();
+    checkGlErrors("after program unbind geometry");
 }
 
 ImagePtr GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation, const FilePath& filePath,
@@ -555,7 +556,7 @@ ImagePtr GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation,
                 glUniform1i(uniformLocation, textureLocation);
             }
         }
-        checkErrors();
+        checkGlErrors("after program bind texture");
         return image;
     }
 
@@ -616,9 +617,7 @@ void GlslProgram::bindTextures(ImageHandlerPtr imageHandler)
             }
         }
     }
-    checkErrors();
 }
-
 
 void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr imageHandler)
 {
@@ -1041,8 +1040,6 @@ void GlslProgram::bindViewInformation(ViewHandlerPtr viewHandler)
             glUniformMatrix4fv(location, 1, false, viewProjWorld.data());
         }
     } 
-
-    checkErrors();
 }
 
 void GlslProgram::bindTimeAndFrame()
@@ -1495,21 +1492,6 @@ void GlslProgram::printAttributes(std::ostream& outputStream)
         if (!value.empty())
             outputStream << ". Value: " << value;
         outputStream << "." << std::endl;
-    }
-}
-
-void GlslProgram::checkErrors()
-{
-    StringVec errors;
-
-    GLenum error;
-    while ((error = glGetError()) != GL_NO_ERROR)
-    {
-        errors.push_back("OpenGL error: " + std::to_string(error));
-    }
-    if (!errors.empty())
-    {
-        throw ExceptionShaderRenderError("OpenGL context error.", errors);
     }
 }
 

--- a/source/MaterialXRenderGlsl/GlslProgram.h
+++ b/source/MaterialXRenderGlsl/GlslProgram.h
@@ -234,11 +234,6 @@ class GlslProgram
     ImagePtr bindTexture(unsigned int uniformType, int uniformLocation, const FilePath& filePath,
                          ImageHandlerPtr imageHandler, bool generateMipMaps, const ImageSamplingProperties& imageProperties);
 
-    /// Utility to check for OpenGL context errors.
-    /// Will throw an ExceptionShaderRenderError exception which will list of the errors found
-    /// if any errors encountered.
-    void checkErrors();
-
     /// Delete any currently created shader program
     void deleteProgram();
 

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -5,7 +5,8 @@
 
 #include <MaterialXRenderGlsl/External/GLew/glew.h>
 #include <MaterialXRenderGlsl/GlslRenderer.h>
-#include <MaterialXRenderGlsl/GLUtilityContext.h>
+#include <MaterialXRenderGlsl/GLContext.h>
+#include <MaterialXRenderGlsl/GLUtil.h>
 #include <MaterialXRenderHw/SimpleWindow.h>
 #include <MaterialXRender/TinyObjLoader.h>
 
@@ -105,7 +106,7 @@ void GlslRenderer::initialize()
         }
 
         // Create offscreen context
-        _context = GLUtilityContext::create(_window->windowWrapper(), nullptr);
+        _context = GLContext::create(_window->windowWrapper(), nullptr);
         if (!_context)
         {
             errors.push_back("Failed to create OpenGL context for testing.");
@@ -294,7 +295,6 @@ void GlslRenderer::render()
                         glDrawElements(GL_TRIANGLES, (GLsizei)indexData.size(), GL_UNSIGNED_INT, (void*)0);
                     }
                 }
-                checkErrors();
 
                 // Unbind resources
                 _program->unbind();
@@ -323,18 +323,7 @@ ImagePtr GlslRenderer::captureImage()
         throw ExceptionShaderRenderError(errorType, errors);
     }
 
-    ImagePtr result = _frameBuffer->createColorImage();
-    try
-    {
-        checkErrors();
-    }
-    catch (ExceptionShaderRenderError& e)
-    {
-        errors.push_back("Failed to read color buffer back.");
-        errors.insert(std::end(errors), std::begin(e.errorLog()), std::end(e.errorLog()));
-        throw ExceptionShaderRenderError(errorType, errors);
-    }
-    return result;
+    return _frameBuffer->createColorImage();
 }
 
 void GlslRenderer::saveImage(const FilePath& filePath)
@@ -347,21 +336,6 @@ void GlslRenderer::saveImage(const FilePath& filePath)
     {
         errors.push_back("Failed to save to file:" + filePath.asString());
         throw ExceptionShaderRenderError(errorType, errors);
-    }
-}
-
-void GlslRenderer::checkErrors()
-{
-    StringVec errors;
-
-    GLenum error;
-    while ((error = glGetError()) != GL_NO_ERROR)
-    {
-        errors.push_back("OpenGL error: " + std::to_string(error));
-    }
-    if (errors.size())
-    {
-        throw ExceptionShaderRenderError("OpenGL context error.", errors);
     }
 }
 
@@ -380,6 +354,10 @@ void GlslRenderer::drawScreenSpaceQuad()
         1, 2, 3
     };
     
+    GLuint vao;
+    glGenVertexArrays(1, &vao);
+    glBindVertexArray(vao);
+
     GLuint vbo;
     glGenBuffers(1, &vbo);
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
@@ -397,6 +375,16 @@ void GlslRenderer::drawScreenSpaceQuad()
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(QUAD_INDICES), QUAD_INDICES, GL_STATIC_DRAW);
 
     glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+
+    glBindVertexArray(GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
+    glBindBuffer(GL_ARRAY_BUFFER, GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
+
+    glDeleteBuffers(1, &ebo);
+    glDeleteBuffers(1, &vbo);
+    glDeleteVertexArrays(1, &vao);
+
+    checkGlErrors("after draw screen-space quad");
 }
 
 } // namespace MaterialX

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -17,7 +17,7 @@
 namespace MaterialX
 {
 
-using GLUtilityContextPtr = std::shared_ptr<class GLUtilityContext>;
+using GLContextPtr = std::shared_ptr<class GLContext>;
 using SimpleWindowPtr = std::shared_ptr<class SimpleWindow>;
 
 /// Shared pointer to a GlslRenderer
@@ -114,9 +114,6 @@ class GlslRenderer : public ShaderRenderer
     virtual void updateWorldInformation();
 
   private:
-    void checkErrors();
-
-  private:
     GlslProgramPtr _program;
 
     GLFrameBufferPtr _frameBuffer;
@@ -129,7 +126,7 @@ class GlslRenderer : public ShaderRenderer
     float _objectScale;
 
     SimpleWindowPtr _window;
-    GLUtilityContextPtr _context;
+    GLContextPtr _context;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1,6 +1,7 @@
 #include <MaterialXView/Viewer.h>
 
 #include <MaterialXRenderGlsl/GLTextureHandler.h>
+#include <MaterialXRenderGlsl/GLUtil.h>
 #include <MaterialXRenderGlsl/TextureBaker.h>
 
 #include <MaterialXRender/Harmonics.h>
@@ -1832,7 +1833,7 @@ void Viewer::drawContents()
 
     updateViewHandlers();
 
-    checkGlErrors("before viewer render");
+    mx::checkGlErrors("before viewer render");
 
     // Render a wedge for the current material.
     if (_wedgeRequested)
@@ -1866,7 +1867,7 @@ void Viewer::drawContents()
         bakeTextures();
     }
 
-    checkGlErrors("after viewer render");
+    mx::checkGlErrors("after viewer render");
 }
 
 bool Viewer::scrollEvent(const ng::Vector2i& p, const ng::Vector2f& rel)
@@ -2190,12 +2191,4 @@ void Viewer::updateAlbedoTable()
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     glDrawBuffer(GL_BACK);
-}
-
-void Viewer::checkGlErrors(const std::string& context)
-{
-    for (GLenum error = glGetError(); error; error = glGetError())
-    {
-        std::cerr << "OpenGL error " << context << ": " << std::to_string(error) << std::endl;
-    }
 }

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -137,9 +137,6 @@ class Viewer : public ng::Screen
     /// Update the directional albedo table.
     void updateAlbedoTable();
 
-    /// Check for any OpenGL errors that have been encountered.
-    void checkGlErrors(const std::string& context);
-
   private:
     ng::Window* _window;
     ng::Arcball _arcball;


### PR DESCRIPTION
- Add missing VAO binding to GlslRenderer::drawScreenSpaceQuad.
- Use warnings rather than exceptions to report OpenGL errors.
- Update CMake settings in MaterialXRenderGlsl to prefer GLVND libraries.
- Reorganize GLUtilityContext into GLUtil and GLContext for clarity.