### PR TITLE
Texture baking improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           compiler: gcc
           compiler_version: "10"
           python: 3.7
+          test_render: ON
 
         - name: MacOS_Xcode_10_Python27
           os: macos-10.15

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -10,8 +10,6 @@
 
 #include <MaterialXCore/Value.h>
 
-#include <regex>
-
 namespace MaterialX
 {
 
@@ -294,11 +292,7 @@ static bool isInvalidChar(char c)
 void Syntax::makeValidName(string& name) const
 {
     std::replace_if(name.begin(), name.end(), isInvalidChar, '_');
-    for (auto tokenPair : _invalidTokens)
-    {
-        std::regex expression(tokenPair.first);
-        name = std::regex_replace(name, expression, tokenPair.second);
-    }
+    name = replaceSubstrings(name, _invalidTokens);
 }
 
 void Syntax::makeIdentifier(string& name, IdentifierMap& identifiers) const

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -26,21 +26,20 @@ const float FAR_PLANE_PERSP = 100.0f;
 // GlslRenderer methods
 //
 
-GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height, Image::BaseType baseType, const Color4& clearColor)
+GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height, Image::BaseType baseType)
 {
-    return GlslRendererPtr(new GlslRenderer(width, height, baseType, clearColor));
+    return GlslRendererPtr(new GlslRenderer(width, height, baseType));
 }
 
-GlslRenderer::GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType, const Color4& clearColor) :
+GlslRenderer::GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
     ShaderRenderer(width, height, baseType),
     _initialized(false),
     _eye(0.0f, 0.0f, 4.0f),
     _center(0.0f, 0.0f, 0.0f),
     _up(0.0f, 1.0f, 0.0f),
-    _objectScale(1.0f)
+    _objectScale(1.0f),
+    _clearColor(0.4f, 0.4f, 0.4f, 1.0f)
 {
-    setClearColor(clearColor);
-
     _program = GlslProgram::create();
 
     _geometryHandler = GeometryHandler::create();

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -41,7 +41,7 @@ class GlslRenderer : public ShaderRenderer
 {
   public:
     /// Create a GLSL renderer instance
-    static GlslRendererPtr create(unsigned int width = 512, unsigned int height = 512, Image::BaseType baseType = Image::BaseType::UINT8, const Color4& clearColor = Color4(0.4f, 0.4f, 0.4f, 1.0f));
+    static GlslRendererPtr create(unsigned int width = 512, unsigned int height = 512, Image::BaseType baseType = Image::BaseType::UINT8);
 
     /// Destructor
     virtual ~GlslRenderer();
@@ -111,7 +111,7 @@ class GlslRenderer : public ShaderRenderer
     /// @}
 
   protected:
-    GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType, const Color4& clearColor = Color4(0.4f, 0.4f, 0.4f, 1.0f));
+    GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType);
 
     virtual void updateViewInformation();
     virtual void updateWorldInformation();

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -22,10 +22,6 @@ namespace MaterialX
 /// A shared pointer to a TextureBaker
 using TextureBakerPtr = shared_ptr<class TextureBaker>;
 
-/// Baked document list of shader node and it's corresponding baked Document
-using ListofBakedDocuments = std::vector<std::pair<std::string, DocumentPtr>>;
-
-
 /// @class TextureBaker
 /// A helper class for baking procedural material content to textures.
 /// TODO: Add support for graphs containing geometric nodes such as position
@@ -131,13 +127,13 @@ class TextureBaker : public GlslRenderer
     }
 
     /// Set the output location for baked texture images
-    void setOutputResourcePath(const FilePath& outputImagePath)
+    void setOutputImagePath(const FilePath& outputImagePath)
     {
         _outputImagePath = outputImagePath;
     }
 
     /// Get the current output location for baked texture images
-    const FilePath& getOutputResourcePath()
+    const FilePath& getOutputImagePath()
     {
         return _outputImagePath;
     }
@@ -151,12 +147,11 @@ class TextureBaker : public GlslRenderer
     /// Optimize baked textures before writing.
     void optimizeBakedTextures(NodePtr shader);
 
-    /// Write the baked material with textures to a document
-    DocumentPtr getBakedMaterial(NodePtr shader, const StringVec& udimSet);
+    /// Write the baked material with textures to a document.
+    DocumentPtr bakeMaterial(NodePtr shader, const StringVec& udimSet);
 
-    /// Returns a list of baked documents for each material in the input document.
-    ListofBakedDocuments bakeAllMaterials(DocumentPtr doc, const FileSearchPath& imageSearchPath);
-
+    /// Generate a baked version of each material in the input document.
+    void bakeAllMaterials(DocumentPtr doc, const FileSearchPath& imageSearchPath, const FilePath& outputFilename);
 
   protected:
     TextureBaker(unsigned int width, unsigned int height, Image::BaseType baseType);

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -560,41 +560,22 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
     return true;
 }
 
-void  GlslShaderRenderTester::runBake(mx::DocumentPtr doc, const mx::FileSearchPath& imageSearchPath, const mx::FilePath& outputFileName,
-                                           unsigned int bakeWidth, unsigned int bakeHeight, bool bakeHdr, std::ostream& log)
+void GlslShaderRenderTester::runBake(mx::DocumentPtr doc, const mx::FileSearchPath& imageSearchPath, const mx::FilePath& outputFileName,
+                                      unsigned int bakeWidth, unsigned int bakeHeight, bool bakeHdr, std::ostream& log)
 {
-    if (bakeWidth < 2)
-    {
-        bakeWidth = 2;
-    }
-    if (bakeHeight < 2)
-    {
-        bakeHeight = 2;
-    }
+    bakeWidth = std::max(bakeWidth, (unsigned int) 2);
+    bakeHeight = std::max(bakeHeight, (unsigned int) 2);
+
     mx::Image::BaseType baseType = bakeHdr ? mx::Image::BaseType::FLOAT : mx::Image::BaseType::UINT8;
     mx::TextureBakerPtr baker = mx::TextureBaker::create(bakeWidth, bakeHeight, baseType);
     baker->setupUnitSystem(doc);
     baker->setTargetUnitSpace("meter");
     baker->setImageHandler(_renderer->getImageHandler());
-    baker->setOutputResourcePath(outputFileName.getParentPath());
-    
+    baker->setOutputImagePath(outputFileName.getParentPath());
     try
     {
-        mx::ListofBakedDocuments bakedDocuments = baker->bakeAllMaterials(doc, imageSearchPath);
-        for (size_t i =0; i < bakedDocuments.size(); i++)
-        {
-            if (bakedDocuments[i].second)
-            {
-                mx::FilePath writeFilename = outputFileName;
-                std::string extension = writeFilename.getExtension();
-                writeFilename.removeExtension();
-                writeFilename = mx::FilePath(writeFilename.asString() + "_baked_" + bakedDocuments[i].first + "." + extension);
-                mx::writeToXmlFile(bakedDocuments[i].second, writeFilename);
-                log << "Write baked document: " << writeFilename.asString() << std::endl;
-            }
-            else
-               log << doc->getSourceUri() + " failed baking process: " << std::endl;
-        }
+        baker->bakeAllMaterials(doc, imageSearchPath, outputFileName);
+        log << "Wrote baked document: " << outputFileName.asString() << std::endl;
     }
     catch (mx::Exception& e)
     {

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
@@ -26,10 +26,10 @@ void bindPyTextureBaker(py::module& mod)
         .def("getBakedGraphName", &mx::TextureBaker::getBakedGraphName)
         .def("setBakedGeomInfoName", &mx::TextureBaker::setBakedGeomInfoName)
         .def("getBakedGeomInfoName", &mx::TextureBaker::getBakedGeomInfoName)
-        .def("setOutputResourcePath", &mx::TextureBaker::setOutputResourcePath)
-        .def("getOutputResourcePath", &mx::TextureBaker::getOutputResourcePath)
+        .def("setOutputImagePath", &mx::TextureBaker::setOutputImagePath)
+        .def("getOutputImagePath", &mx::TextureBaker::getOutputImagePath)
         .def("setOptimizeConstants", &mx::TextureBaker::setOptimizeConstants)
         .def("getOptimizeConstants", &mx::TextureBaker::getOptimizeConstants)
-        .def("bakeAllMaterials", &mx::TextureBaker::bakeAllMaterials)
-        .def("getBakedMaterial", &mx::TextureBaker::getBakedMaterial);
+        .def("bakeMaterial", &mx::TextureBaker::bakeMaterial)
+        .def("bakeAllMaterials", &mx::TextureBaker::bakeAllMaterials);
 }


### PR DESCRIPTION
- Align texture baking logic between render tests and the MaterialX viewer.
- Align TextureBaker function signatures with their v1.37 equivalents for consistency.
- Remove references to the standard regex library, which is not consistently supported in GCC 4.8.
- Restore cloud-based tests for material baking.