### PR TITLE
Fix external nanogui build

### DIFF
--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -76,8 +76,7 @@ if (MATERIALX_BUILD_GEN_MDL)
 endif()
 
 target_link_libraries(
-     ${LIBS}
-    nanogui
+    ${LIBS}
     ${NANOGUI_LIBRARIES}
     ${NANOGUI_EXTRA_LIBS})
 


### PR DESCRIPTION
9197ee9b re-introduced linking via *-lnanogui* , which is redundant with the CMake variable *NANOGUI_LIBRARIES* for a local nano-gui build, and causes errors with an external NanoGUI install.  76a30db6 is the original merge where it was removed.