### PR TITLE
Additional cleanup for v1.38

### DIFF
--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -310,8 +310,8 @@ class Output : public PortElement
 /// @class InterfaceElement
 /// The base class for interface elements such as Node, NodeDef, and NodeGraph.
 ///
-/// An InterfaceElement supports a set of Parameter, Input, and Output elements,
-/// with an API for setting their values.
+/// An InterfaceElement supports a set of Input and Output elements, with an API
+/// for setting their values.
 class InterfaceElement : public TypedElement
 {
   protected:
@@ -360,7 +360,7 @@ class InterfaceElement : public TypedElement
     ///     generated.
     /// @param type An optional type string.
     /// @return A shared pointer to the new Input.
-    InputPtr addInput(const string& name,
+    InputPtr addInput(const string& name = EMPTY_STRING,
                       const string& type = DEFAULT_TYPE_STRING)
     {
         InputPtr child = addChild<Input>(name);
@@ -511,12 +511,12 @@ class InterfaceElement : public TypedElement
 
     /// Return the first value element with the given name that belongs to this
     /// interface, taking interface inheritance into account.
-    /// Examples of value elements are Parameter, Input, Output, and Token.
+    /// Examples of value elements are Input, Output, and Token.
     ValueElementPtr getActiveValueElement(const string& name) const;
 
     /// Return a vector of all value elements that belong to this interface,
     /// taking inheritance into account.
-    /// Examples of value elements are Parameter, Input, Output, and Token.
+    /// Examples of value elements are Input, Output, and Token.
     vector<ValueElementPtr> getActiveValueElements() const;
 
     /// @}
@@ -534,7 +534,7 @@ class InterfaceElement : public TypedElement
     /// @param name The name of the input to be evaluated.
     /// @param target An optional target name, which will be used to filter
     ///    the declarations that are considered.
-    /// @return If the given parameter is found in this interface or its
+    /// @return If the given input is found in this interface or its
     ///    declaration, then a shared pointer to its value is returned;
     ///    otherwise, an empty shared pointer is returned.
     ValuePtr getInputValue(const string& name, const string& target = EMPTY_STRING) const;
@@ -575,9 +575,8 @@ class InterfaceElement : public TypedElement
     /// Node is an instantiation of a given NodeDef.
     ///
     /// If the type string of the instance differs from that of the declaration,
-    /// then false is returned.  If the instance possesses a Parameter or Input
-    /// with no Parameter or Input of matching type in the declaration, then
-    /// false is returned.
+    /// then false is returned.  If the instance possesses an Input with no Input
+    /// of matching type in the declaration, then false is returned.
     bool isTypeCompatible(ConstInterfaceElementPtr declaration) const;
 
     /// @}

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -48,8 +48,8 @@ using NodePredicate = std::function<bool(NodePtr node)>;
 /// @class Node
 /// A node element within a NodeGraph or Document.
 ///
-/// A Node represents an instance of a NodeDef within a graph, and its Parameter
-/// and Input elements apply specific values and connections to that instance.
+/// A Node represents an instance of a NodeDef within a graph, and its Input
+/// elements apply specific values and connections to that instance.
 class Node : public InterfaceElement
 {
   public:

--- a/source/MaterialXGenMdl/MdlShaderGenerator.h
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.h
@@ -14,6 +14,7 @@
 namespace MaterialX
 {
 
+/// Shared pointer to an MdlShaderGenerator
 using MdlShaderGeneratorPtr = shared_ptr<class MdlShaderGenerator>;
 
 /// @class MdlShaderGenerator
@@ -44,26 +45,26 @@ class MdlShaderGenerator : public ShaderGenerator
     /// Unique identifier for this generator target
     static const string TARGET;
 
-protected:
-    /// Create and initialize a new MDL shader for shader generation.
+  protected:
+    // Create and initialize a new MDL shader for shader generation.
     ShaderPtr createShader(const string& name, ElementPtr element, GenContext& context) const;
 
-    /// Override the sourcecode implementation creator
+    // Override the sourcecode implementation creator
     ShaderNodeImplPtr createSourceCodeImplementation(const Implementation& impl) const override;
 
-    /// Override the compound implementation creator.
+    // Override the compound implementation creator.
     ShaderNodeImplPtr createCompoundImplementation(const NodeGraph& impl) const override;
 
-    /// Override the shader graph finalization.
+    // Override the shader graph finalization.
     void finalizeShaderGraph(ShaderGraph& graph) override;
 
-    /// Emit a block of shader inputs.
+    // Emit a block of shader inputs.
     void emitShaderInputs(const VariableBlock& inputs, ShaderStage& stage) const;
 };
 
 namespace MDL
 {
-    /// Identifiers for MDL variable blocks
+    // Identifiers for MDL variable blocks
     extern const string INPUTS;
     extern const string OUTPUTS;
 }

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -5,12 +5,11 @@
 
 #include <MaterialXGenMdl/MdlSyntax.h>
 
-#include <MaterialXFormat/File.h>
-#include <MaterialXGenShader/Library.h>
 #include <MaterialXGenShader/TypeDesc.h>
 
+#include <MaterialXFormat/File.h>
+
 #include <sstream>
-#include <memory>
 
 namespace MaterialX
 {
@@ -30,7 +29,7 @@ namespace
 
 class MdlFilenameTypeSyntax : public ScalarTypeSyntax
 {
-public:
+  public:
     MdlFilenameTypeSyntax() :
         ScalarTypeSyntax("texture_2d", "texture_2d()", "texture_2d()")
     {}
@@ -123,7 +122,7 @@ class MdlIntegerArrayTypeSyntax : public MdlArrayTypeSyntax
 //
 class MdlColor4TypeSyntax : public AggregateTypeSyntax
 {
-public:
+  public:
     MdlColor4TypeSyntax() :
         AggregateTypeSyntax("color4", "mk_color4(0.0)", "mk_color4(0.0)", 
             EMPTY_STRING, EMPTY_STRING, MdlSyntax::COLOR4_MEMBERS)
@@ -164,7 +163,7 @@ public:
 
 class MdlEnumSyntax : public AggregateTypeSyntax
 {
-public:
+  public:
     MdlEnumSyntax(const string& name, const string& defaultValue, const string& defaultUniformValue, const StringVec& members) :
         AggregateTypeSyntax(name, defaultValue, defaultUniformValue, EMPTY_STRING, EMPTY_STRING, members)
     {}
@@ -174,7 +173,6 @@ public:
         return _name + "_" + value.getValueString();
     }
 };
-
 
 } // anonymous namespace
 

--- a/source/MaterialXGenMdl/MdlSyntax.h
+++ b/source/MaterialXGenMdl/MdlSyntax.h
@@ -7,7 +7,7 @@
 #define MATERIALX_MDLSYNTAX_H
 
 /// @file
-/// OSL syntax class
+/// MDL syntax class
 
 #include <MaterialXGenShader/Syntax.h>
 
@@ -16,14 +16,14 @@ namespace MaterialX
 
 class MdlSyntax;
 
-/// Shared pointer to a MdlSyntax
+/// Shared pointer to an MdlSyntax
 using MdlSyntaxPtr = shared_ptr<MdlSyntax>;
 
 /// @class MdlSyntax
 /// Syntax class for MDL (Material Definition Language)
 class MdlSyntax : public Syntax
 {
-public:
+  public:
     MdlSyntax();
 
     static SyntaxPtr create() { return std::make_shared<MdlSyntax>(); }

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
@@ -3,20 +3,15 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
+#include <MaterialXGenMdl/Nodes/BlurNodeMdl.h>
+
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/ShaderNode.h>
 #include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 
-#include <MaterialXGenMdl/Nodes/BlurNodeMdl.h>
-
 namespace MaterialX
 {
-
-BlurNodeMdl::BlurNodeMdl() :
-    BlurNode()
-{
-}
 
 ShaderNodeImplPtr BlurNodeMdl::create()
 {

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
@@ -21,10 +21,6 @@ class BlurNodeMdl : public BlurNode
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
   protected:
-    /// Constructor
-    BlurNodeMdl();
-      
-    /// Output sample array
     void outputSampleArray(const ShaderGenerator& shadergen, ShaderStage& stage, const TypeDesc* inputType,
                            const string& sampleName, const StringVec& sampleStrings) const override;
 };

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
@@ -4,13 +4,12 @@
 //
 
 #include <MaterialXGenMdl/Nodes/CompoundNodeMdl.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
+
 #include <MaterialXGenShader/HwShaderGenerator.h>
+#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
 
-#include <MaterialXCore/Library.h>
 #include <MaterialXCore/Definition.h>
-#include <MaterialXCore/Document.h>
 
 namespace MaterialX
 {

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h>
+
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 
 #include <MaterialXGenShader/Shader.h>
@@ -25,10 +26,6 @@ namespace
     const unsigned int filterWidth = 3;
     const float filterSize = 1.0;
     const float filterOffset = 0.0;
-}
-
-HeightToNormalNodeMdl::HeightToNormalNodeMdl()
-{
 }
 
 ShaderNodeImplPtr HeightToNormalNodeMdl::create()

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
@@ -23,9 +23,6 @@ class HeightToNormalNodeMdl : public ConvolutionNode
     const string& getTarget() const override;
 
   protected:
-    /// Constructor
-    HeightToNormalNodeMdl();
-
     /// Return if given type is an acceptible input
     bool acceptsInputType(const TypeDesc* type) const override;
 

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
@@ -4,10 +4,11 @@
 //
 
 #include <MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h>
+
 #include <MaterialXGenShader/GenContext.h>
+#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/ShaderNode.h>
 #include <MaterialXGenShader/ShaderStage.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
 
 namespace MaterialX
@@ -62,7 +63,6 @@ void SourceCodeNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& con
 
             size_t pos = 0;
             size_t i = _functionSource.find_first_of(prefix);
-            StringSet variableNames;
             StringVec code;
             while (i != string::npos)
             {

--- a/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
@@ -4,16 +4,13 @@
 //
 
 #include <MaterialXGenMdl/Nodes/SurfaceNodeMdl.h>
+
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 
 #include <MaterialXGenShader/GenContext.h>
 
 namespace MaterialX
 {
-
-SurfaceNodeMdl::SurfaceNodeMdl()
-{
-}
 
 ShaderNodeImplPtr SurfaceNodeMdl::create()
 {

--- a/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.h
@@ -15,8 +15,6 @@ namespace MaterialX
 class SurfaceNodeMdl : public ShaderNodeImpl
 {
   public:
-    SurfaceNodeMdl();
-
     static ShaderNodeImplPtr create();
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -408,7 +408,7 @@ void ShaderNode::initialize(const Node& node, const NodeDef& nodeDef, GenContext
 
     // Set element paths based on the node definition. Note that these
     // paths don't actually exist at time of shader generation since there
-    // are no inputs/parameters specified on the node itself
+    // are no inputs specified on the node itself
     //
     const string& nodePath = node.getNamePath();
     for (auto nodeInput : nodeDef.getActiveInputs())


### PR DESCRIPTION
- Remove references to parameter elements in documentation.
- Restore default name argument to InterfaceElement::addInput.
- Align conventions for MDL generation code.