### PR TITLE
Minor refinements to v1.38

### DIFF
--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -410,7 +410,7 @@ void InterfaceElement::setConnectedOutput(const string& inputName, OutputPtr out
     InputPtr input = getInput(inputName);
     if (!input)
     {
-        input = addInput(inputName, DEFAULT_TYPE_STRING);
+        input = addInput(inputName);
     }
     if (output)
     {

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -356,24 +356,15 @@ class InterfaceElement : public TypedElement
 
     /// Add an Input to this interface.
     /// @param name The name of the new Input.
-    ///     If an empty string is specified, then a unique name will automatically be
+    ///     If no name is specified, then a unique name will automatically be
     ///     generated.
-    /// @param type The input type string.
-    /// @param isUniform Option to mark the input as a uniform. By default the input
-    ///     is not marked as being a uniform. "string" and "filename" types are always
-    ///     marked as being a uniform.
+    /// @param type An optional type string.
     /// @return A shared pointer to the new Input.
     InputPtr addInput(const string& name,
-                      const string& type,
-                      bool isUniform = false)
+                      const string& type = DEFAULT_TYPE_STRING)
     {
         InputPtr child = addChild<Input>(name);
         child->setType(type);
-        const StringSet uniformTypes = { FILENAME_TYPE_STRING, STRING_TYPE_STRING };
-        if (isUniform || uniformTypes.count(type))
-        {
-            child->setIsUniform(true);
-        }
         return child;
     }
 
@@ -609,7 +600,7 @@ template<class T> InputPtr InterfaceElement::setInputValue(const string& name,
 {
     InputPtr input = getChildOfType<Input>(name);
     if (!input)
-        input = addInput(name, type);
+        input = addInput(name);
     input->setValue(value, type);
     return input;
 }

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -26,7 +26,7 @@ void Node::setConnectedNode(const string& inputName, NodePtr node)
     InputPtr input = getInput(inputName);
     if (!input)
     {
-        input = addInput(inputName, DEFAULT_TYPE_STRING);
+        input = addInput(inputName);
     }
     if (node)
     {
@@ -50,7 +50,7 @@ void Node::setConnectedNodeName(const string& inputName, const string& nodeName)
     InputPtr input = getInput(inputName);
     if (!input)
     {
-        input = addInput(inputName, DEFAULT_TYPE_STRING);
+        input = addInput(inputName);
     }
     input->setNodeName(nodeName);
 }

--- a/source/MaterialXFormat/Util.cpp
+++ b/source/MaterialXFormat/Util.cpp
@@ -137,7 +137,7 @@ StringSet loadLibraries(const FilePathVec& libraryFolders,
     return loadedLibraries;
 }
 
-void resolveFileNames(DocumentPtr doc, const FileSearchPath& searchPath, StringResolverPtr customResolver)
+void flattenFilenames(DocumentPtr doc, const FileSearchPath& searchPath, StringResolverPtr customResolver)
 {
     for (ElementPtr elem : doc->traverseTree())
     {
@@ -193,6 +193,5 @@ void resolveFileNames(DocumentPtr doc, const FileSearchPath& searchPath, StringR
         }
     }
 }
-
 
 } // namespace MaterialX

--- a/source/MaterialXFormat/Util.h
+++ b/source/MaterialXFormat/Util.h
@@ -45,17 +45,12 @@ StringSet loadLibraries(const FilePathVec& libraryFolders,
                         const StringSet& excludeFiles = StringSet(),
                         XmlReadOptions* readOptions = nullptr);
 
-/// Set file name values to resolved values. 
-/// The resolve applies:
-///   - the Element's default string resolver
-///   - an optional relative to absoulte path conversion
-///   - an optional custom file name string resolver
-/// Note that all "fileprefix" attributes will be removed from the Document as they have
-/// been prepended to the resolved file name values.
-/// \param doc Document to modify.
-/// \param searchPath Optional search path for relative to absolute path conversion. Default value is an empty search path.
-/// \param customResolver Optional custom name resolver to apply. Default value is a null resolver.
-void resolveFileNames(DocumentPtr doc, const FileSearchPath& searchPath = FileSearchPath(), StringResolverPtr customResolver = nullptr);
+/// Flatten all filenames in the given document, applying string resolvers at the
+/// scope of each element and removing all fileprefix attributes.
+/// @param doc The document to modify.
+/// @param searchPath An optional search path for relative to absolute path conversion.
+/// @param customResolver An optional custom resolver to apply.
+void flattenFilenames(DocumentPtr doc, const FileSearchPath& searchPath = FileSearchPath(), StringResolverPtr customResolver = nullptr);
 
 } // namespace MaterialX
 

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -12,8 +12,6 @@
 #include <MaterialXFormat/XmlIo.h>
 #include <MaterialXFormat/PugiXML/pugixml.hpp>
 
-#include <list>
-
 namespace MaterialX
 {
 
@@ -573,7 +571,7 @@ void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& eleme
     findRenderableMaterialNodes(doc, elements, includeReferencedGraphs, processedSources);
 
     // Find node graph outputs. Skip any light shaders
-    std::list<OutputPtr> testOutputs;
+    vector<OutputPtr> testOutputs;
     for (NodeGraphPtr nodeGraph : doc->getNodeGraphs())
     {
         // Skip anything from an include file including libraries.

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -291,7 +291,7 @@ DocumentPtr TextureBaker::bakeMaterial(NodePtr shader, const StringVec& udimSet)
                 InputPtr bakedMaterialInput = bakedMaterial->getInput(sourceMaterialInputName);
                 if (!bakedMaterialInput)
                 {
-                    bakedMaterialInput = bakedMaterial->addInput(sourceMaterialInputName, sourceMaterialInput->getType(), sourceMaterialInput->getIsUniform());
+                    bakedMaterialInput = bakedMaterial->addInput(sourceMaterialInputName, sourceMaterialInput->getType());
                 }
                 bakedMaterialInput->setNodeName(bakedShader->getName());
             }
@@ -312,7 +312,7 @@ DocumentPtr TextureBaker::bakeMaterial(NodePtr shader, const StringVec& udimSet)
         InputPtr bakedInput = bakedShader->getInput(sourceName);
         if (!bakedInput)
         {
-            bakedInput = bakedShader->addInput(sourceName, sourceType, sourceInput->getIsUniform());
+            bakedInput = bakedShader->addInput(sourceName, sourceType);
         }
 
         OutputPtr output = sourceInput->getConnectedOutput();

--- a/source/MaterialXTest/MaterialXFormat/File.cpp
+++ b/source/MaterialXTest/MaterialXFormat/File.cpp
@@ -89,7 +89,7 @@ TEST_CASE("File utilities", "[file]")
     image2->setInputValue("file", "brass_color.jpg", mx::FILENAME_TYPE_STRING);
 
     // 1. Test resolving fileprefix
-    mx::resolveFileNames(doc1);
+    mx::flattenFilenames(doc1);
     REQUIRE(nodeGraph->getFilePrefix() == mx::EMPTY_STRING);
     mx::FilePath resolvedPath(image1->getInputValue("file")->getValueString());
     REQUIRE(resolvedPath == (TEST_FILE_PREFIX_STRING / TEST_IMAGE_STRING1));
@@ -107,7 +107,7 @@ TEST_CASE("File utilities", "[file]")
     mx::FileSearchPath searchPath;
     searchPath.append(rootPath);
 
-    mx::resolveFileNames(doc1, searchPath);    
+    mx::flattenFilenames(doc1, searchPath);    
     CHECK(nodeGraph->getFilePrefix() == mx::EMPTY_STRING);
     resolvedPath = image1->getInputValue("file")->getValueString();
     CHECK(resolvedPath.asString() == (rootPath / TEST_FILE_PREFIX_STRING / TEST_IMAGE_STRING1).asString());
@@ -125,7 +125,7 @@ TEST_CASE("File utilities", "[file]")
     separatorReplacer->setFilenameSubstitution("\\\\", "/");
     separatorReplacer->setFilenameSubstitution("\\", "/");
 
-    mx::resolveFileNames(doc1, searchPath, separatorReplacer);
+    mx::flattenFilenames(doc1, searchPath, separatorReplacer);
     CHECK(nodeGraph->getFilePrefix() == mx::EMPTY_STRING);
     std::string resolvedPathString = image1->getInputValue("file")->getValueString();
     CHECK(resolvedPathString == (rootPath / TEST_FILE_PREFIX_STRING / TEST_IMAGE_STRING1).asString(mx::FilePath::FormatPosix));
@@ -134,7 +134,7 @@ TEST_CASE("File utilities", "[file]")
 
     // 4. Test with pre-resolved filenames
     nodeGraph->setFilePrefix(TEST_FILE_PREFIX_STRING.asString() + "\\");
-    mx::resolveFileNames(doc1, searchPath, separatorReplacer);
+    mx::flattenFilenames(doc1, searchPath, separatorReplacer);
     CHECK(nodeGraph->getFilePrefix() == mx::EMPTY_STRING);
     resolvedPathString = image1->getInputValue("file")->getValueString();
     CHECK(resolvedPathString == (rootPath / TEST_FILE_PREFIX_STRING / TEST_IMAGE_STRING1).asString(mx::FilePath::FormatPosix));

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1931,10 +1931,15 @@ void Viewer::bakeTextures()
         baker->setAverageImages(_bakeAverage);
         baker->setOptimizeConstants(_bakeOptimize);
 
+        // Extend the image search path to include the source material folder.
+        mx::FilePath materialFilename = mx::FilePath(doc->getSourceUri());
+        mx::FileSearchPath materialSearchPath = _searchPath;
+        materialSearchPath.append(materialFilename.getParentPath());
+
         // Bake all materials in the active document.
         try
         {
-            baker->bakeAllMaterials(doc, _imageHandler->getSearchPath(), _bakeFilename);
+            baker->bakeAllMaterials(doc, materialSearchPath, _bakeFilename);
         }
         catch (std::exception& e)
         {

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -50,8 +50,7 @@ void bindPyInterface(py::module& mod)
         .def("hasNodeDefString", &mx::InterfaceElement::hasNodeDefString)
         .def("getNodeDefString", &mx::InterfaceElement::getNodeDefString)
         .def("addInput", &mx::InterfaceElement::addInput,
-            py::arg("name") = mx::EMPTY_STRING, py::arg("type") = mx::DEFAULT_TYPE_STRING,
-            py::arg("isUniform") = false)
+            py::arg("name") = mx::EMPTY_STRING, py::arg("type") = mx::DEFAULT_TYPE_STRING)
         .def("getInput", &mx::InterfaceElement::getInput)
         .def("getInputs", &mx::InterfaceElement::getInputs)
         .def("getInputCount", &mx::InterfaceElement::getInputCount)

--- a/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
@@ -21,6 +21,6 @@ void bindPyUtil(py::module& mod)
         py::arg("file"), py::arg("doc"), py::arg("searchPath") = mx::FileSearchPath(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("loadLibraries", &mx::loadLibraries,
         py::arg("libraryFolders"), py::arg("searchPath"), py::arg("doc"), py::arg("excludeFiles") = mx::StringSet(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
-    mod.def("resolveFileNames", &mx::resolveFileNames,
+    mod.def("flattenFilenames", &mx::flattenFilenames,
         py::arg("doc"), py::arg("searchPath") = mx::FileSearchPath(), py::arg("customResolver") = (mx::StringResolverPtr) nullptr);
 }


### PR DESCRIPTION
- Align the signature of InterfaceElement::addInput with v1.37.
- Rename resolveFileNames to flattenFilenames for clarity.
- Extend the image search path in viewer texture baking.