### PR TITLE
Miscellaneous fixes from production testing

### DIFF
--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -63,11 +63,7 @@ const TypeDesc* TypeDesc::get(const string& name)
 {
     const TypeDescMap& map = typeMap();
     auto it = map.find(name);
-    if (it == map.end())
-    {
-        throw Exception("No registered type with name '" + name + "' could be found");
-    }
-    return it->second.get();
+    return it != map.end() ? it->second.get() : nullptr;
 }
 
 namespace Type

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -59,7 +59,7 @@ class TypeDesc
                                         size_t size = 1, bool editable = true, const ChannelMap& channelMapping = ChannelMap());
 
     /// Get a type descriptor for given name.
-    /// Throws an exception if no type with that name is found.
+    /// Returns an empty shared pointer if no type with the given name is found.
     static const TypeDesc* get(const string& name);
 
     /// Return the name of the type.

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -137,23 +137,23 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool)
         }
     }
 
-    if (!filePath.isEmpty())
+    if (!foundFilePath.isEmpty())
     {
         if (!foundFilePath.exists())
         {
-            std::cerr << string("Image file not found: ") + filePath.asString() << std::endl;
+            std::cerr << string("Image file not found: ") + foundFilePath.asString() << std::endl;
         }
         else if (!extensionSupported)
         {
-            std::cerr << string("Unsupported image extension: ") + filePath.asString() << std::endl;
+            std::cerr << string("Unsupported image extension: ") + foundFilePath.asString() << std::endl;
         }
         else
         {
-            std::cerr << string("Image loader failed to parse image: ") + filePath.asString() << std::endl;
+            std::cerr << string("Image loader failed to parse image: ") + foundFilePath.asString() << std::endl;
         }
     }
 
-    cacheImage(filePath, _invalidImage);
+    cacheImage(foundFilePath, _invalidImage);
     return _invalidImage;
 }
 

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -81,13 +81,13 @@ TEST_CASE("GenShader: TypeDesc Check", "[genshader]")
     REQUIRE(color4Type->getSemantic() == mx::TypeDesc::SEMANTIC_COLOR);
     REQUIRE(color4Type->isFloat4());
 
-    // Make sure we can register a new sutom type
+    // Make sure we can register a new custom type
     const mx::TypeDesc* fooType = mx::TypeDesc::registerType("foo", mx::TypeDesc::BASETYPE_FLOAT, mx::TypeDesc::SEMANTIC_COLOR, 5);
     REQUIRE(fooType != nullptr);
 
-    // Make sure we can't use a name already take
+    // Make sure we can't use a name that is already taken
     REQUIRE_THROWS(mx::TypeDesc::registerType("color3", mx::TypeDesc::BASETYPE_FLOAT));
 
     // Make sure we can't request an unknown type
-    REQUIRE_THROWS(mx::TypeDesc::get("bar"));
+    REQUIRE(mx::TypeDesc::get("bar") == nullptr);
 }

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -74,16 +74,16 @@ class Material
         _elem = val;
     }
 
-    /// Return the material element associated with this material
-    mx::TypedElementPtr getMaterialElement() const
+    /// Return the material node associated with this material
+    mx::NodePtr getMaterialNode() const
     {
-        return _material;
+        return _materialNode;
     }
 
-    /// Set the material element associated with this material
-    void setMaterialElement(mx::TypedElementPtr val)
+    /// Set the material node associated with this material
+    void setMaterialNode(mx::NodePtr node)
     {
-        _material = val;
+        _materialNode = node;
     }
 
     /// Get any associated udim identifier
@@ -195,7 +195,7 @@ class Material
 
     mx::DocumentPtr _doc;
     mx::TypedElementPtr _elem;
-    mx::TypedElementPtr _material;
+    mx::NodePtr _materialNode;
 
     std::string _udim;
     bool _hasTransparency;


### PR DESCRIPTION
- Bind the active shader before setting uniforms for unit selection.  (Fixes an OpenGL error when changing units.)
- Only apply implicit UDIM assignments to material nodes, not to unbound graph outputs.  (Fixes UDIM assignments in documents with unbound graph outputs.)
- Cache resolved filenames when images fail to load.  (Fixes handling of a single bad UDIM within a sequence.)
- Return a nullptr rather than throwing an exception when a TypeDesc is not found.  (Fixes error messages during scanning for light nodes.)