### PR TITLE
Improvements to specular environment rendering

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -15,13 +15,6 @@ float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamp
     return max(effectiveMaxMipLevel - 0.5 * log2(envSamples * pdf * distortion), 0.0);
 }
 
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
-{
-    vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
-    vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(sampler, uv, lod).rgb;
-}
-
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution, FresnelData fd)
 {
     vec3 Y = normalize(cross(N, X));

--- a/libraries/pbrlib/genglsl/lib/mx_math.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_math.glsl
@@ -63,6 +63,13 @@ vec2 mx_latlong_projection(vec3 dir)
     return vec2(longitude, latitude);
 }
 
+vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
+{
+    vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
+    vec2 uv = mx_latlong_projection(envDir);
+    return textureLod(sampler, uv, lod).rgb;
+}
+
 vec3 mx_forward_facing_normal(vec3 N, vec3 V)
 {
     if (dot(N, V) < 0.0)

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -329,14 +329,11 @@ void Material::bindLights(const mx::GenContext& genContext, mx::LightHandlerPtr 
                 }
 
                 // Bind any associated uniforms.
-                if (genContext.getOptions().hwSpecularEnvironmentMethod == mx::SPECULAR_ENVIRONMENT_FIS)
+                if (uniform == mx::HW::ENV_RADIANCE)
                 {
-                    if (uniform == mx::HW::ENV_RADIANCE)
+                    if (_glProgram->hasUniform(mx::HW::ENV_RADIANCE_MIPS))
                     {
-                        if (_glProgram->hasUniform(mx::HW::ENV_RADIANCE_MIPS))
-                        {
-                            _glProgram->bindUniform(mx::HW::ENV_RADIANCE_MIPS, mx::Value::createValue((int) image->getMaxMipCount()));
-                        }
+                        _glProgram->bindUniform(mx::HW::ENV_RADIANCE_MIPS, mx::Value::createValue((int) image->getMaxMipCount()));
                     }
                 }
             }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1257,6 +1257,14 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
             }
         }
     }
+    catch (mx::ExceptionShaderRenderError& e)
+    {
+        for (const std::string& error : e.errorLog())
+        {
+            std::cerr << error << std::endl;
+        }
+        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Shader generation error", e.what());
+    }
     catch (std::exception& e)
     {
         new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to load material", e.what());
@@ -1278,11 +1286,22 @@ void Viewer::reloadShaders()
         {
             material->generateShader(_genContext);
         }
+        return;
+    }
+    catch (mx::ExceptionShaderRenderError& e)
+    {
+        for (const std::string& error : e.errorLog())
+        {
+            std::cerr << error << std::endl;
+        }
+        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Shader generation error", e.what());
     }
     catch (std::exception& e)
     {
-        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Shader Generation Error", e.what());
+        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to reload shaders", e.what());
     }
+
+    _materials.clear();
 }
 
 void Viewer::saveShaderSource(mx::GenContext& context)


### PR DESCRIPTION
- Add a missing geometric term to the prefiltered environment path.
- Improve sharing and alignment between environment rendering paths.
- Display shader generation errors in the console when compiling viewer materials.