### PR TITLE
Upgrade shading models to v1.38

### DIFF
--- a/libraries/bxdf/disney_brdf_2012.mtlx
+++ b/libraries/bxdf/disney_brdf_2012.mtlx
@@ -1,19 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.37" colorspace="lin_rec709">
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
   <nodedef name="ND_disney_brdf_2012_surface" node="disney_brdf_2012">
-    <input name="baseColor" type="color3" value="0.16, 0.16, 0.16"/>
-    <input name="metallic" type="float" value="0"/>
-    <input name="subsurface" type="float" value="0"/>
-    <input name="specular" type="float" value="0.5"/>
-    <input name="roughness" type="float" value="0.5"/>
-    <input name="specularTint" type="float" value="0"/>
-    <input name="anisotropic" type="float" value="0"/>
-    <input name="sheen" type="float" value="0"/>
-    <input name="sheenTint" type="float" value="0.5"/>
-    <input name="clearcoat" type="float" value="0"/>
-    <input name="clearcoatGloss" type="float" value="1"/>
-    <output name="out" type="surfaceshader"/>
+    <input name="baseColor" type="color3" value="0.16, 0.16, 0.16" />
+    <input name="metallic" type="float" value="0" />
+    <input name="subsurface" type="float" value="0" />
+    <input name="specular" type="float" value="0.5" />
+    <input name="roughness" type="float" value="0.5" />
+    <input name="specularTint" type="float" value="0" />
+    <input name="anisotropic" type="float" value="0" />
+    <input name="sheen" type="float" value="0" />
+    <input name="sheenTint" type="float" value="0.5" />
+    <input name="clearcoat" type="float" value="0" />
+    <input name="clearcoatGloss" type="float" value="1" />
+    <output name="out" type="surfaceshader" />
   </nodedef>
-  <implementation name="IM_disney_brdf_2012_surface_brdf_explorer" nodedef="ND_disney_brdf_2012_surface"
-        target="brdf_explorer" file="https://github.com/wdas/brdf/blob/master/src/brdfs/disney.brdf"/>
+  <implementation name="IM_disney_brdf_2012_surface_brdf_explorer" nodedef="ND_disney_brdf_2012_surface" target="brdf_explorer" file="https://github.com/wdas/brdf/blob/master/src/brdfs/disney.brdf" />
 </materialx>

--- a/libraries/bxdf/disney_brdf_2015.mtlx
+++ b/libraries/bxdf/disney_brdf_2015.mtlx
@@ -1,26 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.37" colorspace="lin_rec709">
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
   <nodedef name="ND_disney_bsdf_2015_surface" node="disney_bsdf_2015">
-    <input name="baseColor" type="color3" value="0.16, 0.16, 0.16"/>
-    <input name="metallic" type="float" value="0"/>
-    <input name="roughness" type="float" value="0.5"/>
-    <input name="anisotropic" type="float" value="0"/>
-    <input name="specularTint" type="float" value="0"/>
-    <input name="sheen" type="float" value="0"/>
-    <input name="sheenTint" type="float" value="0.5"/>
-    <input name="clearcoat" type="float" value="0"/>
-    <input name="clearcoatGloss" type="float" value="1"/>
-    <input name="specTrans" type="float" value="0"/>
-    <input name="ior" type="float" value="1.5"/>
-    <input name="scatterDistance" type="vector3" value="0, 0, 0"/>
-    <input name="flatness" type="float" value="0"/>
-    <input name="diffTrans" type="float" value="0"/>
-    <parameter name="thin" type="boolean" value="false"/>
-    <output name="out" type="surfaceshader"/>
+    <input name="baseColor" type="color3" value="0.16, 0.16, 0.16" />
+    <input name="metallic" type="float" value="0" />
+    <input name="roughness" type="float" value="0.5" />
+    <input name="anisotropic" type="float" value="0" />
+    <input name="specularTint" type="float" value="0" />
+    <input name="sheen" type="float" value="0" />
+    <input name="sheenTint" type="float" value="0.5" />
+    <input name="clearcoat" type="float" value="0" />
+    <input name="clearcoatGloss" type="float" value="1" />
+    <input name="specTrans" type="float" value="0" />
+    <input name="ior" type="float" value="1.5" />
+    <input name="scatterDistance" type="vector3" value="0, 0, 0" />
+    <input name="flatness" type="float" value="0" />
+    <input name="diffTrans" type="float" value="0" />
+    <input name="thin" type="boolean" value="false" uniform="true" />
+    <output name="out" type="surfaceshader" />
   </nodedef>
-  <implementation name="IM_disney_bsdf_2015_surface_pbrt" nodedef="ND_disney_bsdf_2015_surface" target="pbrt"
-        file="https://github.com/mmp/pbrt-v3/blob/master/src/materials/disney.cpp" function="DisneyMaterial::DisneyMaterial">
-    <input name="baseColor" type="color3" implname="color"/>
-    <input name="ior" type="float" implname="eta"/>
+  <implementation name="IM_disney_bsdf_2015_surface_pbrt" nodedef="ND_disney_bsdf_2015_surface" target="pbrt" file="https://github.com/mmp/pbrt-v3/blob/master/src/materials/disney.cpp" function="DisneyMaterial::DisneyMaterial">
+    <input name="baseColor" type="color3" implname="color" />
+    <input name="ior" type="float" implname="eta" />
   </implementation>
 </materialx>

--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -1,95 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.37">
+<?xml version="1.0"?>
+<materialx version="1.38">
   <!--
     Autodesk Standard Surface node definition.
   -->
-  <nodedef name="ND_standard_surface_surfaceshader" node="standard_surface" nodegroup="pbr"
-            doc="Autodesk standard surface shader" version="1.0.1" isdefaultversion="true">
-      <input name="base" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Base" uifolder="Base"
-            doc="Multiplier on the intensity of the diffuse reflection." />
-      <input name="base_color" type="color3" value="0.8, 0.8, 0.8" uimin="0,0,0" uimax="1,1,1" uiname="Base Color"  uifolder="Base"
-            doc="Color of the diffuse reflection." />
-      <input name="diffuse_roughness" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Diffuse Roughness"  uifolder="Base" uiadvanced="true"
-            doc="Roughness of the diffuse reflection. Higher values cause the surface to appear flatter and darker." />
-      <input name="metalness" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Metalness" uifolder="Base"
-            doc="Specifies how metallic the material appears. At its maximum, the surface behaves like a metal, using fully specular reflection and complex fresnel." />
-      <input name="specular" type="float" value="1" uimin="0.0" uimax="1.0" uiname="Specular" uifolder="Specular"
-            doc="Multiplier on the intensity of the specular reflection." />
-      <input name="specular_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Specular Color" uifolder="Specular"
-            doc="Color tint on the specular reflection." />
-      <input name="specular_roughness" type="float" value="0.2" uimin="0.0" uimax="1.0" uiname="Specular Roughness" uifolder="Specular"
-            doc="The roughness of the specular reflection. Lower numbers produce sharper reflections, higher numbers produce blurrier reflections." />
-      <input name="specular_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Index of Refraction" uifolder="Specular"
-            doc="Index of refraction for specular reflection." />
-      <input name="specular_anisotropy" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Specular Anisotropy" uifolder="Specular" uiadvanced="true"
-            doc="The directional bias of reflected and transmitted light resulting in materials appearing rougher or glossier in certain directions." />
-      <input name="specular_rotation" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Specular Rotation" uifolder="Specular" uiadvanced="true"
-            doc="Rotation of the axis of specular anisotropy around the surface normal." />
-      <input name="transmission" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Transmission" uifolder="Transmission" uiadvanced="true"
-            doc="Transmission of light through the surface for materials such as glass or water. The greater the value the more transparent the material." />
-      <input name="transmission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Color" uifolder="Transmission" uiadvanced="true"
-            doc="Color tint on the transmitted light." />
-      <input name="transmission_depth" type="float" value="0" uimin="0.0" uisoftmax="100.0" uiname="Transmission Depth" uifolder="Transmission" uiadvanced="true"
-            doc="Specifies the distance light travels inside the material before its becomes exactly the transmission color according to Beer's law." />
-      <input name="transmission_scatter" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Scatter" uifolder="Transmission" uiadvanced="true"
-            doc="Scattering coefficient of the interior medium. Suitable for a large body of liquid or one that is fairly thick, such as an ocean, honey, ice, or frosted glass." />
-      <input name="transmission_scatter_anisotropy" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Transmission Anisotropy" uifolder="Transmission" uiadvanced="true"
-            doc="The amount of directional bias, or anisotropy, of the scattering." />
-      <input name="transmission_dispersion" type="float" value="0" uimin="0.0" uisoftmax="100.0" uiname="Transmission Dispersion" uifolder="Transmission" uiadvanced="true"
-            doc="Dispersion amount, describing how much the index of refraction varies across wavelengths." />
-      <input name="transmission_extra_roughness" type="float" value="0" uimin="-1.0" uisoftmin="0.0" uimax="1.0" uiname="Transmission Roughness" uifolder="Transmission" uiadvanced="true"
-            doc="Additional roughness on top of specular roughness. Positive values blur refractions more than reflections, and negative values blur refractions less." />
-      <input name="subsurface" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Subsurface" uifolder="Subsurface" uiadvanced="true"
-            doc="The blend between diffuse reflection and subsurface scattering. A value of 1.0 indicates full subsurface scattering and a value 0 for diffuse reflection only." />
-      <input name="subsurface_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Subsurface Color" uifolder="Subsurface" uiadvanced="true"
-            doc="The color of the subsurface scattering effect." />
-      <input name="subsurface_radius" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Subsurface Radius" uifolder="Subsurface" uiadvanced="true"
-            doc="The mean free path. The distance which light can travel before being scattered inside the surface." />
-      <input name="subsurface_scale" type="float" value="1" uimin="0.0" uisoftmax="10.0" uiname="Subsurface Scale" uifolder="Subsurface" uiadvanced="true"
-            doc="Scalar weight for the subsurface radius value." />
-      <input name="subsurface_anisotropy" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Subsurface Anisotropy" uifolder="Subsurface" uiadvanced="true"
-            doc="The direction of subsurface scattering. 0 scatters light evenly, positive values scatter forward and negative values scatter backward." />
-      <input name="sheen" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Sheen" uifolder="Sheen" uiadvanced="true"
-            doc="The weight of a sheen layer that can be used to approximate microfibers or fabrics such as velvet and satin." />
-      <input name="sheen_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Sheen Color" uifolder="Sheen" uiadvanced="true"
-            doc="The color of the sheen layer." />
-      <input name="sheen_roughness" type="float" value="0.3" uimin="0.0" uimax="1.0" uiname="Sheen Roughness" uifolder="Sheen" uiadvanced="true"
-            doc="The roughness of the sheen layer." />
-      <input name="coat" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Coat" uifolder="Coat"
-            doc="The weight of a reflective clear-coat layer on top of the material. Use for materials such as car paint or an oily layer." />
-      <input name="coat_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Coat Color" uifolder="Coat"
-            doc="The color of the clear-coat layer's transparency." />
-      <input name="coat_roughness" type="float" value="0.1" uimin="0.0" uimax="1.0" uiname="Coat Roughness" uifolder="Coat"
-            doc="The roughness of the clear-coat reflections. The lower the value, the sharper the reflection." />
-      <input name="coat_anisotropy" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Anisotropy" uifolder="Coat" uiadvanced="true"
-            doc="The amount of directional bias, or anisotropy, of the clear-coat layer." />
-      <input name="coat_rotation" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Rotation" uifolder="Coat" uiadvanced="true"
-            doc="The rotation of the anisotropic effect of the clear-coat layer." />
-      <input name="coat_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Coat Index of Refraction" uifolder="Coat"
-            doc="The index of refraction of the clear-coat layer." />
-      <input name="coat_normal" type="vector3" defaultgeomprop="Nworld" uiname="Coat normal" uifolder="Coat"
-            doc="Input normal for clear-coat layer" />
-      <input name="coat_affect_color" type="float" value="0" uimin="0" uimax="1" uiname="Coat Affect Color" uifolder="Coat" uiadvanced="true"
-            doc="Controls the saturation of diffuse reflection and subsurface scattering below the clear-coat." />
-      <input name="coat_affect_roughness" type="float" value="0" uimin="0" uimax="1" uiname="Coat Affect Roughness" uifolder="Coat" uiadvanced="true"
-            doc="Controls the roughness of the specular reflection in the layers below the clear-coat." />
-      <input name="thin_film_thickness" type="float" value="0" uimin="0.0" uisoftmax="2000.0" uiname="Thin Film Thickness" uifolder="Thin Film" uiadvanced="true"
-            doc="The thickness of the thin film layer on a surface. Use for materials such as multitone car paint or soap bubbles." />
-      <input name="thin_film_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
-            doc="The index of refraction of the medium surrounding the material." />
-      <input name="emission" type="float" value="0" uimin="0.0" uisoftmax="1.0"  uiname="Emission" uifolder="Emission"
-            doc="The amount of emitted incandescent light." />
-      <input name="emission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Emission Color" uifolder="Emission"
-            doc="The color of the emitted light." />
-      <input name="opacity" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Opacity" uifolder="Geometry"
-            doc="The opacity of the entire material." />
-      <input name="thin_walled" type="boolean" value="false" uiname="Thin Walled" uifolder="Geometry" uiadvanced="true"
-            doc="If true the surface is double-sided and represents an infinitely thin shell. Suiteable for thin objects such as tree leafs or paper"/>
-      <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Geometry"
-            doc="Input geometric normal" />
-      <input name="tangent" type="vector3"  defaultgeomprop="Tworld" uiname="Tangent Input" uifolder="Geometry"
-          doc="Input geometric tangent" />
-      <output name="out" type="surfaceshader" />
+  <nodedef name="ND_standard_surface_surfaceshader" node="standard_surface" nodegroup="pbr" doc="Autodesk standard surface shader" version="1.0.1" isdefaultversion="true">
+    <input name="base" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Base" uifolder="Base" doc="Multiplier on the intensity of the diffuse reflection." />
+    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" uimin="0,0,0" uimax="1,1,1" uiname="Base Color" uifolder="Base" doc="Color of the diffuse reflection." />
+    <input name="diffuse_roughness" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Diffuse Roughness" uifolder="Base" uiadvanced="true" doc="Roughness of the diffuse reflection. Higher values cause the surface to appear flatter and darker." />
+    <input name="metalness" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Metalness" uifolder="Base" doc="Specifies how metallic the material appears. At its maximum, the surface behaves like a metal, using fully specular reflection and complex fresnel." />
+    <input name="specular" type="float" value="1" uimin="0.0" uimax="1.0" uiname="Specular" uifolder="Specular" doc="Multiplier on the intensity of the specular reflection." />
+    <input name="specular_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Specular Color" uifolder="Specular" doc="Color tint on the specular reflection." />
+    <input name="specular_roughness" type="float" value="0.2" uimin="0.0" uimax="1.0" uiname="Specular Roughness" uifolder="Specular" doc="The roughness of the specular reflection. Lower numbers produce sharper reflections, higher numbers produce blurrier reflections." />
+    <input name="specular_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Index of Refraction" uifolder="Specular" doc="Index of refraction for specular reflection." />
+    <input name="specular_anisotropy" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Specular Anisotropy" uifolder="Specular" uiadvanced="true" doc="The directional bias of reflected and transmitted light resulting in materials appearing rougher or glossier in certain directions." />
+    <input name="specular_rotation" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Specular Rotation" uifolder="Specular" uiadvanced="true" doc="Rotation of the axis of specular anisotropy around the surface normal." />
+    <input name="transmission" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Transmission" uifolder="Transmission" uiadvanced="true" doc="Transmission of light through the surface for materials such as glass or water. The greater the value the more transparent the material." />
+    <input name="transmission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Color" uifolder="Transmission" uiadvanced="true" doc="Color tint on the transmitted light." />
+    <input name="transmission_depth" type="float" value="0" uimin="0.0" uisoftmax="100.0" uiname="Transmission Depth" uifolder="Transmission" uiadvanced="true" doc="Specifies the distance light travels inside the material before its becomes exactly the transmission color according to Beer's law." />
+    <input name="transmission_scatter" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Scatter" uifolder="Transmission" uiadvanced="true" doc="Scattering coefficient of the interior medium. Suitable for a large body of liquid or one that is fairly thick, such as an ocean, honey, ice, or frosted glass." />
+    <input name="transmission_scatter_anisotropy" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Transmission Anisotropy" uifolder="Transmission" uiadvanced="true" doc="The amount of directional bias, or anisotropy, of the scattering." />
+    <input name="transmission_dispersion" type="float" value="0" uimin="0.0" uisoftmax="100.0" uiname="Transmission Dispersion" uifolder="Transmission" uiadvanced="true" doc="Dispersion amount, describing how much the index of refraction varies across wavelengths." />
+    <input name="transmission_extra_roughness" type="float" value="0" uimin="-1.0" uisoftmin="0.0" uimax="1.0" uiname="Transmission Roughness" uifolder="Transmission" uiadvanced="true" doc="Additional roughness on top of specular roughness. Positive values blur refractions more than reflections, and negative values blur refractions less." />
+    <input name="subsurface" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Subsurface" uifolder="Subsurface" uiadvanced="true" doc="The blend between diffuse reflection and subsurface scattering. A value of 1.0 indicates full subsurface scattering and a value 0 for diffuse reflection only." />
+    <input name="subsurface_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Subsurface Color" uifolder="Subsurface" uiadvanced="true" doc="The color of the subsurface scattering effect." />
+    <input name="subsurface_radius" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Subsurface Radius" uifolder="Subsurface" uiadvanced="true" doc="The mean free path. The distance which light can travel before being scattered inside the surface." />
+    <input name="subsurface_scale" type="float" value="1" uimin="0.0" uisoftmax="10.0" uiname="Subsurface Scale" uifolder="Subsurface" uiadvanced="true" doc="Scalar weight for the subsurface radius value." />
+    <input name="subsurface_anisotropy" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Subsurface Anisotropy" uifolder="Subsurface" uiadvanced="true" doc="The direction of subsurface scattering. 0 scatters light evenly, positive values scatter forward and negative values scatter backward." />
+    <input name="sheen" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Sheen" uifolder="Sheen" uiadvanced="true" doc="The weight of a sheen layer that can be used to approximate microfibers or fabrics such as velvet and satin." />
+    <input name="sheen_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Sheen Color" uifolder="Sheen" uiadvanced="true" doc="The color of the sheen layer." />
+    <input name="sheen_roughness" type="float" value="0.3" uimin="0.0" uimax="1.0" uiname="Sheen Roughness" uifolder="Sheen" uiadvanced="true" doc="The roughness of the sheen layer." />
+    <input name="coat" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Coat" uifolder="Coat" doc="The weight of a reflective clear-coat layer on top of the material. Use for materials such as car paint or an oily layer." />
+    <input name="coat_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Coat Color" uifolder="Coat" doc="The color of the clear-coat layer's transparency." />
+    <input name="coat_roughness" type="float" value="0.1" uimin="0.0" uimax="1.0" uiname="Coat Roughness" uifolder="Coat" doc="The roughness of the clear-coat reflections. The lower the value, the sharper the reflection." />
+    <input name="coat_anisotropy" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Anisotropy" uifolder="Coat" uiadvanced="true" doc="The amount of directional bias, or anisotropy, of the clear-coat layer." />
+    <input name="coat_rotation" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Rotation" uifolder="Coat" uiadvanced="true" doc="The rotation of the anisotropic effect of the clear-coat layer." />
+    <input name="coat_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Coat Index of Refraction" uifolder="Coat" doc="The index of refraction of the clear-coat layer." />
+    <input name="coat_normal" type="vector3" defaultgeomprop="Nworld" uiname="Coat normal" uifolder="Coat" doc="Input normal for clear-coat layer" />
+    <input name="coat_affect_color" type="float" value="0" uimin="0" uimax="1" uiname="Coat Affect Color" uifolder="Coat" uiadvanced="true" doc="Controls the saturation of diffuse reflection and subsurface scattering below the clear-coat." />
+    <input name="coat_affect_roughness" type="float" value="0" uimin="0" uimax="1" uiname="Coat Affect Roughness" uifolder="Coat" uiadvanced="true" doc="Controls the roughness of the specular reflection in the layers below the clear-coat." />
+    <input name="thin_film_thickness" type="float" value="0" uimin="0.0" uisoftmax="2000.0" uiname="Thin Film Thickness" uifolder="Thin Film" uiadvanced="true" doc="The thickness of the thin film layer on a surface. Use for materials such as multitone car paint or soap bubbles." />
+    <input name="thin_film_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true" doc="The index of refraction of the medium surrounding the material." />
+    <input name="emission" type="float" value="0" uimin="0.0" uisoftmax="1.0" uiname="Emission" uifolder="Emission" doc="The amount of emitted incandescent light." />
+    <input name="emission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Emission Color" uifolder="Emission" doc="The color of the emitted light." />
+    <input name="opacity" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Opacity" uifolder="Geometry" doc="The opacity of the entire material." />
+    <input name="thin_walled" type="boolean" value="false" uiname="Thin Walled" uifolder="Geometry" uiadvanced="true" doc="If true the surface is double-sided and represents an infinitely thin shell. Suiteable for thin objects such as tree leafs or paper" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Geometry" doc="Input geometric normal" />
+    <input name="tangent" type="vector3" defaultgeomprop="Tworld" uiname="Tangent Input" uifolder="Geometry" doc="Input geometric tangent" />
+    <output name="out" type="surfaceshader" />
   </nodedef>
 
   <!--
@@ -124,7 +81,7 @@
     <rotate3d name="tangent_rotate" type="vector3">
       <input name="in" type="vector3" interfacename="tangent" />
       <input name="amount" type="float" nodename="tangent_rotate_degree" />
-      <input name="axis" type="vector3" interfacename="normal"/>
+      <input name="axis" type="vector3" interfacename="normal" />
     </rotate3d>
     <normalize name="tangent_rotate_normalize" type="vector3">
       <input name="in" type="vector3" nodename="tangent_rotate" />
@@ -144,7 +101,7 @@
     <rotate3d name="coat_tangent_rotate" type="vector3">
       <input name="in" type="vector3" interfacename="tangent" />
       <input name="amount" type="float" nodename="coat_tangent_rotate_degree" />
-      <input name="axis" type="vector3" interfacename="coat_normal"/>
+      <input name="axis" type="vector3" interfacename="coat_normal" />
     </rotate3d>
     <normalize name="coat_tangent_rotate_normalize" type="vector3">
       <input name="in" type="vector3" nodename="coat_tangent_rotate" />
@@ -199,8 +156,8 @@
     <subsurface_bsdf name="subsurface_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color" type="color3" nodename="coat_affected_subsurface_color" />
-      <input name="radius" type="vector3" nodename="subsurface_radius_scaled"/>
-      <input name="anisotropy" type="float" interfacename="subsurface_anisotropy"/>
+      <input name="radius" type="vector3" nodename="subsurface_radius_scaled" />
+      <input name="anisotropy" type="float" interfacename="subsurface_anisotropy" />
       <input name="normal" type="vector3" interfacename="normal" />
     </subsurface_bsdf>
     <convert name="subsurface_selector" type="float">
@@ -237,8 +194,8 @@
       <input name="roughness" type="vector2" nodename="main_roughness" />
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" nodename="main_tangent" />
-      <parameter name="distribution" type="string" value="ggx" />
-      <parameter name="scatter_mode" type="string" value="T" />
+      <input name="distribution" type="string" value="ggx" />
+      <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
     <mix name="transmission_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="transmission_bsdf" />
@@ -260,8 +217,8 @@
       <input name="roughness" type="vector2" nodename="main_roughness" />
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" nodename="main_tangent" />
-      <parameter name="distribution" type="string" value="ggx" />
-      <parameter name="scatter_mode" type="string" value="R" />
+      <input name="distribution" type="string" value="ggx" />
+      <input name="scatter_mode" type="string" value="R" />
     </dielectric_bsdf>
     <layer name="specular_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="specular_bsdf" />
@@ -282,17 +239,17 @@
       <input name="in2" type="float" interfacename="specular" />
     </multiply>
     <artistic_ior name="artistic_ior" type="multioutput">
-      <input name="reflectivity" type="color3" nodename="metal_reflectivity"/>
-      <input name="edge_color" type="color3" nodename="metal_edgecolor"/>
+      <input name="reflectivity" type="color3" nodename="metal_reflectivity" />
+      <input name="edge_color" type="color3" nodename="metal_edgecolor" />
     </artistic_ior>
     <conductor_bsdf name="metal_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
-      <input name="ior" type="color3" nodename="artistic_ior" output="ior"/>
-      <input name="extinction" type="color3" nodename="artistic_ior" output="extinction"/>
+      <input name="ior" type="color3" nodename="artistic_ior" output="ior" />
+      <input name="extinction" type="color3" nodename="artistic_ior" output="extinction" />
       <input name="roughness" type="vector2" nodename="main_roughness" />
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" nodename="main_tangent" />
-      <parameter name="distribution" type="string" value="ggx" />
+      <input name="distribution" type="string" value="ggx" />
     </conductor_bsdf>
     <mix name="metalness_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="metal_bsdf" />
@@ -301,7 +258,7 @@
     </mix>
 
     <!-- Coat Layer -->
-    <mix name="coat_attenuation" type="color3" >
+    <mix name="coat_attenuation" type="color3">
       <input name="fg" type="color3" interfacename="coat_color" />
       <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
       <input name="mix" type="float" interfacename="coat" />
@@ -310,7 +267,7 @@
       <input name="in1" type="BSDF" nodename="metalness_mix" />
       <input name="in2" type="color3" nodename="coat_attenuation" />
     </multiply>
-    <roughness_anisotropy name="coat_roughness" type="vector2">
+    <roughness_anisotropy name="coat_roughness_vector" type="vector2">
       <input name="roughness" type="float" interfacename="coat_roughness" />
       <input name="anisotropy" type="float" interfacename="coat_anisotropy" />
     </roughness_anisotropy>
@@ -318,11 +275,11 @@
       <input name="weight" type="float" interfacename="coat" />
       <input name="tint" type="color3" value="1.0, 1.0, 1.0" />
       <input name="ior" type="float" interfacename="coat_IOR" />
-      <input name="roughness" type="vector2" nodename="coat_roughness" />
+      <input name="roughness" type="vector2" nodename="coat_roughness_vector" />
       <input name="normal" type="vector3" interfacename="coat_normal" />
       <input name="tangent" type="vector3" nodename="coat_tangent" />
-      <parameter name="distribution" type="string" value="ggx" />
-      <parameter name="scatter_mode" type="string" value="R" />
+      <input name="distribution" type="string" value="ggx" />
+      <input name="scatter_mode" type="string" value="R" />
     </dielectric_bsdf>
     <layer name="coat_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="coat_bsdf" />
@@ -345,7 +302,7 @@
       <input name="in1" type="color3" interfacename="coat_color" />
       <input name="in2" type="float" nodename="coat_fresnel_inv" />
     </multiply>
-    <mix name="coat_emission_attenuation" type="color3" >
+    <mix name="coat_emission_attenuation" type="color3">
       <input name="fg" type="color3" nodename="coat_color_fresnel" />
       <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
       <input name="mix" type="float" interfacename="coat" />
@@ -377,5 +334,5 @@
     <output name="out" type="surfaceshader" nodename="shader_constructor" />
 
   </nodegraph>
-  
+
 </materialx>

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.37">
+<?xml version="1.0"?>
+<materialx version="1.38">
 
   <!-- ======================================================================== -->
   <!-- USD Preview Surface node definitions                                     -->
   <!-- ======================================================================== -->
 
   <!-- Node: UsdPreviewSurface -->
-  <nodedef name="ND_UsdPreviewSurface_surfaceshader" node="UsdPreviewSurface" nodegroup="pbr"
-            doc="USD preview surface shader" version="2.3" isdefaultversion="true">
+  <nodedef name="ND_UsdPreviewSurface_surfaceshader" node="UsdPreviewSurface" nodegroup="pbr" doc="USD preview surface shader" version="2.3" isdefaultversion="true">
     <input name="diffuseColor" type="color3" value="0.18, 0.18, 0.18" />
     <input name="emissiveColor" type="color3" value="0, 0, 0" />
     <input name="useSpecularWorkflow" type="integer" value="0" />
@@ -19,7 +18,7 @@
     <input name="opacity" type="float" value="1" />
     <input name="opacityThreshold" type="float" value="0" />
     <input name="ior" type="float" value="1.5" />
-    <input name="normal" type="vector3" value="0, 0, 1"/>
+    <input name="normal" type="vector3" value="0, 0, 1" />
     <input name="displacement" type="float" value="0" />
     <input name="occlusion" type="float" value="1" />
     <output name="out" type="surfaceshader" />
@@ -27,13 +26,13 @@
 
   <!-- Node: UsdUVTexture -->
   <nodedef name="ND_UsdUVTexture" node="UsdUVTexture">
-    <parameter name="file" type="filename" />
+    <input name="file" type="filename" uniform="true" />
     <input name="st" type="vector2" defaultgeomprop="UV0" />
-    <parameter name="wrapS" type="string" value="periodic" enum="black,clamp,periodic" />
-    <parameter name="wrapT" type="string" value="periodic" enum="black,clamp,periodic" />
-    <parameter name="fallback" type="color4" value="0, 0, 0, 1" />
-    <input name="scale" type="color4" value="1, 1, 1, 1" />
-    <input name="bias" type="color4" value="0, 0, 0, 0" />
+    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic" uniform="true" />
+    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic" uniform="true" />
+    <input name="fallback" type="color4" value="0, 0, 0, 1" />
+    <input name="scale" type="color4" value="1, 1, 1, 1" uniform="true" />
+    <input name="bias" type="color4" value="0, 0, 0, 0" uniform="true" />
     <output name="r" type="float" />
     <output name="g" type="float" />
     <output name="b" type="float" />
@@ -44,55 +43,55 @@
 
   <!-- Node: UsdPrimvarReader -->
   <nodedef name="ND_UsdPrimvarReader_integer" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="integer" value="0" />
+    <input name="varname" type="string" uniform="true" />
+    <input name="fallback" type="integer" value="0" />
     <output name="out" type="integer" />
   </nodedef>
   <nodedef name="ND_UsdPrimvarReader_boolean" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="boolean" value="false" />
+    <input name="varname" type="string" uniform="true" />
+    <input name="fallback" type="boolean" value="false" />
     <output name="out" type="boolean" />
   </nodedef>
   <nodedef name="ND_UsdPrimvarReader_string" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="string" value="" />
+    <input name="varname" type="string" uniform="true" />
+    <input name="fallback" type="string" value="" />
     <output name="out" type="string" />
   </nodedef>
   <nodedef name="ND_UsdPrimvarReader_float" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="float" value="0" />
+    <input name="varname" type="string" uniform="true" />
+    <input name="fallback" type="float" value="0" />
     <output name="out" type="float" />
   </nodedef>
   <nodedef name="ND_UsdPrimvarReader_vector2" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="vector2" value="0, 0" />
+    <input name="varname" type="string" uniform="true" />
+    <input name="fallback" type="vector2" value="0, 0" />
     <output name="out" type="vector2" />
   </nodedef>
   <nodedef name="ND_UsdPrimvarReader_vector3" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="vector3" value="0, 0, 0" />
+    <input name="varname" type="string" uniform="true" />
+    <input name="fallback" type="vector3" value="0, 0, 0" />
     <output name="out" type="vector3" />
   </nodedef>
   <nodedef name="ND_UsdPrimvarReader_vector4" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="vector4" value="0, 0, 0, 0" />
+    <input name="varname" type="string" uniform="true" />
+    <input name="fallback" type="vector4" value="0, 0, 0, 0" />
     <output name="out" type="vector4" />
   </nodedef>
   <!-- TODO: Getting primvar of matrix type is not supported in MaterialX standard library.
   <nodedef name="ND_UsdPrimvarReader_matrix44" node="UsdPrimvarReader">
-    <parameter name="varname" type="string" />
-    <parameter name="fallback" type="matrix44" value="1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1" />
+    <input name="varname" type="string" />
+    <input name="fallback" type="matrix44" value="1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1" />
     <output name="out" type="matrix44" />
   </nodedef>
   -->
 
   <!-- Node: UsdTransform2d -->
   <nodedef name="ND_UsdTransform2d" node="UsdTransform2d">
-    <input name="in" type="vector2"/>
-    <input name="rotation" type="float" value="0"/>
-    <input name="scale" type="vector2" value="1, 1"/>
-    <input name="translation" type="vector2" value="0, 0"/>
-    <output name="out" type="vector2"/>
+    <input name="in" type="vector2" />
+    <input name="rotation" type="float" value="0" />
+    <input name="scale" type="vector2" value="1, 1" />
+    <input name="translation" type="vector2" value="0, 0" />
+    <output name="out" type="vector2" />
   </nodedef>
 
   <!-- ======================================================================== -->
@@ -173,7 +172,7 @@
     </multiply>
     <generalized_schlick_bsdf name="specular_bsdf2" type="BSDF">
       <input name="weight" type="float" value="1" />
-      <input name="color0" type="color3" nodename="F0" channels="rrr"/>
+      <input name="color0" type="color3" nodename="F0" channels="rrr" />
       <input name="color90" type="color3" value="1, 1, 1" />
       <input name="roughness" type="vector2" nodename="specular_roughness" />
       <input name="normal" type="vector3" nodename="surface_normal" />
@@ -183,13 +182,13 @@
       <input name="base" type="BSDF" nodename="transmission_mix" />
     </layer>
     <artistic_ior name="artistic_ior" type="multioutput">
-      <input name="reflectivity" type="color3" interfacename="diffuseColor"/>
-      <input name="edge_color" type="color3" interfacename="diffuseColor"/>
+      <input name="reflectivity" type="color3" interfacename="diffuseColor" />
+      <input name="edge_color" type="color3" interfacename="diffuseColor" />
     </artistic_ior>
     <conductor_bsdf name="metalness_metal_bsdf" type="BSDF">
       <input name="weight" type="float" value="1" />
-      <input name="ior" type="color3" nodename="artistic_ior" output="ior"/>
-      <input name="extinction" type="color3" nodename="artistic_ior" output="extinction"/>
+      <input name="ior" type="color3" nodename="artistic_ior" output="ior" />
+      <input name="extinction" type="color3" nodename="artistic_ior" output="extinction" />
       <input name="roughness" type="vector2" nodename="specular_roughness" />
       <input name="normal" type="vector3" nodename="surface_normal" />
     </conductor_bsdf>
@@ -233,9 +232,9 @@
 
     <!-- Surface Shader Constructor -->
     <clamp name="opacity_clamped" type="float">
-      <input name="in" type="float" interfacename="opacity"/>
-      <parameter name="low" type="float" value="0.00001"/>
-      <parameter name="high" type="float" value="1.0"/>
+      <input name="in" type="float" interfacename="opacity" />
+      <input name="low" type="float" value="0.00001" />
+      <input name="high" type="float" value="1.0" />
     </clamp>
     <ifgreater name="cutout_opacity" type="float">
       <input name="value1" type="float" nodename="opacity_clamped" />
@@ -246,7 +245,7 @@
     <surface name="surface_constructor" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="coat_bsdf" />
       <input name="edf" type="EDF" nodename="emission_edf" />
-      <input name="opacity" type="float" nodename="cutout_opacity"/>
+      <input name="opacity" type="float" nodename="cutout_opacity" />
     </surface>
 
     <!-- Output -->
@@ -256,81 +255,81 @@
   <!-- Node: UsdUVTexture -->
   <nodegraph name="IMP_UsdUVTexture" nodedef="ND_UsdUVTexture">
     <image name="image_reader" type="color4">
-      <parameter name="file" type="filename" interfacename="file"/>
-      <parameter name="default" type="color4" interfacename="fallback"/>
-      <input name="texcoord" type="vector2" interfacename="st"/>
-      <parameter name="uaddressmode" type="string" interfacename="wrapS"/>
-      <parameter name="vaddressmode" type="string" interfacename="wrapT"/>
+      <input name="file" type="filename" interfacename="file" />
+      <input name="default" type="color4" interfacename="fallback" />
+      <input name="texcoord" type="vector2" interfacename="st" />
+      <input name="uaddressmode" type="string" interfacename="wrapS" />
+      <input name="vaddressmode" type="string" interfacename="wrapT" />
     </image>
     <multiply name="image_scale" type="color4">
-      <input name="in1" type="color4" nodename="image_reader"/>
-      <input name="in2" type="color4" interfacename="scale"/>
+      <input name="in1" type="color4" nodename="image_reader" />
+      <input name="in2" type="color4" interfacename="scale" />
     </multiply>
     <add name="image_bias" type="color4">
-      <input name="in1" type="color4" nodename="image_scale"/>
-      <input name="in2" type="color4" interfacename="bias"/>
+      <input name="in1" type="color4" nodename="image_scale" />
+      <input name="in2" type="color4" interfacename="bias" />
     </add>
-    <output name="r" type="float" nodename="image_bias" channels="r"/>
-    <output name="g" type="float" nodename="image_bias" channels="g"/>
-    <output name="b" type="float" nodename="image_bias" channels="b"/>
-    <output name="a" type="float" nodename="image_bias" channels="a"/>
-    <output name="rgb" type="color3" nodename="image_bias" channels="rgb"/>
+    <output name="r" type="float" nodename="image_bias" channels="r" />
+    <output name="g" type="float" nodename="image_bias" channels="g" />
+    <output name="b" type="float" nodename="image_bias" channels="b" />
+    <output name="a" type="float" nodename="image_bias" channels="a" />
+    <output name="rgb" type="color3" nodename="image_bias" channels="rgb" />
     <output name="rgba" type="color4" nodename="image_bias" />
   </nodegraph>
 
   <!-- Node: UsdPrimvarReader -->
   <nodegraph name="IMP_UsdPrimvarReader_integer" nodedef="ND_UsdPrimvarReader_integer">
     <geompropvalue name="primvar" type="integer">
-      <parameter name="geomprop" type="string" interfacename="varname"/>
+      <input name="geomprop" type="string" interfacename="varname" />
     </geompropvalue>
-    <output name="out" type="integer" nodename="primvar"/>
+    <output name="out" type="integer" nodename="primvar" />
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_boolean" nodedef="ND_UsdPrimvarReader_boolean">
     <geompropvalue name="primvar" type="boolean">
-      <parameter name="geomprop" type="string" interfacename="varname"/>
+      <input name="geomprop" type="string" interfacename="varname" />
     </geompropvalue>
-    <output name="out" type="boolean" nodename="primvar"/>
+    <output name="out" type="boolean" nodename="primvar" />
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_string" nodedef="ND_UsdPrimvarReader_string">
     <geompropvalue name="primvar" type="string">
-      <parameter name="geomprop" type="string" interfacename="varname"/>
+      <input name="geomprop" type="string" interfacename="varname" />
     </geompropvalue>
-    <output name="out" type="string" nodename="primvar"/>
+    <output name="out" type="string" nodename="primvar" />
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_float" nodedef="ND_UsdPrimvarReader_float">
     <geompropvalue name="primvar" type="float">
-      <parameter name="geomprop" type="string" interfacename="varname"/>
+      <input name="geomprop" type="string" interfacename="varname" />
     </geompropvalue>
-    <output name="out" type="float" nodename="primvar"/>
+    <output name="out" type="float" nodename="primvar" />
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_vector2" nodedef="ND_UsdPrimvarReader_vector2">
     <geompropvalue name="primvar" type="vector2">
-      <parameter name="geomprop" type="string" interfacename="varname"/>
+      <input name="geomprop" type="string" interfacename="varname" />
     </geompropvalue>
-    <output name="out" type="vector2" nodename="primvar"/>
+    <output name="out" type="vector2" nodename="primvar" />
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_vector3" nodedef="ND_UsdPrimvarReader_vector3">
     <geompropvalue name="primvar" type="vector3">
-      <parameter name="geomprop" type="string" interfacename="varname"/>
+      <input name="geomprop" type="string" interfacename="varname" />
     </geompropvalue>
-    <output name="out" type="vector3" nodename="primvar"/>
+    <output name="out" type="vector3" nodename="primvar" />
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_vector4" nodedef="ND_UsdPrimvarReader_vector4">
     <geompropvalue name="primvar" type="vector4">
-      <parameter name="geomprop" type="string" interfacename="varname"/>
+      <input name="geomprop" type="string" interfacename="varname" />
     </geompropvalue>
-    <output name="out" type="vector4" nodename="primvar"/>
+    <output name="out" type="vector4" nodename="primvar" />
   </nodegraph>
 
   <!-- Node: UsdTransform2d -->
   <nodegraph name="IMP_UsdTransform2d" nodedef="ND_UsdTransform2d">
     <place2d name="placement" type="vector2">
-      <input name="texcoord" type="vector2" interfacename="in"/>
-      <input name="scale" type="vector2" interfacename="scale"/>
-      <input name="rotate" type="float" interfacename="rotation"/>
-      <input name="offset" type="vector2" interfacename="translation"/>
+      <input name="texcoord" type="vector2" interfacename="in" />
+      <input name="scale" type="vector2" interfacename="scale" />
+      <input name="rotate" type="float" interfacename="rotation" />
+      <input name="offset" type="vector2" interfacename="translation" />
     </place2d>
-    <output name="out" type="vector2" nodename="placement"/>
+    <output name="out" type="vector2" nodename="placement" />
   </nodegraph>
 
 </materialx>


### PR DESCRIPTION
- Upgrade all documents in the libraries/bxdf folder to v1.38.
- Adjust uniform attributes in shading model interfaces to match their specifications.
- Rename a node in the implementation of standard_surface to avoid a collision with its interface.