### PR TITLE
Improvements to search paths

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -5,12 +5,7 @@
 
 #include <MaterialXGenShader/Util.h>
 
-#include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/HwShaderGenerator.h>
-#include <MaterialXGenShader/GenContext.h>
-
-#include <MaterialXFormat/XmlIo.h>
-#include <MaterialXFormat/PugiXML/pugixml.hpp>
 
 namespace MaterialX
 {
@@ -178,29 +173,6 @@ namespace
 
         return false;
     }
-}
-
-FileSearchPath getDefaultSearchPath()
-{
-    FileSearchPath searchPath;
-
-    // Default search path for installed binaries.
-    FilePath installSearchPath = FilePath::getModulePath().getParentPath();
-    if (installSearchPath.exists())
-    {
-        searchPath.append(installSearchPath);
-        searchPath.append(installSearchPath / "libraries");
-    }
-
-    // Default search path for development environments.
-    FilePath devSearchPath = FilePath(__FILE__).getParentPath().getParentPath().getParentPath();
-    if (devSearchPath.exists())
-    {
-        searchPath.append(devSearchPath);
-        searchPath.append(devSearchPath / "libraries");
-    }
-
-    return searchPath;
 }
 
 bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -25,9 +25,6 @@ namespace MaterialX
 
 class ShaderGenerator;
 
-/// Return a default search path for binaries that leverage shader generation.
-FileSearchPath getDefaultSearchPath();
-
 /// Returns true if the given element is a surface shader with the potential
 /// of beeing transparent. This can be used by HW shader generators to determine
 /// if a shader will require transparency handling.

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -388,7 +388,7 @@ DocumentPtr TextureBaker::bakeMaterial(NodePtr shader, const StringVec& udimSet)
     return bakingSuccessful ? bakedTextureDoc : nullptr;
 }
 
-BakedDocumentVec TextureBaker::createBakeDocuments(DocumentPtr doc, const FileSearchPath& imageSearchPath)
+BakedDocumentVec TextureBaker::createBakeDocuments(DocumentPtr doc, const FileSearchPath& searchPath)
 {
     GenContext genContext(_generator);
     genContext.getOptions().hwSpecularEnvironmentMethod = SPECULAR_ENVIRONMENT_FIS;
@@ -400,10 +400,10 @@ BakedDocumentVec TextureBaker::createBakeDocuments(DocumentPtr doc, const FileSe
 
     DefaultColorManagementSystemPtr cms = DefaultColorManagementSystem::create(genContext.getShaderGenerator().getTarget());
     cms->loadLibrary(doc);
-    if (_codeSearchPath.isEmpty())
-        genContext.registerSourceCodeSearchPath(getDefaultSearchPath());
-    else
-        genContext.registerSourceCodeSearchPath(_codeSearchPath);
+    for (const FilePath& path : searchPath)
+    {
+        genContext.registerSourceCodeSearchPath(path / "libraries");
+    }
     genContext.getShaderGenerator().setColorManagementSystem(cms);
     StringResolverPtr resolver = StringResolver::create();
     ImageHandlerPtr imageHandler = GLTextureHandler::create(StbImageLoader::create());
@@ -455,7 +455,7 @@ BakedDocumentVec TextureBaker::createBakeDocuments(DocumentPtr doc, const FileSe
             {
                 continue;
             }
-            imageHandler->setSearchPath(imageSearchPath);
+            imageHandler->setSearchPath(searchPath);
             resolver->setUdimString(tag);
             imageHandler->setFilenameResolver(resolver);
             setImageHandler(imageHandler);
@@ -473,7 +473,7 @@ BakedDocumentVec TextureBaker::createBakeDocuments(DocumentPtr doc, const FileSe
     return bakedDocuments;
 }
 
-void TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileSearchPath& imageSearchPath, const FilePath& outputFilename)
+void TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileSearchPath& searchPath, const FilePath& outputFilename)
 {
     if (_outputImagePath.isEmpty())
     {
@@ -484,7 +484,7 @@ void TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileSearchPath& image
         }
     }
 
-    BakedDocumentVec bakedDocuments = createBakeDocuments(doc, imageSearchPath);
+    BakedDocumentVec bakedDocuments = createBakeDocuments(doc, searchPath);
     size_t bakeCount = bakedDocuments.size();
     if (bakeCount == 1)
     {

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -117,12 +117,6 @@ class TextureBaker : public GlslRenderer
         return _outputImagePath;
     }
 
-    /// Set the "libraries" search path location. Otherwise will use getDefaultSearchPath()
-    void setCodeSearchPath(const FileSearchPath& codesearchPath)
-    {
-        _codeSearchPath = codesearchPath;
-    }
-
     /// Set the name of the baked graph element.
     void setBakedGraphName(const string& name)
     {
@@ -175,11 +169,11 @@ class TextureBaker : public GlslRenderer
     DocumentPtr bakeMaterial(NodePtr shader, const StringVec& udimSet);
 
     /// Bake all materials in the given document and return them as a vector.
-    BakedDocumentVec createBakeDocuments(DocumentPtr doc, const FileSearchPath& imageSearchPath);
+    BakedDocumentVec createBakeDocuments(DocumentPtr doc, const FileSearchPath& searchPath);
 
     /// Bake all materials in the given document and write them to disk.  If multiple documents are written,
     /// then the given output filename will be used as a template.
-    void bakeAllMaterials(DocumentPtr doc, const FileSearchPath& imageSearchPath, const FilePath& outputFileName);
+    void bakeAllMaterials(DocumentPtr doc, const FileSearchPath& searchPath, const FilePath& outputFileName);
 
   protected:
     TextureBaker(unsigned int width, unsigned int height, Image::BaseType baseType);
@@ -217,7 +211,6 @@ class TextureBaker : public GlslRenderer
     FilePath _outputImagePath;
     string _bakedGraphName;
     string _bakedGeomInfoName;
-    FileSearchPath _codeSearchPath;
     std::ostream* _outputStream;
 
     ShaderGeneratorPtr _generator;

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -50,6 +50,27 @@ template<class T> void parseToken(std::string token, std::string type, T& res)
     res = value->asA<T>();
 }
 
+mx::FileSearchPath getDefaultSearchPath()
+{
+    mx::FileSearchPath searchPath;
+
+    // Default search path for installed binaries.
+    mx::FilePath installSearchPath = mx::FilePath::getModulePath().getParentPath();
+    if (installSearchPath.exists())
+    {
+        searchPath.append(installSearchPath);
+    }
+
+    // Default search path for development environments.
+    mx::FilePath devSearchPath = mx::FilePath(__FILE__).getParentPath().getParentPath().getParentPath();
+    if (devSearchPath.exists())
+    {
+        searchPath.append(devSearchPath);
+    }
+
+    return searchPath;
+}
+
 int main(int argc, char* const argv[])
 {  
     std::vector<std::string> tokens;
@@ -61,7 +82,7 @@ int main(int argc, char* const argv[])
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx";
     std::string meshFilename = "resources/Geometry/shaderball.obj";
     std::string envRadianceFilename = "resources/Lights/san_giuseppe_bridge_split.hdr";
-    mx::FileSearchPath searchPath = mx::getDefaultSearchPath();
+    mx::FileSearchPath searchPath = getDefaultSearchPath();
     mx::FilePathVec libraryFolders = { "libraries" };
 
     mx::Vector3 meshRotation;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1458,7 +1458,10 @@ void Viewer::saveDotFiles()
 void Viewer::initContext(mx::GenContext& context)
 {
     // Initialize search paths.
-    context.registerSourceCodeSearchPath(_searchPath);
+    for (const mx::FilePath& path : _searchPath)
+    {
+        context.registerSourceCodeSearchPath(path / "libraries");
+    }
 
     // Initialize color management.
     mx::DefaultColorManagementSystemPtr cms = mx::DefaultColorManagementSystem::create(context.getShaderGenerator().getTarget());


### PR DESCRIPTION
- In the Viewer and TextureBaker, respect input search paths for shader code as well as documents and images, applying the necessary modifications to match the expectations of the code generator.
- Move the getDefaultSearchPath helper function from MaterialXGenShader to MaterialXView, since its assumptions are specific to that application.