### PR TITLE
Improvements to viewer builds

### DIFF
--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -98,11 +98,3 @@ install(TARGETS MaterialXView
     RUNTIME DESTINATION bin)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/MaterialXView.pdb"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/bin/" OPTIONAL)
-    
-# Copy over libraries and resources to local build area
-add_custom_command(TARGET MaterialXView POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy_directory
-	${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_CURRENT_BINARY_DIR}/libraries)
-add_custom_command(TARGET MaterialXView POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy_directory
-	${CMAKE_CURRENT_SOURCE_DIR}/../../resources ${CMAKE_CURRENT_BINARY_DIR}/resources)

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -52,21 +52,13 @@ template<class T> void parseToken(std::string token, std::string type, T& res)
 
 mx::FileSearchPath getDefaultSearchPath()
 {
+    mx::FilePath modulePath = mx::FilePath::getModulePath();
+    mx::FilePath installRootPath = modulePath.getParentPath();
+    mx::FilePath devRootPath = installRootPath.getParentPath().getParentPath().getParentPath();
+
     mx::FileSearchPath searchPath;
-
-    // Default search path for installed binaries.
-    mx::FilePath installSearchPath = mx::FilePath::getModulePath().getParentPath();
-    if (installSearchPath.exists())
-    {
-        searchPath.append(installSearchPath);
-    }
-
-    // Default search path for development environments.
-    mx::FilePath devSearchPath = mx::FilePath(__FILE__).getParentPath().getParentPath().getParentPath();
-    if (devSearchPath.exists())
-    {
-        searchPath.append(devSearchPath);
-    }
+    searchPath.append(installRootPath);
+    searchPath.append(devRootPath);
 
     return searchPath;
 }


### PR DESCRIPTION
- Remove library and resource copies for viewer builds, as they tend to slow down shader development.
- Simplify the logic for viewer search paths, making it more robust in production contexts.