### PR TITLE
Fix edge case for shaderref updates

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -197,8 +197,8 @@ vector<PortElementPtr> Node::getDownstreamPorts() const
 bool Node::validate(string* message) const
 {
     bool res = true;
-    validateRequire(!getCategory().empty(), res, message, "Missing category");
-    validateRequire(hasType(), res, message, "Missing type");
+    validateRequire(!getCategory().empty(), res, message, "Node element is missing a category");
+    validateRequire(hasType(), res, message, "Node element is missing a type");
     return InterfaceElement::validate(message) && res;
 }
 


### PR DESCRIPTION
This changelist addresses an edge case when updating shaderrefs to v1.38, where the node string of the associated nodedef was ignored when determining the shader node category.  Thanks to Karen Lucknavalai at Pixar for catching this!