### PR TITLE
Streamline port connection methods

### DIFF
--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -172,13 +172,6 @@ class PortElement : public ValueElement
     /// Return the node, if any, to which this element is connected.
     virtual NodePtr getConnectedNode() const;
 
-    /// Set the output to which this element is connected.  If the output
-    /// argument is null, then any existing output connection will be cleared.
-    void setConnectedOutput(ConstOutputPtr output);
-
-    /// Return the output, if any, to which this element is connected.
-    OutputPtr getConnectedOutput() const;
-
     /// @}
     /// @name Validation
     /// @{
@@ -215,20 +208,6 @@ class Input : public PortElement
     virtual ~Input() { }
 
   public:
-    /// @name Traversal
-    /// @{
-
-    /// Return the input on the parent graph corresponding to the interface name
-    /// for the element.
-    InputPtr getConnectedInterface() const;
-
-    /// Return the output, if any, to which this element is connected.
-    OutputPtr getConnectedOutput() const;
-
-    /// Return the node, if any, to which this element is connected.
-    NodePtr getConnectedNode() const override;
-
-    /// @}
     /// @name Default Geometric Property
     /// @{
 
@@ -252,6 +231,24 @@ class Input : public PortElement
 
     /// Return the GeomPropDef element to use, if defined for this input.
     GeomPropDefPtr getDefaultGeomProp() const;
+
+    /// @}
+    /// @name Connections
+    /// @{
+
+    /// Return the node, if any, to which this input is connected.
+    NodePtr getConnectedNode() const override;
+
+    /// Set the output to which this input is connected.  If the output
+    /// argument is null, then any existing output connection will be cleared.
+    void setConnectedOutput(ConstOutputPtr output);
+
+    /// Return the output, if any, to which this input is connected.
+    virtual OutputPtr getConnectedOutput() const;
+
+    /// Return the input on the parent graph corresponding to the interface name
+    /// for this input.
+    InputPtr getInterfaceInput() const;
 
     /// @}
     /// @name Validation

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -145,7 +145,7 @@ OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)
             InputPtr interfaceInput = nullptr;
             if (connectedInput->hasInterfaceName())
             {
-                interfaceInput = connectedInput->getConnectedInterface();
+                interfaceInput = connectedInput->getInterfaceInput();
                 if (interfaceInput)
                 {
                     outputName = &(interfaceInput->getOutputString());
@@ -642,7 +642,7 @@ bool NodeGraph::validate(string* message) const
                 const string& interfaceName = input->getInterfaceName();
                 if (!interfaceName.empty())
                 {
-                    InputPtr interfaceInput = input->getConnectedInterface();
+                    InputPtr interfaceInput = input->getInterfaceInput();
                     validateRequire(interfaceInput != nullptr, res, message, "NodeGraph interface input: \"" + interfaceName + "\" does not exist on nodegraph");
                     string connectedNodeName = interfaceInput ? interfaceInput->getNodeName() : EMPTY_STRING;
                     if (connectedNodeName.empty())

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -29,15 +29,17 @@ void bindPyInterface(py::module& mod)
         .def("setChannels", &mx::PortElement::setChannels)
         .def("getChannels", &mx::PortElement::getChannels)
         .def("setConnectedNode", &mx::PortElement::setConnectedNode)
-        .def("getConnectedNode", &mx::PortElement::getConnectedNode)
-        .def("setConnectedOutput", &mx::PortElement::setConnectedOutput)
-        .def("getConnectedOutput", &mx::PortElement::getConnectedOutput);
+        .def("getConnectedNode", &mx::PortElement::getConnectedNode);
 
     py::class_<mx::Input, mx::InputPtr, mx::PortElement>(mod, "Input")
         .def("setDefaultGeomPropString", &mx::Input::setDefaultGeomPropString)
         .def("hasDefaultGeomPropString", &mx::Input::hasDefaultGeomPropString)
         .def("getDefaultGeomPropString", &mx::Input::getDefaultGeomPropString)
         .def("getDefaultGeomProp", &mx::Input::getDefaultGeomProp)
+        .def("getConnectedNode", &mx::Input::getConnectedNode)
+        .def("setConnectedOutput", &mx::Input::setConnectedOutput)
+        .def("getConnectedOutput", &mx::Input::getConnectedOutput)
+        .def("getInterfaceInput", &mx::Input::getInterfaceInput)
         .def_readonly_static("CATEGORY", &mx::Input::CATEGORY);
 
     py::class_<mx::Output, mx::OutputPtr, mx::PortElement>(mod, "Output")


### PR DESCRIPTION
- Merge output accessors for Input and PortElement for simplicity.
- Simplify the implementation of Input::getConnectedNode.
- Rename Input::getConnectedInterface to Input::getInterfaceInput for clarity.