### PR TITLE
Improved color space handling in MaterialXRenderGlsl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,12 +91,6 @@ jobs:
           echo "CC=clang-${{ matrix.compiler_version }}" >> $GITHUB_ENV
           echo "CXX=clang++-${{ matrix.compiler_version }}" >> $GITHUB_ENV
         fi
-        if [ "${{ matrix.test_render }}" = "ON" ]; then
-          echo "MESA_GL_VERSION_OVERRIDE=4.0FC" >> $GITHUB_ENV
-          echo "MESA_GLSL_VERSION_OVERRIDE=400" >> $GITHUB_ENV
-          echo "GALLIUM_DRIVER=softpipe" >> $GITHUB_ENV
-          echo "RENDER_ENVIRONMENT=xvfb-run" >> $GITHUB_ENV
-        fi
 
     - name: Install Dependencies (MacOS)
       if: runner.os == 'macOS'
@@ -144,11 +138,21 @@ jobs:
         python genshader.py
       working-directory: python/MaterialXTest
 
+    - name: Initialize Virtual Framebuffer
+      if: matrix.test_render == 'ON' && runner.os == 'Linux'
+      run: |
+        Xvfb :99 -screen 0 1280x960x24 &
+        echo "DISPLAY=:99" >> $GITHUB_ENV
+        echo "MESA_GL_VERSION_OVERRIDE=4.0FC" >> $GITHUB_ENV
+        echo "MESA_GLSL_VERSION_OVERRIDE=400" >> $GITHUB_ENV
+        echo "GALLIUM_DRIVER=softpipe" >> $GITHUB_ENV
+
     - name: Material Baking Tests
       if: matrix.test_render == 'ON'
       run: |
         mkdir build/baked
-        $RENDER_ENVIRONMENT python python/Scripts/baketextures.py resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx build/baked/brass_tiled_baked.mtlx --path .
+        python python/Scripts/baketextures.py resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx build/baked/brass_tiled_baked.mtlx --path .
+        python python/Scripts/baketextures.py resources/Materials/Examples/StandardSurface/standard_surface_carpaint.mtlx build/baked/carpaint_baked.mtlx --path .
 
     - name: Generate Test HTML
       if: matrix.generate_html == 'ON'
@@ -165,7 +169,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: matrix.test_render == 'ON'
       with:
-        name: BakedMaterials
+        name: BakedMaterials_${{matrix.name}}
         path: build/baked/
 
     - name: Upload Test HTML

--- a/resources/Materials/Examples/StandardSurface/standard_surface_carpaint.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_carpaint.mtlx
@@ -8,7 +8,6 @@
       <bindinput name="specular_color" type="color3" value="1.0, 1.0, 1.0" />
       <bindinput name="specular_roughness" type="float" value="0.4" />
       <bindinput name="specular_anisotropy" type="float" value="0.5" />
-      <bindinput name="transmission_depth" type="float" value="1" />
       <bindinput name="coat" type="float" value="1" />
       <bindinput name="coat_roughness" type="float" value="0" />
     </shaderref>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_greysphere_calibration.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_greysphere_calibration.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<materialx version="1.37" colorspace="srgb_texture" fileprefix="resources/Images/">
-  <nodegraph name="NG_Greysphere_Calibration">
+<materialx version="1.37" fileprefix="resources/Images/">
+  <nodegraph name="NG_Greysphere_Calibration" colorspace="srgb_texture">
     <texcoord name="texcoord1" type="vector2" />
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1"/>

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -13,6 +13,7 @@
 
 #include <MaterialXCore/Document.h>
 
+#include <iostream>
 #include <queue>
 
 namespace MaterialX
@@ -1593,7 +1594,7 @@ void ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManage
     const string& sourceColorSpace = input->getActiveColorSpace();
     if (shaderPort && !sourceColorSpace.empty())
     {
-        if(shaderPort->getType() == Type::COLOR3 || shaderPort->getType() == Type::COLOR4)
+        if (shaderPort->getType() == Type::COLOR3 || shaderPort->getType() == Type::COLOR4)
         {
             // If we're converting between two identical color spaces than we have no work to do.
             if (sourceColorSpace != targetColorSpace)
@@ -1609,6 +1610,11 @@ void ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManage
                     {
                         _outputColorTransformMap.emplace(static_cast<ShaderOutput*>(shaderPort), transform);
                     }
+                }
+                else
+                {
+                    std::cerr << "Unsupported color space transform from " <<
+                        sourceColorSpace << " to " << targetColorSpace << std::endl;
                 }
             }
         }


### PR DESCRIPTION
- Correctly transfer color spaces of uniform values in TextureBaker.
- Add a warning for unsupported color space transforms in ShaderGraph.
- Add a second material baking test to GitHub Actions.
- Minor clarifications to example materials.