### PR TITLE
Fix for UDIM texture baking

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -459,14 +459,14 @@ BakedDocumentVec TextureBaker::createBakeDocuments(DocumentPtr doc, const FileSe
             imageHandler->setFilenameResolver(resolver);
             setImageHandler(imageHandler);
             bakeShaderInputs(materialNode, shaderNode, genContext, tag);
-
-            // Optimize baked textures.
-            optimizeBakedTextures(shaderNode);
-
-            // Write the baked material and textures.
-            DocumentPtr bakedMaterialDoc = bakeMaterial(shaderNode, udimSet);
-            bakedDocuments.push_back(std::make_pair(shaderNode->getName(), bakedMaterialDoc));
         }
+
+        // Optimize baked textures.
+        optimizeBakedTextures(shaderNode);
+
+        // Write the baked material and textures.
+        DocumentPtr bakedMaterialDoc = bakeMaterial(shaderNode, udimSet);
+        bakedDocuments.push_back(std::make_pair(shaderNode->getName(), bakedMaterialDoc));
     }
 
     return bakedDocuments;


### PR DESCRIPTION
Material optimization must occur after all UDIMs have been baked, so that the detection of uniform outputs takes all UDIMs into account.