### PR TITLE
Update luma coefficients for acescg

### DIFF
--- a/libraries/stdlib/osl/mx_luminance_color.osl
+++ b/libraries/stdlib/osl/mx_luminance_color.osl
@@ -27,7 +27,7 @@ shader mx_luminance_color
     [[ string help = "Output a grayscale image containing the luminance of the incoming RGB color in all color channels." ]]
   (
     color in = 0,
-    color lumacoeffs = color(0.272287, 0.6740818, 0.0536895),
+    color lumacoeffs = color(0.2722287, 0.6740818, 0.0536895),
     output color out = 0
   )
 {

--- a/libraries/stdlib/osl/mx_luminance_color4.osl
+++ b/libraries/stdlib/osl/mx_luminance_color4.osl
@@ -27,7 +27,7 @@ shader mx_luminance_color4
     [[ string help = "Output a grayscale image containing the luminance of the incoming RGB color in all color channels." ]]
   (
     color4 in = {color(0,0,0), 0},
-    color lumacoeffs = color(0.272287, 0.6740818, 0.0536895),
+    color lumacoeffs = color(0.2722287, 0.6740818, 0.0536895),
     output color4 out = {color(0,0,0), 0}
   )
 {

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2643,16 +2643,16 @@
   -->
   <nodedef name="ND_luminance_color3" node="luminance" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
+    <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+	enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
     <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_luminance_color4" node="luminance" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
+    <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+	enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
     <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
@@ -2890,17 +2890,17 @@
   <nodedef name="ND_saturate_color3" node="saturate" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
-    <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
+    <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+	enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
     <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_saturate_color4" node="saturate" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
-    <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
+    <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+	enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
     <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 

--- a/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
@@ -219,14 +219,14 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="luminance_color3" type="" xpos="6.10149" ypos="37.0378">
     <luminance name="luminance1" type="color3" xpos="5.74483" ypos="4.74">
       <input name="in" type="color3" value="1.0000, 0.7500, 0.5000" />
-      <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895" />
+      <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />
     </luminance>
     <output name="out" type="color3" nodename="luminance1" />
   </nodegraph>
   <nodegraph name="luminance_color4" type="" xpos="7.07552" ypos="37.024">
     <luminance name="luminance1" type="color4" xpos="5.74483" ypos="4.73222">
       <input name="in" type="color4" value="1.0000, 0.7500, 0.5000, 0.2500" />
-      <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895" />
+      <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />
     </luminance>
     <output name="out" type="color4" nodename="luminance1" />
   </nodegraph>
@@ -508,7 +508,7 @@ Basic adjustment function tests each test is in a separate graph for each variat
     <saturate name="saturate1" type="color3" xpos="5.74483" ypos="4.74">
       <input name="in" type="color3" value="1.0000, 0.5000, 0.2500" />
       <input name="amount" type="float" value="0.5000" />
-      <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895" />
+      <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />
     </saturate>
     <output name="out" type="color3" nodename="saturate1" />
   </nodegraph>
@@ -516,7 +516,7 @@ Basic adjustment function tests each test is in a separate graph for each variat
     <saturate name="saturate1" type="color4" xpos="5.74483" ypos="4.74">
       <input name="in" type="color4" value="1.0000, 0.5000, 0.2500, 1.0" />
       <input name="amount" type="float" value="0.5000" />
-      <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895" />
+      <parameter name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />
     </saturate>
     <output name="out" type="color4" nodename="saturate1" />
   </nodegraph>

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
@@ -2599,7 +2599,7 @@ export float4 mx_curveadjust_vector4(
 
 export color mx_luminance_color3(
 	color mxp_in = color(0.0, 0.0, 0.0),
-	uniform color mxp_lumacoeffs = color(0.272287, 0.6740818, 0.0536895)	
+	uniform color mxp_lumacoeffs = color(0.2722287, 0.6740818, 0.0536895)	
 	[[
 		anno::description("Enumeration {acescg, rec709, rec2020, rec2100}."),
         anno::unused()
@@ -2614,7 +2614,7 @@ export color mx_luminance_color3(
 
 export color4 mx_luminance_color4(
 	color4 mxp_in = mk_color4(0.0, 0.0, 0.0, 0.0),
-	uniform color mxp_lumacoeffs = color(0.272287, 0.6740818, 0.0536895)
+	uniform color mxp_lumacoeffs = color(0.2722287, 0.6740818, 0.0536895)
 	[[
 		anno::description("Enumeration {acescg, rec709, rec2020, rec2100}."),
         anno::unused()


### PR DESCRIPTION
This changelist updates the luma coefficients for the acescg/lin_ap1 colorspace, aligning them with reference values at https://www.colour-science.org/api/0.3.5/html/colour.models.dataset.aces.html.  Thanks to Philippe Leprince on the RenderMan team for this catch!