### PR TITLE
Python wrapper improvements

### DIFF
--- a/python/MaterialX/__init__.py
+++ b/python/MaterialX/__init__.py
@@ -5,3 +5,5 @@ try:
     from .legacy import *
 except ImportError:
     pass
+
+__version__ = getVersionString()

--- a/python/MaterialX/colorspace.py
+++ b/python/MaterialX/colorspace.py
@@ -1,13 +1,16 @@
+#!/usr/bin/env python
+'''
+Native Python wrappers for PyMaterialX and PyOpenColorIO, providing helper
+functions for transforming MaterialX colors between OpenColorIO color spaces.
+
+By default, the OpenColorIO configuration packaged with MaterialX Python will
+be used, but clients may instead pass their own custom configurations to these
+methods.
+'''
+
 import os
 
 from .PyMaterialXCore import *
-
-# Native Python wrappers for PyMaterialX and PyOpenColorIO, providing helper
-# functions for transforming MaterialX colors between OpenColorIO color spaces.
-#
-# By default, the OpenColorIO configuration packaged with MaterialX Python will
-# be used, but clients may instead pass their own custom configurations to these
-# methods.
 
 
 #--------------------------------------------------------------------------------
@@ -29,8 +32,6 @@ def getColorSpaces(cms = 'ocio', config = None):
 
     return [cs.getName() for cs in config.getColorSpaces()]
 
-
-#--------------------------------------------------------------------------------
 def transformColor(color, sourceColorSpace, destColorSpace, cms = 'ocio', config = None):
     """Given a MaterialX color and the names of two supported color spaces,
        transform the color from the source to the destination color space.
@@ -51,8 +52,6 @@ def transformColor(color, sourceColorSpace, destColorSpace, cms = 'ocio', config
 
     return newColor
 
-
-#--------------------------------------------------------------------------------
 def getDefaultOCIOConfig():
     """Return the default OCIO config packaged with this Python library.
        Raises ImportError if the PyOpenColorIO module cannot be imported."""

--- a/python/MaterialX/datatype.py
+++ b/python/MaterialX/datatype.py
@@ -1,8 +1,12 @@
+#!/usr/bin/env python
+'''
+Native Python helper functions for MaterialX data types.
+'''
+
 import sys
 
 from .PyMaterialXCore import *
 
-# Native Python helper functions for MaterialX data types.
 
 #--------------------------------------------------------------------------------
 _typeToName = { int         : 'integer',
@@ -45,8 +49,6 @@ def getTypeString(value):
         return 'stringarray'
     return None
 
-
-#--------------------------------------------------------------------------------
 def getValueString(value):
     """Return the MaterialX value string associated with the given Python value
        If the type of the given Python value is not recognized by MaterialX,
@@ -62,8 +64,6 @@ def getValueString(value):
     method = globals()['TypedValue_' + typeString].createValue
     return method(value).getValueString()
 
-
-#--------------------------------------------------------------------------------
 def createValueFromStrings(valueString, typeString):
     """Convert a MaterialX value and type strings to the corresponding
        Python value.  If the given conversion cannot be performed, then None
@@ -79,13 +79,10 @@ def createValueFromStrings(valueString, typeString):
     return valueObj.getData()
 
 
-#--------------------------------------------------------------------------------
 def isColorType(t):
     "Return True if the given type is a MaterialX color."
     return t in (Color3, Color4)
 
-
-#--------------------------------------------------------------------------------
 def isColorValue(value):
     "Return True if the given value is a MaterialX color."
     return isColorType(type(value))

--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -1,13 +1,14 @@
+#!/usr/bin/env python
+'''
+Native Python wrappers for PyMaterialX, providing a more Pythonic interface
+for Elements and Values.
+'''
+
 import warnings
 
 from .PyMaterialXCore import *
 from .PyMaterialXFormat import *
 from .datatype import *
-
-"""
-Native Python wrappers for PyMaterialX, providing a more Pythonic interface
-for Elements and Values.
-"""
 
 
 #
@@ -141,6 +142,7 @@ def _addBindParam(self, name, type = DEFAULT_TYPE_STRING):
 
 InterfaceElement.setInputValue = _setInputValue
 InterfaceElement.getInputValue = _getInputValue
+InterfaceElement.addParameter = _addParameter
 InterfaceElement.getParameters = _getParameters
 InterfaceElement.getActiveParameters = _getActiveParameters
 InterfaceElement.setParameterValue = _setParameterValue
@@ -166,17 +168,6 @@ def _addShaderRef(self, name, nodeName):
 
 Node.getReferencedNodeDef = _getReferencedNodeDef
 Node.addShaderRef = _addShaderRef
-
-
-#
-# GraphElement
-#
-
-def _addNode(self, category, name = '', typeString = DEFAULT_TYPE_STRING):
-    "Add a node to the graph."
-    return self._addNode(category, name, typeString)
-
-GraphElement.addNode = _addNode
 
 
 #
@@ -209,22 +200,24 @@ def _setGeomPropValue(self, name, value, typeString = ''):
     method = getattr(self.__class__, "_setGeomPropValue" + getTypeString(value))
     return method(self, name, value, typeString)
 
-GeomInfo.setGeomPropValue = _setGeomPropValue
+def _addGeomAttr(self, name):
+    "(Deprecated) Add a geomprop to this element."
+    warnings.warn("This function is deprecated; call GeomInfo.addGeomProp() instead", DeprecationWarning, stacklevel = 2)
+    return self.addGeomProp(name)
 
-GeomInfo.addGeomAttr = GeomInfo.addGeomProp
-GeomInfo.setGeomAttrValue = GeomInfo.setGeomPropValue
+def _setGeomAttrValue(self, name, value, typeString = ''):
+    "(Deprecated) Set the value of a geomattr by its name."
+    warnings.warn("This function is deprecated; call GeomInfo.setGeomPropValue() instead", DeprecationWarning, stacklevel = 2)
+    return self.setGeomPropValue(name, value, typeString)
+
+GeomInfo.setGeomPropValue = _setGeomPropValue
+GeomInfo.addGeomAttr = _addGeomAttr
+GeomInfo.setGeomAttrValue = _setGeomAttrValue
 
 
 #
 # Document
 #
-
-def _applyStringSubstitutions(self, filename, geom = '/'):
-    """(Deprecated) Given an input filename and geom string, apply any string
-        substitutions that have been defined for the given geom to the filename,
-        returning the modified filename."""
-    warnings.warn("This function is deprecated; call Element.createStringResolver() instead.", DeprecationWarning, stacklevel = 2)
-    return self.createStringResolver(geom).resolve(filename, 'filename')
 
 def _addMaterial(self, name):
     """(Deprecated) Add a material element to the document."""
@@ -236,7 +229,6 @@ def _getMaterials(self):
     warnings.warn("This function is deprecated; call Document.getMaterialNodes() instead.", DeprecationWarning, stacklevel = 2)
     return self.getMaterialNodes()
 
-Document.applyStringSubstitutions = _applyStringSubstitutions
 Document.addMaterial = _addMaterial
 Document.getMaterials = _getMaterials
 

--- a/python/MaterialXTest/genshader.py
+++ b/python/MaterialXTest/genshader.py
@@ -1,13 +1,15 @@
-import os
-import unittest
+#!/usr/bin/env python
+'''
+Unit tests for shader generation in MaterialX Python.
+'''
+
+import os, unittest
 
 import MaterialX as mx
 import MaterialX.PyMaterialXGenShader as mx_gen_shader
 import MaterialX.PyMaterialXGenOsl as mx_gen_osl
 
-# Unit tests for GenShader (Python).
 class TestGenShader(unittest.TestCase):
-
     def test_ShaderInterface(self):
         doc = mx.createDocument()
 

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -1,10 +1,12 @@
-import math
-import os
-import unittest
+#!/usr/bin/env python
+'''
+Unit tests for MaterialX Python.
+'''
+
+import math, os, unittest
 
 import MaterialX as mx
 
-# Unit tests for MaterialX Python.
 
 #--------------------------------------------------------------------------------
 _testValues = (1,
@@ -42,8 +44,12 @@ _exampleFilenames = ('CustomNode.mtlx',
 
 _epsilon = 1e-4
 
+
 #--------------------------------------------------------------------------------
 class TestMaterialX(unittest.TestCase):
+    def test_Globals(self):
+        self.assertTrue(mx.__version__ == mx.getVersionString())
+
     def test_DataTypes(self):
         for value in _testValues:
             valueString = mx.getValueString(value)

--- a/python/Scripts/genmdl.py
+++ b/python/Scripts/genmdl.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 '''
-   TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-   All rights reserved.  See LICENSE.txt for license.
-
-   Generate MDL implementation directory based on MaterialX nodedefs
+Generate MDL implementation directory based on MaterialX nodedefs
 '''
 
 import sys

--- a/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
@@ -27,7 +27,7 @@ void bindPyNode(py::module& mod)
         .def_readonly_static("CATEGORY", &mx::Node::CATEGORY);
 
     py::class_<mx::GraphElement, mx::GraphElementPtr, mx::InterfaceElement>(mod, "GraphElement")
-        .def("_addNode", &mx::GraphElement::addNode,
+        .def("addNode", &mx::GraphElement::addNode,
             py::arg("category"), py::arg("name") = mx::EMPTY_STRING, py::arg("type") = mx::DEFAULT_TYPE_STRING)
         .def("addNodeInstance", &mx::GraphElement::addNodeInstance,
             py::arg("nodeDef"), py::arg("name") = mx::EMPTY_STRING)


### PR DESCRIPTION
- Add a standard __version__ string to MaterialX Python, matching the value of MaterialX.getVersionString().
- Add missing deprecation warnings for GeomAttr elements.
- Add missing deprecation warning for InterfaceElement.addParameter.
- Simplify the Python wrapper for GraphElement.addNode.
- Unify formatting across Python wrapper modules.