### PR TITLE
Improvements to prefiltered environments

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -31,13 +31,17 @@ vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lodBias, sampler2D sa
 
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution, FresnelData fd)
 {
+    N = mx_forward_facing_normal(N, V);
     vec3 L = reflect(-V, N);
+
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
+    vec3 F = mx_compute_fresnel(NdotV, fd);
     float avgRoughness = mx_average_roughness(roughness);
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
+    vec3 Li = mx_latlong_map_lookup(L, $envMatrix, avgRoughness, $envRadiance);
 
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, fd.ior, fd.extinction);
-    return mx_latlong_map_lookup(L, $envMatrix, avgRoughness, $envRadiance) * dirAlbedo;
+    return Li * F * comp;
 }
 
 vec3 mx_environment_irradiance(vec3 N)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -799,27 +799,32 @@ void Viewer::createAdvancedSettings(Widget* parent)
         reloadShaders();
     });
 
-    if (_genContext.getOptions().hwSpecularEnvironmentMethod == mx::SPECULAR_ENVIRONMENT_FIS)
+    ng::CheckBox* importanceSampleBox = new ng::CheckBox(advancedPopup, "Environment FIS");
+    importanceSampleBox->setChecked(_genContext.getOptions().hwSpecularEnvironmentMethod == mx::SPECULAR_ENVIRONMENT_FIS);
+    importanceSampleBox->setCallback([this](bool enable)
     {
-        Widget* sampleGroup = new Widget(advancedPopup);
-        sampleGroup->setLayout(new ng::BoxLayout(ng::Orientation::Horizontal));
-        new ng::Label(sampleGroup, "Environment Samples:");
-        mx::StringVec sampleOptions;
-        _genContext.getOptions().hwMaxRadianceSamples = MAX_ENV_SAMPLES;
-        for (int i = MIN_ENV_SAMPLES; i <= MAX_ENV_SAMPLES; i *= 4)
-        {
-            mProcessEvents = false;
-            sampleOptions.push_back(std::to_string(i));
-            mProcessEvents = true;
-        }
-        ng::ComboBox* sampleBox = new ng::ComboBox(sampleGroup, sampleOptions);
-        sampleBox->setChevronIcon(-1);
-        sampleBox->setSelectedIndex((int)std::log2(_envSampleCount / MIN_ENV_SAMPLES) / 2);
-        sampleBox->setCallback([this](int index)
-        {
-            _envSampleCount = MIN_ENV_SAMPLES * (int) std::pow(4, index);
-        });
+        _genContext.getOptions().hwSpecularEnvironmentMethod = enable ? mx::SPECULAR_ENVIRONMENT_FIS : mx::SPECULAR_ENVIRONMENT_PREFILTER;
+        reloadShaders();
+    });
+
+    Widget* sampleGroup = new Widget(advancedPopup);
+    sampleGroup->setLayout(new ng::BoxLayout(ng::Orientation::Horizontal));
+    new ng::Label(sampleGroup, "Environment Samples:");
+    mx::StringVec sampleOptions;
+    _genContext.getOptions().hwMaxRadianceSamples = MAX_ENV_SAMPLES;
+    for (int i = MIN_ENV_SAMPLES; i <= MAX_ENV_SAMPLES; i *= 4)
+    {
+        mProcessEvents = false;
+        sampleOptions.push_back(std::to_string(i));
+        mProcessEvents = true;
     }
+    ng::ComboBox* sampleBox = new ng::ComboBox(sampleGroup, sampleOptions);
+    sampleBox->setChevronIcon(-1);
+    sampleBox->setSelectedIndex((int)std::log2(_envSampleCount / MIN_ENV_SAMPLES) / 2);
+    sampleBox->setCallback([this](int index)
+    {
+        _envSampleCount = MIN_ENV_SAMPLES * (int) std::pow(4, index);
+    });
 
     ng::Label* textureLabel = new ng::Label(advancedPopup, "Texture Baking Options (B)");
     textureLabel->setFontSize(20);


### PR DESCRIPTION
- Add a viewer option for switching between filtered importance sampling and prefiltered environments for specular lighting.
- Align the prefiltered environment path with Niklas's latest work on Fresnel model selection.