### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -932,7 +932,10 @@ void Document::upgradeVersion()
                     {
                         newChild = shaderNode->addToken(child->getName());
                     }
-                    newChild->copyContentFrom(child);
+                    if (newChild)
+                    {
+                        newChild->copyContentFrom(child);
+                    }
                 }
 
                 // Create a material node if needed, making a connection to the new shader node.

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -272,6 +272,9 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
     }
     else
     {
+        // End shader body
+        emitScopeEnd(stage);
+
         throw ExceptionShaderGenError("Output type '" + outputSocket->getType()->getName() + "' is not yet supported by shader generator");
     }
 

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -201,12 +201,12 @@ void TextureBaker::optimizeBakedTextures(NodePtr shader)
 
     // Check for uniform outputs at their default values.
     NodeDefPtr shaderNodeDef = shader->getNodeDef();
-    for (InputPtr shaderInput : shader->getInputs())
+    if (shaderNodeDef)
     {
-        OutputPtr output = shaderInput->getConnectedOutput();
-        if (output && _bakedConstantMap.count(output))
+        for (InputPtr shaderInput : shader->getInputs())
         {
-            if (_bakedConstantMap.count(output) && shaderNodeDef)
+            OutputPtr output = shaderInput->getConnectedOutput();
+            if (output && _bakedConstantMap.count(output))
             {
                 InputPtr input = shaderNodeDef->getInput(shaderInput->getName());
                 if (input)


### PR DESCRIPTION
- Fix potential dereference of null shared pointer in Document::upgradeVersion.
- Close shader scope before throwing an exception in MDL generation.
- Remove duplicate checks in TextureBaker::optimizeBakedTextures.