### PR TITLE
MDL texture lookup code generation updates

### DIFF
--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -287,14 +287,6 @@ string MdlShaderGenerator::getUpstreamResult(const ShaderInput* input, GenContex
 {
     const ShaderOutput* upstreamOutput = input->getConnection();
 
-    // TODO: This is a temporary fix for Iray.
-    // File texture constructors with a filename set are emitted inline "by value".
-    if (upstreamOutput && upstreamOutput->getType() == Type::FILENAME &&
-        upstreamOutput->getValue() && !upstreamOutput->getValue()->getValueString().empty())
-    {
-        return _syntax->getValue(upstreamOutput->getType(), *upstreamOutput->getValue());
-    }
-
     if (!upstreamOutput || upstreamOutput->getNode()->isAGraph())
     {
         return ShaderGenerator::getUpstreamResult(input, context);
@@ -547,14 +539,6 @@ void MdlShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
     for (size_t i = 0; i < inputs.size(); ++i)
     {
         const ShaderPort* input = inputs[i];
-
-        // TODO: This is a temporary fix for Iray.
-        // File texture constructors with a filename set must be emitted inside the shader body.
-        // They will be emitted inline "by value", see MdlShaderGenerator::getUpstreamResult().
-        if (input->getType() == Type::FILENAME && input->getValue() && !input->getValue()->getValueString().empty())
-        {
-            continue;
-        }
 
         const string& qualifier = input->isUniform() || input->getType()==Type::FILENAME ? uniformPrefix : EMPTY_STRING;
         const string& type = _syntax->getTypeName(input->getType());

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -37,13 +37,19 @@ class MdlFilenameTypeSyntax : public ScalarTypeSyntax
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
+        const string outputValue = value.getValueString();
+        if (outputValue.empty() || outputValue == "/")
+        {
+            return getDefaultValue(true);
+        }
+
         string pathSeparator("");
-        FilePath path(value.getValueString());
+        FilePath path(outputValue);
         if (!path.isAbsolute())
         {
             pathSeparator = "/";
         }
-        return getName() + "(\"" + pathSeparator + value.getValueString() + "\", tex::gamma_linear)";
+        return getName() + "(\"" + pathSeparator + outputValue + "\", tex::gamma_linear)";
     }
 };
 


### PR DESCRIPTION
Issues Addressed
- Fixes erroneous generation of a texture_2d() reference with "/" as an argument when no value is specified.
- Make texture_2d() lookups input arguments as opposed to always inlined.