### PR TITLE
Update Python scripts for v1.38

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,9 +144,11 @@ jobs:
 
     - name: Python Tests
       run: |
-        python main.py
-        python genshader.py
-      working-directory: python/MaterialXTest
+        python MaterialXTest/main.py
+        python MaterialXTest/genshader.py
+        python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --verbose
+        python Scripts/mxdoc.py ../libraries/pbrlib/pbrlib_defs.mtlx
+      working-directory: python
 
     - name: Render Tests
       if: matrix.test_render == 'ON'

--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -87,26 +87,6 @@ ValueElement.getDefaultValue = _getDefaultValue
 # InterfaceElement
 #
 
-def _setParameterValue(self, name, value, typeString = ''):
-    """Set the typed value of a parameter by its name, creating a child element
-       to hold the parameter if needed."""
-    method = getattr(self.__class__, "_setParameterValue" + getTypeString(value))
-    return method(self, name, value, typeString)
-
-def _getParameterValue(self, name, target = ''):
-    """Return the typed value of a parameter by its name, taking both the
-       calling element and its declaration into account.  If the given
-       parameter is not found, then None is returned."""
-    value = self._getParameterValue(name, target)
-    return value.getData() if value else None
-
-def _getParameterValueString(self, name):
-    """(Deprecated) Return the value string of a parameter by its name.  If the
-       given parameter is not present, then an empty string is returned."""
-    warnings.warn("This function is deprecated; call InterfaceElement.getParameter() and Parameter.getValueString() instead.", DeprecationWarning, stacklevel = 2)
-    param = self.getParameter(name)
-    return param.getValueString() if param else ""
-
 def _setInputValue(self, name, value, typeString = ''):
     """Set the typed value of an input by its name, creating a child element
        to hold the input if needed."""
@@ -120,11 +100,37 @@ def _getInputValue(self, name, target = ''):
     value = self._getInputValue(name, target)
     return value.getData() if value else None
 
+def _getParameters(self):
+    """(Deprecated) Return a vector of all Parameter elements."""
+    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    return list()
+
+def _getActiveParameters(self):
+    """(Deprecated) Return a vector of all parameters belonging to this interface, taking inheritance into account."""
+    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    return list()
+
+def _setParameterValue(self, name, value, typeString = ''):
+    """(Deprecated) Set the typed value of a parameter by its name."""
+    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+
+def _getParameterValue(self, name, target = ''):
+    """(Deprecated) Return the typed value of a parameter by its name."""
+    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    return None
+
+def _getParameterValueString(self, name):
+    """(Deprecated) Return the value string of a parameter by its name."""
+    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    return ""
+
+InterfaceElement.setInputValue = _setInputValue
+InterfaceElement.getInputValue = _getInputValue
+InterfaceElement.getParameters = _getParameters
+InterfaceElement.getActiveParameters = _getActiveParameters
 InterfaceElement.setParameterValue = _setParameterValue
 InterfaceElement.getParameterValue = _getParameterValue
 InterfaceElement.getParameterValueString = _getParameterValueString
-InterfaceElement.setInputValue = _setInputValue
-InterfaceElement.getInputValue = _getInputValue
 
 
 #
@@ -197,12 +203,13 @@ def _applyStringSubstitutions(self, filename, geom = '/'):
     warnings.warn("This function is deprecated; call Element.createStringResolver() instead.", DeprecationWarning, stacklevel = 2)
     return self.createStringResolver(geom).resolve(filename, 'filename')
 
-def _generateRequireString(self):
-    """(Deprecated) Generate the require string for a document."""
-    warnings.warn("Require strings are no longer supported in MaterialX.", DeprecationWarning, stacklevel = 2)
+def _getMaterials(self):
+    """(Deprecated) Return a vector of all materials in the document."""
+    warnings.warn("This function is deprecated, call Document.getMaterialNodes() instead.", DeprecationWarning, stacklevel = 2)
+    return self.getMaterialNodes()
 
 Document.applyStringSubstitutions = _applyStringSubstitutions
-Document.generateRequireString = _generateRequireString
+Document.getMaterials = _getMaterials
 
 
 #

--- a/python/Scripts/baketextures.py
+++ b/python/Scripts/baketextures.py
@@ -18,14 +18,13 @@ def main():
     parser.add_argument("--average", dest="average", action="store_true", help="Average baked images to generate constant values.")
     parser.add_argument("--path", dest="paths", action='append', nargs='+', help="An additional absolute search path location (e.g. '/projects/MaterialX')")
     parser.add_argument("--library", dest="libraries", action='append', nargs='+', help="An additional relative path to a custom data library folder (e.g. 'libraries/custom')")
-    parser.add_argument(dest="input_filename", help="Filename of the input document.")
-    parser.add_argument(dest="output_filename", help="Filename of the output document.")
-
+    parser.add_argument(dest="inputFilename", help="Filename of the input document.")
+    parser.add_argument(dest="outputFilename", help="Filename of the output document.")
     opts = parser.parse_args()
 
     doc = mx.createDocument()
     try:
-        mx.readFromXmlFile(doc, opts.input_filename)
+        mx.readFromXmlFile(doc, opts.inputFilename)
     except mx.ExceptionFileMissing as err:
         print(err)
         sys.exit(0)
@@ -33,7 +32,7 @@ def main():
     stdlib = mx.createDocument()
     filePath = os.path.dirname(os.path.abspath(__file__))
     searchPath = mx.FileSearchPath(os.path.join(filePath, '..', '..'))
-    searchPath.append(os.path.dirname(opts.input_filename))
+    searchPath.append(os.path.dirname(opts.inputFilename))
     libraryFolders = [ "libraries" ]
     if opts.paths:
         for pathList in opts.paths:
@@ -55,7 +54,7 @@ def main():
     baker = mx_render_glsl.TextureBaker.create(opts.width, opts.height, baseType)
     if opts.average:
         baker.setAverageImages(True)
-    baker.bakeAllMaterials(doc, searchPath, opts.output_filename)
+    baker.bakeAllMaterials(doc, searchPath, opts.outputFilename)
 
 if __name__ == '__main__':
     main()

--- a/python/Scripts/mxdoc.py
+++ b/python/Scripts/mxdoc.py
@@ -1,92 +1,45 @@
 #!/usr/bin/env python
 '''
-Output documentation for nodedefs for a given MaterialX document.
+Print markdown documentation for each nodedef in the given document.
 '''
 
-import sys, os, string; os.environ["PYTHONIOENCODING"] = "utf-8"
+import sys, os, argparse
 import MaterialX as mx
 
-def usage():
-    print 'mxdoc.py: Output documentation for MaterialX nodedefs in Markdown format.'
-    print 'Usage:  mxdoc.py <file.mtlx> [<outputfile.md>]'
-    print '- Default output file name is "nodedef_documentation.md"'
-
 HEADERS = ('Name', 'Type', 'Default Value',
-           'UI min', 'UI max',
-           'UI Soft Min', 'UI Soft Max',
-           'UI step', 'UI group',
-           'Description', 'UI Advanced',
-           'Connectable')
+           'Uniform', 'UI min', 'UI max', 'UI Soft Min', 'UI Soft Max', 'UI step', 'UI group', 'UI Advanced')
 
-ATTR_NAMES = ('uimin', 'uimax',
-              'uisoftmin', 'uisoftmax',
-              'uistep', 'uifolder',
-              'doc', 'uiadvanced')
+ATTR_NAMES = ('uniform', 'uimin', 'uimax', 'uisoftmin', 'uisoftmax', 'uistep', 'uifolder', 'uiadvanced')
 
 def main():
-    if len(sys.argv) < 2:
-        usage()
-        sys.exit(0)
-
-    outfilename = 'nodedef_documentation.md'
-    if len(sys.argv) > 2:
-        outfilename = sys.argv[2]
-
-    filename = sys.argv[1]
+    parser = argparse.ArgumentParser(description="Print markdown documentation for each nodedef in the given document.")
+    parser.add_argument(dest="inputFilename", help="Filename of the input MaterialX document.")
+    opts = parser.parse_args()
 
     doc = mx.createDocument()
-
-    # The mx.readFromXmlFile() will fail with
-    #   'MaterialX.ExceptionFileMissing' if the file is not found, or
-    #   'MaterialX.ExceptionParseError' if the document is found but not readable.
     try:
-        mx.readFromXmlFile(doc, filename)
+        mx.readFromXmlFile(doc, opts.inputFilename)
     except mx.ExceptionFileMissing as err:
-        print err
-        return
-    except mx.ExceptionParseError as err:
-        print '%s is not a valid MaterialX file.\n%s' % (filename, err)
-        return
+        print(err)
+        sys.exit(0)
 
-    file = open(outfilename, 'w+')
-
-    nodedefs = doc.getNodeDefs()
-
-    for nd in nodedefs:
-        file.write('- *Nodedef*: %s\n' % nd.getName())
-        file.write('- *Type*: %s\n' % nd.getType())
-        file.write('- *Doc*: %s\n\n' % nd.getAttribute('doc'))
-        file.write('| ' + ' | '.join(HEADERS) + ' |\n')
-        file.write('|' + ' ---- |' * len(HEADERS) + '\n')
+    for nd in doc.getNodeDefs():
+        print('- *Nodedef*: %s' % nd.getName())
+        print('- *Type*: %s' % nd.getType())
+        print('- *Doc*: %s\n' % nd.getAttribute('doc'))
+        print('| ' + ' | '.join(HEADERS) + ' |')
+        print('|' + ' ---- |' * len(HEADERS) + '')
         for inp in nd.getInputs():
             infos = []
             infos.append(inp.getName())
             infos.append(inp.getType())
             val = inp.getValue()
-            if infos[1] == "float":
+            if inp.getType() == "float":
                 val = round(val, 6)
             infos.append(str(val))
             for attrname in ATTR_NAMES:
                 infos.append(inp.getAttribute(attrname))
-            infos.append("true")
-            buf = '| ' + " | ".join(infos) + ' |\n'
-            file.write(buf)
-        for p in nd.getParameters():
-            infos = []
-            infos.append(p.getName())
-            infos.append(p.getType())
-            val = p.getValue()
-            if infos[1] == "float":
-                val = round(val, 6)
-            infos.append(str(val))
-            for attrname in ATTR_NAMES:
-                infos.append(p.getAttribute(attrname))
-            infos.append("false")
-            buf = '| ' + " | ".join(infos) + ' |\n'
-            file.write(buf)
-
-    file.close()
+            print('| ' + " | ".join(infos) + ' |')
 
 if __name__ == '__main__':
     main()
-

--- a/python/Scripts/mxvalidate.py
+++ b/python/Scripts/mxvalidate.py
@@ -1,141 +1,81 @@
 #!/usr/bin/env python
 '''
-Verify that a specified file is a valid MaterialX document.
+Verify that the given file is a valid MaterialX document.
 '''
 
-import sys
-import os
-import string
+import sys, os, argparse
 import MaterialX as mx
 
-
-def usage():
-    print("mxvalidate.py: verify that a specified file is a valid MaterialX document.")
-    print("Usage:  mxvalidate.py [options] <file.mtlx>")
-    print("    -h[elp]         Print usage information")
-    print("    -v[erbose]      Print summary of elements found in the document")
-    print(
-        "    -vv[eryverbose] Also print material bindings, nodedef interfaces and nodegraph trees")
-    print("    -i[ncludedefs]  Automatically XInclude stdlib_defs")
-    print("    -r[esolve]      Resolve inheritance and string substitutions")
-
-
 def main():
-    verbose = 0
-    incldefs = 0
-    resolve = 0
-
-    if len(sys.argv) < 2:
-        usage()
-        sys.exit(0)
-    for arg in sys.argv[1:]:
-        if arg in ['-v', '-verbose']:
-            verbose = 1
-        elif arg in ['-vv', '-veryverbose']:
-            verbose = 2
-        elif arg in ['-i', '-includedefs']:
-            incldefs = 1
-        elif arg in ['-r', '-resolve']:
-            resolve = 1
-        elif arg in ['-h', '-help', '--help']:
-            usage()
-            sys.exit(0)
-        else:
-            filename = arg
+    parser = argparse.ArgumentParser(description="Verify that the given file is a valid MaterialX document.")
+    parser.add_argument("--resolve", dest="resolve", action="store_true", help="Resolve inheritance and string substitutions.")
+    parser.add_argument("--verbose", dest="verbose", action="store_true", help="Print summary of elements found in the document.")
+    parser.add_argument("--stdlib", dest="stdlib", action="store_true", help="Import standard MaterialX libraries into the document.")
+    parser.add_argument(dest="inputFilename", help="Filename of the input document.")
+    opts = parser.parse_args()
 
     doc = mx.createDocument()
-    mxversion = mx.getVersionString()
-    (mxmajorv, mxminorv, mxbuildv) = mx.getVersionIntegers()
-
-    # The mx.readFromXmlFile() will fail with
-    #   "MaterialX.ExceptionFileMissing" if the file is not found, or
-    #   "MaterialX.ExceptionParseError" if the document is found but not readable.
     try:
-        mx.readFromXmlFile(doc, filename)
+        mx.readFromXmlFile(doc, opts.inputFilename)
     except mx.ExceptionFileMissing as err:
-        # TODO: library doesn't correctly set missing filename if it's an XIncluded file (it's blank)
-        print (err)
-        return
-    except mx.ExceptionParseError as err:
-        print ("%s is not a valid XML file.\n%s" % (filename, err))
-        return
+        print(err)
+        sys.exit(0)
 
-    if incldefs:
-        incldoc = mx.createDocument()
-        try:
-            mx.readFromXmlFile(incldoc, "stdlib_defs.mtlx")
-            print ("Loaded stdlib_defs.mtlx")
-            doc.importLibrary(incldoc)
-        except mx.ExceptionFileMissing:
-            try:
-                mx.readFromXmlFile(incldoc, "stdlib/stdlib_defs.mtlx")
-                print ("Loaded stdlib/stdlib_defs.mtlx")
-                doc.importLibrary(incldoc)
-            except mx.ExceptionFileMissing:
-                mxspath = os.getenv('MATERIALX_SEARCH_PATH')
-                print ('Unable to find stdlib_defs.mtlx in current MATERIALX_SEARCH_PATH "%s"' % mxspath)
+    if opts.stdlib:
+        stdlib = mx.createDocument()
+        filePath = os.path.dirname(os.path.abspath(__file__))
+        searchPath = mx.FileSearchPath(os.path.join(filePath, '..', '..'))
+        searchPath.append(os.path.dirname(opts.inputFilename))
+        libraryFolders = [ "libraries" ]
+        mx.loadLibraries(libraryFolders, searchPath, stdlib)
+        doc.importLibrary(stdlib)
 
-    rc = doc.validate()
-    if (len(rc) >= 1 and rc[0]):
-        print ("%s is a valid MaterialX %s document." % (filename, mxversion))
+    (valid, message) = doc.validate()
+    if (valid):
+        print("%s is a valid MaterialX document in v%s" % (opts.inputFilename, mx.getVersionString()))
     else:
-        print ("%s is not a valid MaterialX %s document:" % (filename, mxversion))
-        print (rc[1])
+        print("%s is not a valid MaterialX document in v%s" % (opts.inputFilename, mx.getVersionString()))
+        print(message)
 
-    if verbose:
+    if opts.verbose:
         nodegraphs = doc.getNodeGraphs()
-        materials = doc.getMaterials()
+        materials = doc.getMaterialNodes()
         looks = doc.getLooks()
         lookgroups = doc.getLookGroups()
         collections = doc.getCollections()
         nodedefs = doc.getNodeDefs()
         implementations = doc.getImplementations()
         geominfos = doc.getGeomInfos()
-        # geompropdef was introduced in v1.36.3 codebase
-        if mxminorv >= 37 or (mxminorv == 36 and mxbuildv >= 3):
-            geompropdefs = doc.getGeomPropDefs()
-        else:
-            geompropdefs = []
+        geompropdefs = doc.getGeomPropDefs()
         typedefs = doc.getTypeDefs()
         propsets = doc.getPropertySets()
         variantsets = doc.getVariantSets()
         backdrops = doc.getBackdrops()
-        vv = (verbose > 1)
 
-        print ("Document MaterialX Version: {}.{:02d}".format(*doc.getVersionIntegers()))
-        clrmgmtsys = doc.getColorManagementSystem() or "undefined"
-        clrmgmtconfig = doc.getColorManagementConfig() or "undefined"
-        print ("Document CMS: %s  (config file: %s)" % (clrmgmtsys, clrmgmtconfig))
+        print("----------------------------------")
+        print("Document Version: {}.{:02d}".format(*doc.getVersionIntegers()))
+        print("%4d Custom Type%s%s" % (len(typedefs), pl(typedefs), listContents(typedefs, opts.resolve)))
+        print("%4d Custom GeomProp%s%s" % (len(geompropdefs), pl(geompropdefs), listContents(geompropdefs, opts.resolve)))
+        print("%4d NodeDef%s%s" % (len(nodedefs), pl(nodedefs), listContents(nodedefs, opts.resolve)))
+        print("%4d Implementation%s%s" % (len(implementations), pl(implementations), listContents(implementations, opts.resolve)))
+        print("%4d Nodegraph%s%s" % (len(nodegraphs), pl(nodegraphs), listContents(nodegraphs, opts.resolve)))
+        print("%4d VariantSet%s%s" % (len(variantsets), pl(variantsets), listContents(variantsets, opts.resolve)))
+        print("%4d Material%s%s" % (len(materials), pl(materials), listContents(materials, opts.resolve)))
+        print("%4d Collection%s%s" % (len(collections), pl(collections), listContents(collections, opts.resolve)))
+        print("%4d GeomInfo%s%s" % (len(geominfos), pl(geominfos), listContents(geominfos, opts.resolve)))
+        print("%4d PropertySet%s%s" % (len(propsets), pl(propsets), listContents(propsets, opts.resolve)))
+        print("%4d Look%s%s" % (len(looks), pl(looks), listContents(looks, opts.resolve)))
+        print("%4d LookGroup%s%s" % (len(lookgroups), pl(lookgroups), listContents(lookgroups, opts.resolve)))
+        print("%4d Top-level backdrop%s%s" % (len(backdrops), pl(backdrops), listContents(backdrops, opts.resolve)))
+        print("----------------------------------")
 
-        print ("%4d Custom Type%s%s" % (len(typedefs), pl(typedefs), listContents(typedefs, resolve, vv)))
-        print ("%4d Custom GeomProp%s%s" % (len(geompropdefs), pl(geompropdefs), listContents(geompropdefs, resolve, vv)))
-        print ("%4d NodeDef%s%s" % (len(nodedefs), pl(nodedefs), listContents(nodedefs, resolve, vv)))
-        print ("%4d Implementation%s%s" % (len(implementations), pl(implementations), listContents(implementations, resolve, vv)))
-        print ("%4d Nodegraph%s%s" % (len(nodegraphs), pl(nodegraphs), listContents(nodegraphs, resolve, vv)))
-        print ("%4d VariantSet%s%s" % (len(variantsets), pl(variantsets), listContents(variantsets, resolve, vv)))
-        print ("%4d Material%s%s" % (len(materials), pl(materials), listContents(materials, resolve, vv)))
-        print ("%4d Collection%s%s" % (len(collections), pl(collections), listContents(collections, resolve, vv)))
-        print ("%4d GeomInfo%s%s" % (len(geominfos), pl(geominfos), listContents(geominfos, resolve, vv)))
-        print ("%4d PropertySet%s%s" % (len(propsets), pl(propsets), listContents(propsets, resolve, vv)))
-        print ("%4d Look%s%s" % (len(looks), pl(looks), listContents(looks, resolve, vv)))
-        print ("%4d LookGroup%s%s" % (len(lookgroups), pl(lookgroups), listContents(lookgroups, resolve, vv)))
-        print ("%4d Top-level backdrop%s%s" % (len(backdrops), pl(backdrops), listContents(backdrops, resolve, vv)))
-
-
-def pl(elem):
-    if len(elem) == 1:
-        return ""
-    else:
-        return "s"
-
-
-def listContents(elemlist, resolve, vv):
+def listContents(elemlist, resolve):
     if len(elemlist) == 0:
         return ''
     names = []
     for elem in elemlist:
 
-        if elem.getCategory() == "nodedef":
+        if elem.isA(mx.NodeDef):
             outtype = elem.getType()
             outs = ""
             if outtype == "multioutput":
@@ -144,19 +84,15 @@ def listContents(elemlist, resolve, vv):
                         '\n\t    %s output "%s"' % (ot.getType(), ot.getName())
             names.append('%s %s "%s"%s' %
                          (outtype, elem.getNodeString(), elem.getName(), outs))
-            if vv:
-                names.append(listNodedefInterface(elem))
+            names.append(listNodedefInterface(elem))
 
-        elif elem.getCategory() == "implementation":
-            impl = '%s for nodedef %s' % (
-                elem.getName(), elem.getNodeDef().getName())
+        elif elem.isA(mx.Implementation):
+            impl = elem.getName()
             targs = []
             if elem.hasTarget():
                 targs.append("target %s" % elem.getTarget())
-            if elem.hasLanguage():
-                targs.append("language %s" % elem.getLanguage())
             if targs:
-                impl = "%s (%s)" % (impl, string.join(targs, ", "))
+                impl = "%s (%s)" % (impl, ", ".join(targs))
             if elem.hasFunction():
                 if elem.hasFile():
                     impl = "%s [%s:%s()]" % (
@@ -167,11 +103,11 @@ def listContents(elemlist, resolve, vv):
                 impl = "%s [%s]" % (impl, elem.getFile())
             names.append(impl)
 
-        elif elem.getCategory() == "backdrop":
+        elif elem.isA(mx.Backdrop):
             names.append('%s: contains "%s"' %
                          (elem.getName(), elem.getContainsString()))
 
-        elif elem.getCategory() == "nodegraph":
+        elif elem.isA(mx.NodeGraph):
             nchildnodes = len(elem.getChildren()) - elem.getOutputCount()
             backdrops = elem.getBackdrops()
             nbackdrops = len(backdrops)
@@ -179,14 +115,11 @@ def listContents(elemlist, resolve, vv):
             if nbackdrops > 0:
                 for bd in backdrops:
                     outs = outs + '\n\t    backdrop "%s"' % (bd.getName())
-                    if vv:
-                        outs = outs + ' contains "%s"' % bd.getContainsString()
+                    outs = outs + ' contains "%s"' % bd.getContainsString()
             if elem.getOutputCount() > 0:
                 for ot in elem.getOutputs():
-                    outs = outs + \
-                        '\n\t    %s output "%s"' % (ot.getType(), ot.getName())
-                    if vv:
-                        outs = outs + traverseInputs(ot, "", 0)
+                    outs = outs + '\n\t    %s output "%s"' % (ot.getType(), ot.getName())
+                    outs = outs + traverseInputs(ot, "", 0)
             nd = elem.getNodeDef()
             if nd:
                 names.append('%s (implementation for nodedef "%s"): %d nodes%s' % (
@@ -195,103 +128,48 @@ def listContents(elemlist, resolve, vv):
                 names.append("%s: %d nodes, %d backdrop%s%s" % (
                     elem.getName(), nchildnodes, nbackdrops, pl(backdrops), outs))
 
-        elif elem.getCategory() == "material":
-            shaders = []
-            if resolve:
-                srefs = elem.getActiveShaderRefs()
+        elif elem.isA(mx.GeomInfo):
+            props = elem.getGeomProps()
+            if props:
+                propnames = " (Geomprops: " + ", ".join(map(
+                            lambda x: "%s=%s" % (x.getName(), getConvertedValue(x)), props)) + ")"
             else:
-                srefs = elem.getShaderRefs()
-            vvitems = []
-            for sref in srefs:
-                if sref.hasNodeDefString():
-                    nodedefname = sref.getNodeDefString()
-                    # Get nodedef with this name
-                    nd = sref.getDocument().getNodeDef(nodedefname)
-                    if nd:
-                        nodetype = nd.getType()
-                    else:
-                        nodetype = "<unknown>"
-                    shaders.append('%s %s(ND) "%s"' % (
-                        nodetype, nd.getNodeString(), sref.getName()))
-                    if vv:
-                        vvitems.append((nodetype, nd.getNodeString(), sref))
-                        shaders.append(listSrefBindings(
-                            nodetype, nd.getNodeString(), sref))
-                elif sref.hasNodeString():
-                    node = sref.getNodeString()
-                    # Get list of nodedefs for this (shader) node
-                    nds = sref.getDocument().getMatchingNodeDefs(node)
-                    if nds:
-                        nodetype = nds[0].getType()
-                    else:
-                        nodetype = "<unknown>"
-                    shaders.append('%s %s "%s"' %
-                                   (nodetype, node, sref.getName()))
-                    if vv:
-                        vvitems.append((nodetype, node, sref))
-                else:
-                    shaders.append("unknown %s" % (sref.getName()))
-            shnames = '(' + string.join(shaders, ", ") + ')'
-            names.append("%s %s" % (elem.getName(), shnames))
-            if vv:
-                for i in vvitems:
-                    names.append(listSrefBindings(i[0], i[1], i[2]))
+                propnames = ""
 
-        elif elem.getCategory() == "geominfo":
-            # For 1.37, geomattr->geomprop
-            (mxmajorv, mxminorv, mxbuildv) = mx.getVersionIntegers()
-            if (mxminorv <= 36):
-                props = elem.getGeomAttrs()
-                if props:
-                    propnames = " (Geomattrs: " + \
-                        string.join(
-                            map(lambda x: x.getName(), props), ", ") + ")"
-                else:
-                    propnames = ""
-            else:
-                props = elem.getGeomProps()
-                if props:
-                    # getConvertedValue() handles unit conversion if needed
-                    propnames = " (Geomprops: " + string.join(map(lambda x: "%s=%s" %
-                                                                  (x.getName(), getConvertedValue(x)), props), ", ") + ")"
-                    #propnames = " (Geomprops: " + string.join(map(lambda x: "%s=%s"%(x.getName(),x.getResolvedValue().toValueString()), props), ", ") + ")"
-                else:
-                    propnames = ""
             tokens = elem.getTokens()
             if tokens:
-                #tokennames = " (Tokens: " + string.join(map(lambda x: x.getName(), tokens), ", ") + ")"
-                tokennames = " (Tokens: " + string.join(map(lambda x: "%s=%s" %
-                                                            (x.getName(), x.getValueString()), tokens), ", ") + ")"
+                tokennames = " (Tokens: " + ", ".join(map(
+                             lambda x: "%s=%s" % (x.getName(), x.getValueString()), tokens)) + ")"
             else:
                 tokennames = ""
             names.append("%s%s%s" % (elem.getName(), propnames, tokennames))
 
-        elif elem.getCategory() == "variantset":
+        elif elem.isA(mx.VariantSet):
             vars = elem.getVariants()
             if vars:
-                varnames = " (variants " + string.join(map(lambda x: '"' +
-                                                           x.getName()+'"', vars), ", ") + ")"
+                varnames = " (variants " + ", ".join(map(
+                           lambda x: '"' + x.getName()+'"', vars)) + ")"
             else:
                 varnames = ""
             names.append("%s%s" % (elem.getName(), varnames))
 
-        elif elem.getCategory() == "propertyset":
+        elif elem.isA(mx.PropertySet):
             props = elem.getProperties()
             if props:
-                propnames = " (" + string.join(map(lambda x: "%s %s%s" %
-                                                   (x.getType(), x.getName(), getTarget(x)), props), ", ") + ")"
+                propnames = " (" + ", ".join(map(
+                           lambda x: "%s %s%s" % (x.getType(), x.getName(), getTarget(x)), props)) + ")"
             else:
                 propnames = ""
             names.append("%s%s" % (elem.getName(), propnames))
 
-        elif elem.getCategory() == "lookgroup":
+        elif elem.isA(mx.LookGroup):
             lks = elem.getLooks()
             if lks:
                 names.append("%s (looks: %s)" % (elem.getName(), lks))
             else:
                 names.append("%s (no looks)" % (elem.getName()))
 
-        elif elem.getCategory() == "look":
+        elif elem.isA(mx.Look):
             mas = ""
             if resolve:
                 mtlassns = elem.getActiveMaterialAssigns()
@@ -344,40 +222,7 @@ def listContents(elemlist, resolve, vv):
 
         else:
             names.append(elem.getName())
-    return ":\n\t" + string.join(names, "\n\t")
-
-
-def listSrefBindings(nodetype, node, sref):
-    s = '  Bindings for %s "%s":' % (nodetype, node)
-    for inp in sref.getBindInputs():
-        bname = inp.getName()
-        btype = inp.getType()
-        if inp.hasOutputString():
-            outname = inp.getOutputString()
-            if inp.hasNodeGraphString():
-                ngname = inp.getNodeGraphString()
-                s = s + \
-                    '\n\t    %s input "%s" -> nodegraph "%s" output "%s"' % (
-                        btype, bname, ngname, outname)
-            else:
-                s = s + \
-                    '\n\t    %s input "%s" -> output "%s"' % (
-                        btype, bname, outname)
-        else:
-            bval = getConvertedValue(inp)
-            s = s + '\n\t    %s input "%s" = %s' % (btype, bname, bval)
-    for parm in sref.getBindParams():
-        bname = parm.getName()
-        btype = parm.getType()
-        bval = getConvertedValue(parm)
-        s = s + '\n\t    %s parameter "%s" = %s' % (btype, bname, bval)
-    for tok in sref.getBindTokens():
-        bname = tok.getName()
-        btype = tok.getType()
-        bval = tok.getValueString()
-        s = s + '\n\t    %s token "%s" = %s' % (btype, bname, bval)
-    return s
-
+    return ":\n\t" + "\n\t".join(names)
 
 def listNodedefInterface(nodedef):
     s = ''
@@ -387,12 +232,6 @@ def listNodedefInterface(nodedef):
         if s:
             s = s + '\n\t'
         s = s + '    %s input "%s"' % (itype, iname)
-    for parm in nodedef.getActiveParameters():
-        pname = parm.getName()
-        ptype = parm.getType()
-        if s:
-            s = s + '\n\t'
-        s = s + '    %s parameter "%s"' % (ptype, pname)
     for tok in nodedef.getActiveTokens():
         tname = tok.getName()
         ttype = tok.getType()
@@ -401,10 +240,9 @@ def listNodedefInterface(nodedef):
         s = s + '    %s token "%s"' % (ttype, tname)
     return s
 
-
 def traverseInputs(node, port, depth):
     s = ''
-    if node.getCategory() == "output":
+    if node.isA(mx.Output):
         parent = node.getConnectedNode()
         s = s + traverseInputs(parent, "", depth+1)
     else:
@@ -426,22 +264,6 @@ def traverseInputs(node, port, depth):
                 parent = i.getConnectedNode()
                 if parent:
                     s = s + traverseInputs(parent, i.getName(), depth+1)
-        parms = node.getActiveParameters()
-        for i in parms:
-            if i.hasInterfaceName():
-                intname = i.getInterfaceName()
-                s = s + \
-                    '%s[P]%s ^- %s interface "%s"' % (
-                        spc(depth+1), i.getName(), i.getType(), intname)
-            elif i.hasValueString():
-                val = getConvertedValue(i)
-                s = s + \
-                    '%s[P]%s = %s value %s' % (
-                        spc(depth+1), i.getName(), i.getType(), val)
-            else:
-                s = s + \
-                    '%s[P]%s error: no valueString' % (
-                        spc(depth+1), i.getName())
         toks = node.getActiveTokens()
         for i in toks:
             if i.hasInterfaceName():
@@ -460,13 +282,16 @@ def traverseInputs(node, port, depth):
                         spc(depth+1), i.getName())
     return s
 
+def pl(elem):
+    if len(elem) == 1:
+        return ""
+    else:
+        return "s"
 
 def spc(depth):
     return "\n\t    " + ": "*depth
 
 # Return a value string for the element, converting units if appropriate
-
-
 def getConvertedValue(elem):
     if elem.getType() in ["float", "vector2", "vector3", "vector4"]:
         if elem.hasUnit():
@@ -477,7 +302,6 @@ def getConvertedValue(elem):
                 print ("[Unittype for %s is %s]" % (elem.getName(), utype))
             # NOTDONE...
     return elem.getValueString()
-
 
 def getGeoms(elem, resolve):
     s = ""
@@ -490,7 +314,6 @@ def getGeoms(elem, resolve):
         s = s + ' collection "%s"' % elem.getCollectionString()
     return s
 
-
 def getViewerGeoms(elem):
     s = ""
     if elem.hasViewerGeom():
@@ -501,13 +324,11 @@ def getViewerGeoms(elem):
         s = " of" + s
     return s
 
-
 def getTarget(elem):
     if elem.hasTarget():
         return ' [target "%s"]' % elem.getTarget()
     else:
         return ""
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Add mxdoc.py and mxvalidate.py to cloud-based tests.
- Add deprecation warnings for v1.37 Python methods in v1.38, using the original versions of mxdoc.py and mxvalidate.py for testing.
- Update mxdoc.py and mxvalidate.py for v1.38, simplifying and aligning the Python code with more recent MaterialX scripts.