### PR TITLE
Improvements to relative image paths

### DIFF
--- a/resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
-  <nodegraph name="NG_brass1" colorspace="srgb_texture" fileprefix="resources/Images/">
+  <nodegraph name="NG_brass1" colorspace="srgb_texture" fileprefix="../../../Images/">
     <tiledimage name="image_color" type="color3">
       <parameter name="file" type="filename" value="brass_color.jpg" />
       <input name="uvtiling" type="vector2" value="1.0, 1.0"/>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_wood_tiled.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_wood_tiled.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
-  <nodegraph name="NG_wood1" colorspace="srgb_texture" fileprefix="resources/Images/">
+  <nodegraph name="NG_wood1" colorspace="srgb_texture" fileprefix="../../../Images/">
     <tiledimage name="image_color" type="color3">
       <parameter name="file" type="filename" value="wood_color.jpg" />
       <input name="uvtiling" type="vector2" value="4.0, 4.0"/>

--- a/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_brass_tiled.mtlx
+++ b/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_brass_tiled.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
-  <nodegraph name="NG_brass1" colorspace="srgb_texture" fileprefix="resources/Images/">
+  <nodegraph name="NG_brass1" colorspace="srgb_texture" fileprefix="../../../Images/">
     <tiledimage name="image_color" type="color3">
       <parameter name="file" type="filename" value="brass_color.jpg" />
       <input name="uvtiling" type="vector2" value="4.0, 4.0"/>

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1254,11 +1254,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
     catch (std::exception& e)
     {
         new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to load material", e.what());
-        return;
     }
-
-    // Restore the original image search path.
-    _imageHandler->setSearchPath(_searchPath);
 
     // Update material UI.
     updateMaterialSelections();


### PR DESCRIPTION
- Fix an edge case for relative image paths with the "--material" option in the viewer.
- Update material examples to use relative image paths, making the resources folder relocatable.