### PR TITLE
Update example scripts for document writing

### DIFF
--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -100,29 +100,44 @@ def _getInputValue(self, name, target = ''):
     value = self._getInputValue(name, target)
     return value.getData() if value else None
 
+def _addParameter(self, name):
+    """(Deprecated) Add a Parameter to this interface."""
+    warnings.warn("This function is deprecated; parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    return self.addInput(name)
+
 def _getParameters(self):
     """(Deprecated) Return a vector of all Parameter elements."""
-    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    warnings.warn("This function is deprecated; parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
     return list()
 
 def _getActiveParameters(self):
     """(Deprecated) Return a vector of all parameters belonging to this interface, taking inheritance into account."""
-    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    warnings.warn("This function is deprecated; parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
     return list()
 
 def _setParameterValue(self, name, value, typeString = ''):
     """(Deprecated) Set the typed value of a parameter by its name."""
-    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    warnings.warn("This function is deprecated; parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
 
 def _getParameterValue(self, name, target = ''):
     """(Deprecated) Return the typed value of a parameter by its name."""
-    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    warnings.warn("This function is deprecated; parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
     return None
 
 def _getParameterValueString(self, name):
     """(Deprecated) Return the value string of a parameter by its name."""
-    warnings.warn("This function is deprecated, parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
+    warnings.warn("This function is deprecated; parameters have been replaced with uniform inputs in 1.38.", DeprecationWarning, stacklevel = 2)
     return ""
+
+def _addBindInput(self, name, type = DEFAULT_TYPE_STRING):
+    """(Deprecated) Add a BindInput to this shader reference."""
+    warnings.warn("This function is deprecated; shader references have been replaced with shader nodes in 1.38.", DeprecationWarning, stacklevel = 2)
+    return self.addInput(name, type)
+
+def _addBindParam(self, name, type = DEFAULT_TYPE_STRING):
+    """(Deprecated) Add a BindParam to this shader reference."""
+    warnings.warn("This function is deprecated; shader references have been replaced with shader nodes in 1.38.", DeprecationWarning, stacklevel = 2)
+    return self.addInput(name, type)
 
 InterfaceElement.setInputValue = _setInputValue
 InterfaceElement.getInputValue = _getInputValue
@@ -131,6 +146,8 @@ InterfaceElement.getActiveParameters = _getActiveParameters
 InterfaceElement.setParameterValue = _setParameterValue
 InterfaceElement.getParameterValue = _getParameterValue
 InterfaceElement.getParameterValueString = _getParameterValueString
+InterfaceElement.addBindInput = _addBindInput
+InterfaceElement.addBindParam = _addBindParam
 
 
 #
@@ -142,7 +159,13 @@ def _getReferencedNodeDef(self):
     warnings.warn("This function is deprecated; call Node.getNodeDef instead.", DeprecationWarning, stacklevel = 2)
     return self.getNodeDef()
 
+def _addShaderRef(self, name, nodeName):
+    "(Deprecated) Add a shader reference to this material element."
+    warnings.warn("This function is deprecated; material elements have been replaced with material nodes in 1.38.", DeprecationWarning, stacklevel = 2)
+    return self.getParent().addNode(nodeName, name)
+
 Node.getReferencedNodeDef = _getReferencedNodeDef
+Node.addShaderRef = _addShaderRef
 
 
 #
@@ -203,12 +226,18 @@ def _applyStringSubstitutions(self, filename, geom = '/'):
     warnings.warn("This function is deprecated; call Element.createStringResolver() instead.", DeprecationWarning, stacklevel = 2)
     return self.createStringResolver(geom).resolve(filename, 'filename')
 
+def _addMaterial(self, name):
+    """(Deprecated) Add a material element to the document."""
+    warnings.warn("This function is deprecated; call Document.addMaterialNode() instead.", DeprecationWarning, stacklevel = 2)
+    return self.addMaterialNode(name)
+
 def _getMaterials(self):
     """(Deprecated) Return a vector of all materials in the document."""
-    warnings.warn("This function is deprecated, call Document.getMaterialNodes() instead.", DeprecationWarning, stacklevel = 2)
+    warnings.warn("This function is deprecated; call Document.getMaterialNodes() instead.", DeprecationWarning, stacklevel = 2)
     return self.getMaterialNodes()
 
 Document.applyStringSubstitutions = _applyStringSubstitutions
+Document.addMaterial = _addMaterial
 Document.getMaterials = _getMaterials
 
 

--- a/python/Scripts/writelooks.py
+++ b/python/Scripts/writelooks.py
@@ -3,75 +3,54 @@
 Generate the "Looks.mtlx" example file programmatically.
 '''
 
-import sys, string
 import MaterialX as mx
 
-
 def main():
-
     doc = mx.createDocument()
 
     # Add document CMS/colorspace
     doc.setColorManagementSystem("ocio")
     doc.setColorSpace("lin_rec709")
 
-    # Add "SimpleSrf.mtlx" as a library, which will create an xi:include in the output file.
-    xi_doc = mx.createDocument()
-    inclfile = "SimpleSrf.mtlx"
-    try:
-	mx.readFromXmlFile(xi_doc, inclfile)
-	doc.importLibrary(xi_doc)
-    except mx.ExceptionFileMissing:
-	print 'Unable to find "%s" in current MATERIALX_SEARCH_PATH' % inclfile
+    # Prepend an XInclude reference for "SimpleSrf.mtlx".
+    mx.prependXInclude(doc, "SimpleSrf.mtlx")
 
     #
     # Materials
     #
-    mplastic1 = doc.addMaterial("Mplastic1")
-    sref = mplastic1.addShaderRef("sr_mp1", "simple_srf")
-    bin1 = sref.addBindInput("diffColor", "color3")
-    bin1.setValue(mx.Color3(0.134, 0.130, 0.125))
-    bin2 = sref.addBindInput("specColor", "color3")
-    bin2.setValue(mx.Color3(0.114, 0.114, 0.114))
-    bin3 = sref.addBindInput("specRoughness", "float")
-    bin3.setValue(0.38)
+    shader = doc.addNode("simple_srf", "sr_mp1")
+    shader.setInputValue("diffColor", mx.Color3(0.134, 0.130, 0.125))
+    shader.setInputValue("specColor", mx.Color3(0.114))
+    shader.setInputValue("specRoughness", 0.38)
+    mplastic1 = doc.addMaterialNode("Mplastic1", shader)
 
-    mplastic2 = doc.addMaterial("Mplastic2")
-    mplastic2.setInheritsFrom(mplastic1)
-    sref = mplastic2.addShaderRef("sr_mp2", "simple_srf")
-    bin1 = sref.addBindInput("diffColor", "color3")
-    bin1.setValue(mx.Color3(0.17, 0.26, 0.23))
-    bin2 = sref.addBindInput("specRoughness", "float")
-    bin2.setValue(0.24)
+    shader = doc.addNode("simple_srf", "sr_mp2")
+    shader.setInputValue("diffColor", mx.Color3(0.17, 0.26, 0.23))
+    shader.setInputValue("specRoughness", 0.24)
+    mplastic2 = doc.addMaterialNode("Mplastic2", shader)
 
-    mmetal1 = doc.addMaterial("Mmetal1")
-    sref = mmetal1.addShaderRef("sr_mm1", "simple_srf")
-    bin1 = sref.addBindInput("diffColor", "color3")
-    bin1.setValue(mx.Color3(0.001, 0.001, 0.001))
-    bin2 = sref.addBindInput("specColor", "color3")
-    bin2.setValue(mx.Color3(0.671, 0.676, 0.667))
-    bin3 = sref.addBindInput("specRoughness", "float")
-    bin3.setValue(0.005)
+    shader = doc.addNode("simple_srf", "sr_mm1")
+    shader.setInputValue("diffColor", mx.Color3(0.001))
+    shader.setInputValue("specColor", mx.Color3(0.671, 0.676, 0.667))
+    shader.setInputValue("specRoughness", 0.005)
+    mmetal1 = doc.addMaterialNode("Mmetal1", shader)
 
-    mmetal2 = doc.addMaterial("Mmetal2")
-    sref = mmetal2.addShaderRef("sr_mm2", "simple_srf")
-    bin1 = sref.addBindInput("diffColor", "color3")
-    bin1.setValue(mx.Color3(0.049, 0.043, 0.033))
-    bin2 = sref.addBindInput("specColor", "color3")
-    bin2.setValue(mx.Color3(0.115, 0.091, 0.064))
-    bin3 = sref.addBindInput("specRoughness", "float")
-    bin3.setValue(0.35)
+    shader = doc.addNode("simple_srf", "sr_mm2")
+    shader.setInputValue("diffColor", mx.Color3(0.049, 0.043, 0.033))
+    shader.setInputValue("specColor", mx.Color3(0.115, 0.091, 0.064))
+    shader.setInputValue("specRoughness", 0.35)
+    mmetal2 = doc.addMaterialNode("Mmetal2", shader)
 
     #
     # VariantSet
     #
     vset = doc.addVariantSet("varset")
     vardry = vset.addVariant("dry")
-    vardry.setParameterValue("wetgain", 0.0)
+    vardry.setInputValue("wetgain", 0.0)
     varwet = vset.addVariant("wet")
-    varwet.setParameterValue("wetgain", 1.0)
+    varwet.setInputValue("wetgain", 1.0)
     vardamp = vset.addVariant("damp")
-    vardamp.setParameterValue("wetgain", 0.2)
+    vardamp.setInputValue("wetgain", 0.2)
 
     #
     # Collections
@@ -89,15 +68,14 @@ def main():
     # Nodedef and lightshader material
     #
     nd_disklgt = doc.addNodeDef("ND_disk_lgt_light", "lightshader", "disk_lgt")
-    nd_disklgt.setParameterValue("emissionmap", "", "filename")
-    nd_disklgt.setParameterValue("gain", 2000.0)
-    mheadlight = doc.addMaterial("mheadlight")
-    sref = mheadlight.addShaderRef("lgtsr1", "disk_lgt")
-    bpar = sref.addBindParam("gain", "float")
-    bpar.setValue(500.0)
+    nd_disklgt.setInputValue("emissionmap", "", "filename")
+    nd_disklgt.setInputValue("gain", 2000.0)
+    shader = doc.addNode("disk_lgt", "lgtsr1")
+    shader.setInputValue("gain", 500.0)
+    mheadlight = doc.addMaterialNode("mheadlight", shader)
 
     #
-    # Propertyset
+    # PropertySet
     #
     propset = doc.addPropertySet("standard")
     p = propset.addProperty("displacementbound_sphere")
@@ -151,7 +129,7 @@ def main():
     va.setVisible(0)
 
     #
-    # Lookgroups
+    # LookGroups
     #
     lookgrp = doc.addLookGroup("testlooks")
     looks = "%s,%s" % (lookA.getName(), lookB.getName())
@@ -160,15 +138,13 @@ def main():
     # Validate the doc just to be sure
     rc = doc.validate()
     if (len(rc) >= 1 and rc[0]):
-	print "Mtlx document is valid."
+        print("Mtlx document is valid.")
     else:
-	print "Mtlx document is NOT valid: %s" % str(rc[1])
+        print("Mtlx document is NOT valid: %s" % str(rc[1]))
 
     outfile = "myLooks.mtlx"
     mx.writeToXmlFile(doc, outfile)
-    print "Wrote materials and looks and such to %s" % outfile
-
+    print("Wrote materials and looks and such to %s" % outfile)
 
 if __name__ == '__main__':
     main()
-

--- a/python/Scripts/writenodegraphs.py
+++ b/python/Scripts/writenodegraphs.py
@@ -3,12 +3,9 @@
 Generate the "NodeGraphs.mtlx" example file programmatically.
 '''
 
-import sys, string
 import MaterialX as mx
 
-
 def main():
-
     doc = mx.createDocument()
 
     #
@@ -18,13 +15,13 @@ def main():
     img1 = ng1.addNode("image", "img1", "color3")
     # Because filenames look like string types, it is necessary to explicitly declare
     # this parameter value as type "filename".
-    img1.setParameterValue("file", "layer1.tif", "filename")
+    img1.setInputValue("file", "layer1.tif", "filename")
 
     img2 = ng1.addNode("image", "img2", "color3")
-    img2.setParameterValue("file", "layer2.tif", "filename")
+    img2.setInputValue("file", "layer2.tif", "filename")
 
     img3 = ng1.addNode("image", "img3", "float")
-    img3.setParameterValue("file", "mask1.tif", "filename")
+    img3.setInputValue("file", "mask1.tif", "filename")
 
     n0 = ng1.addNode("mix", "n0", "color3")
     # To connect an input to another node, you must first add the input with the expected
@@ -50,20 +47,20 @@ def main():
     ng3 = doc.addNodeGraph("NG_example3")
 
     img1 = ng3.addNode("image", "img1", "color3")
-    img1.setParameterValue("file", "<diff_albedo>", "filename")
+    img1.setInputValue("file", "<diff_albedo>", "filename")
 
     img2 = ng3.addNode("image", "img2", "color3")
-    img2.setParameterValue("file", "<dirt_albedo>", "filename")
+    img2.setInputValue("file", "<dirt_albedo>", "filename")
 
     img3 = ng3.addNode("image", "img3", "float")
-    img3.setParameterValue("file", "<areamask>", "filename")
+    img3.setInputValue("file", "<areamask>", "filename")
 
     img4 = ng3.addNode("image", "img4", "float")
-    img4.setParameterValue("file", "<noisemask>", "filename")
+    img4.setInputValue("file", "<noisemask>", "filename")
 
     n5 = ng3.addNode("constant", "n5", "color3")
     # For colorN, vectorN or matrix types, use the appropriate mx Type constructor.
-    n5.setParameterValue("value", mx.Color3(0.8,1.0,1.3))
+    n5.setInputValue("value", mx.Color3(0.8,1.0,1.3))
 
     n6 = ng3.addNode("multiply", "n6", "color3")
     inp1 = n6.addInput("in1", "color3")
@@ -75,7 +72,7 @@ def main():
     inp = n7.addInput("in", "color3")
     inp.setConnectedNode(img2)
     n7.setInputValue("amount", 0.2)
-    n7.setParameterValue("pivot", 0.5)
+    n7.setInputValue("pivot", 0.5)
 
     n8 = ng3.addNode("mix", "n8", "color3")
     infg = n8.addInput("fg", "color3")
@@ -99,7 +96,7 @@ def main():
     n9 = ng3.addNode("noise2d", "n9", "color3")
     intx = n9.addInput("texcoord", "vector2")
     intx.setConnectedNode(m1)
-    n9.setParameterValue("amplitude", mx.Vector3(0.05,0.04,0.06))
+    n9.setInputValue("amplitude", mx.Vector3(0.05,0.04,0.06))
 
     n10 = ng3.addNode("inside", "n10", "color3")
     inmask = n10.addInput("mask", "float")
@@ -123,19 +120,18 @@ def main():
     # independently, not just the whole document.
     rc = ng1.validate()
     if (len(rc) >= 1 and rc[0]):
-	print "Nodegraph %s is valid." % ng1.getName()
+        print("Nodegraph %s is valid." % ng1.getName())
     else:
-	print "Nodegraph %s is NOT valid: %s" % (ng1.getName(), str(rc[1]))
+        print("Nodegraph %s is NOT valid: %s" % (ng1.getName(), str(rc[1])))
     rc = ng3.validate()
     if (len(rc) >= 1 and rc[0]):
-	print "Nodegraph %s is valid." % ng3.getName()
+        print("Nodegraph %s is valid." % ng3.getName())
     else:
-	print "Nodegraph %s is NOT valid: %s" % (ng3.getName(), str(rc[1]))
+        print("Nodegraph %s is NOT valid: %s" % (ng3.getName(), str(rc[1])))
 
     outfile = "myNodeGraphs.mtlx"
     mx.writeToXmlFile(doc, outfile)
-    print "Wrote nodegraphs to %s" % outfile
-
+    print("Wrote nodegraphs to %s" % outfile)
 
 if __name__ == '__main__':
     main()

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -331,7 +331,7 @@ void prependXInclude(DocumentPtr doc, const FilePath& filename)
 {
     if (!filename.isEmpty())
     {
-        ElementPtr elem = doc->addChildOfCategory("xinclude");
+        ElementPtr elem = doc->addNode("xinclude");
         elem->setSourceUri(filename.asString());
         doc->setChildIndex(elem->getName(), 0);
     }

--- a/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
@@ -35,7 +35,8 @@ void bindPyNode(py::module& mod)
         .def("getNodes", &mx::GraphElement::getNodes,
             py::arg("category") = mx::EMPTY_STRING)
         .def("removeNode", &mx::GraphElement::removeNode)
-        .def("addMaterialNode", &mx::GraphElement::addMaterialNode)
+        .def("addMaterialNode", &mx::GraphElement::addMaterialNode,
+            py::arg("name") = mx::EMPTY_STRING, py::arg("shaderNode") = nullptr)
         .def("getMaterialNodes", &mx::GraphElement::getMaterialNodes)
         .def("addBackdrop", &mx::GraphElement::addBackdrop,
             py::arg("name") = mx::EMPTY_STRING)


### PR DESCRIPTION
- Update writelooks.py and writenodegraphs.py to the latest Python API.
- Add default arguments to the Python wrapper for Document::addMaterialNode.
- Add deprecation warnings for legacy Python methods (addParameter, addBindInput, addBindParam, addShaderRef, addMaterial).