### PR TITLE
Add support for UINT16 images in MaterialXRender

### DIFF
--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -105,7 +105,8 @@ unsigned int Image::getBaseStride() const
     {
         return 4;
     }
-    if (_baseType == BaseType::HALF)
+    if (_baseType == BaseType::HALF ||
+        _baseType == BaseType::UINT16)
     {
         return 2;
     }
@@ -149,12 +150,20 @@ void Image::setTexelColor(unsigned int x, unsigned int y, const Color4& color)
             data[c] = (Half) color[c];
         }
     }
+    else if (_baseType == BaseType::UINT16)
+    {
+        uint16_t* data = static_cast<uint16_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        for (unsigned int c = 0; c < writeChannels; c++)
+        {
+            data[c] = (uint16_t) std::round(color[c] * (float) std::numeric_limits<uint16_t>::max());
+        }
+    }
     else if (_baseType == BaseType::UINT8)
     {
         uint8_t* data = static_cast<uint8_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
         for (unsigned int c = 0; c < writeChannels; c++)
         {
-            data[c] = (uint8_t) std::round(color[c] * 255.0f);
+            data[c] = (uint8_t) std::round(color[c] * (float) std::numeric_limits<uint8_t>::max());
         }
     }
     else
@@ -222,24 +231,51 @@ Color4 Image::getTexelColor(unsigned int x, unsigned int y) const
             throw Exception("Unsupported channel count in getTexelColor");
         }
     }
-    else if (_baseType == BaseType::UINT8)
+    else if (_baseType == BaseType::UINT16)
     {
-        uint8_t* data = static_cast<uint8_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        uint16_t* data = static_cast<uint16_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        const float MAX_VALUE = (float) std::numeric_limits<uint16_t>::max();
         if (_channelCount == 4)
         {
-            return Color4(data[0] / 255.0f, data[1] / 255.0f, data[2] / 255.0f, data[3] / 255.0f);
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, data[3] / MAX_VALUE);
         }
         else if (_channelCount == 3)
         {
-            return Color4(data[0] / 255.0f, data[1] / 255.0f, data[2] / 255.0f, 1.0f);
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, 1.0f);
         }
         else if (_channelCount == 2)
         {
-            return Color4(data[0] / 255.0f, data[1] / 255.0f, 0.0f, 1.0f);
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, 0.0f, 1.0f);
         }
         else if (_channelCount == 1)
         {
-            float scalar = data[0] / 255.0f;
+            float scalar = data[0] / MAX_VALUE;
+            return Color4(scalar, scalar, scalar, 1.0f);
+        }
+        else
+        {
+            throw Exception("Unsupported channel count in getTexelColor");
+        }
+    }
+    else if (_baseType == BaseType::UINT8)
+    {
+        uint8_t* data = static_cast<uint8_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        const float MAX_VALUE = (float) std::numeric_limits<uint8_t>::max();
+        if (_channelCount == 4)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, data[3] / MAX_VALUE);
+        }
+        else if (_channelCount == 3)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, 1.0f);
+        }
+        else if (_channelCount == 2)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, 0.0f, 1.0f);
+        }
+        else if (_channelCount == 1)
+        {
+            float scalar = data[0] / MAX_VALUE;
             return Color4(scalar, scalar, scalar, 1.0f);
         }
         else

--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -42,8 +42,9 @@ class Image
     enum class BaseType
     {
         UINT8 = 0,
-        HALF = 1,
-        FLOAT = 2
+        UINT16 = 1,
+        HALF = 2,
+        FLOAT = 3
     };
 
   public:

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -36,6 +36,20 @@ const string ImageLoader::TXT_EXTENSION = "txt";
 const string ImageLoader::TXR_EXTENSION = "txr";
 
 //
+// ImageLoader methods
+//
+
+bool ImageLoader::saveImage(const FilePath&, ConstImagePtr, bool)
+{
+    return false;
+}
+
+ImagePtr ImageLoader::loadImage(const FilePath&)
+{
+    return nullptr;
+}
+
+//
 // ImageHandler methods
 //
 

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -127,12 +127,12 @@ class ImageLoader
     /// @return if save succeeded
     virtual bool saveImage(const FilePath& filePath,
                            ConstImagePtr image,
-                           bool verticalFlip = false) = 0;
+                           bool verticalFlip = false);
 
     /// Load an image from the file system. This method must be implemented by derived classes.
     /// @param filePath The requested image file path.
     /// @return On success, a shared pointer to the loaded image; otherwise an empty shared pointer.
-    virtual ImagePtr loadImage(const FilePath& filePath) = 0;
+    virtual ImagePtr loadImage(const FilePath& filePath);
 
   protected:
     // List of supported string extensions
@@ -216,6 +216,10 @@ class ImageHandler
     /// Release rendering resources for the given image.
     virtual void releaseRenderResources(ImagePtr image);
 
+    /// Clear the contents of the image cache, first releasing any
+    /// render resources associated with each image.
+    void clearImageCache();
+
     /// Return a fallback image with zeroes in all channels.
     ImagePtr getZeroImage() const
     {
@@ -242,10 +246,6 @@ class ImageHandler
     // Return the cached image, if found; otherwise return an empty
     // shared pointer.
     ImagePtr getCachedImage(const FilePath& filePath);
-
-    /// Clear the contents of the image cache, first releasing any
-    /// render resources associated with each image.
-    void clearImageCache();
 
   protected:
     ImageLoaderMap _imageLoaders;

--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -36,6 +36,9 @@ bool OiioImageLoader::saveImage(const FilePath& filePath,
         case Image::BaseType::UINT8:
             format = OIIO::TypeDesc::UINT8;
             break;
+        case Image::BaseType::UINT16:
+            format = OIIO::TypeDesc::UINT16;
+            break;
         case Image::BaseType::HALF:
             format = OIIO::TypeDesc::HALF;
             break;
@@ -91,6 +94,9 @@ ImagePtr OiioImageLoader::loadImage(const FilePath& filePath)
     {
         case OIIO::TypeDesc::UINT8:
             baseType = Image::BaseType::UINT8;
+            break;
+        case OIIO::TypeDesc::UINT16:
+            baseType = Image::BaseType::UINT16;
             break;
         case OIIO::TypeDesc::HALF:
             baseType = Image::BaseType::HALF;

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -228,6 +228,18 @@ void GLTextureHandler::mapTextureFormatToGL(Image::BaseType baseType, unsigned i
             default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
         }
     }
+    else if (baseType == Image::BaseType::UINT16)
+    {
+        glType = GL_UNSIGNED_SHORT;
+        switch (channelCount)
+        {
+            case 4: glInternalFormat = GL_RGBA16; break;
+            case 3: glInternalFormat = GL_RGB16; break;
+            case 2: glInternalFormat = GL_RG16; break;
+            case 1: glInternalFormat = GL_R16; break;
+            default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
+        }
+    }
     else if (baseType == Image::BaseType::HALF)
     {
         glType = GL_HALF_FLOAT;

--- a/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
@@ -14,6 +14,7 @@ void bindPyImage(py::module& mod)
 {
     py::enum_<mx::Image::BaseType>(mod, "BaseType")
         .value("UINT8", mx::Image::BaseType::UINT8)
+        .value("UINT16", mx::Image::BaseType::UINT16)
         .value("HALF", mx::Image::BaseType::HALF)
         .value("FLOAT", mx::Image::BaseType::FLOAT)
         .export_values();

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -10,38 +10,6 @@
 namespace py = pybind11;
 namespace mx = MaterialX;
 
-class PyImageLoader : public mx::ImageLoader
-{
-  public:
-    PyImageLoader() :
-        mx::ImageLoader()
-    {
-    }
-
-    bool saveImage(const mx::FilePath& filePath, mx::ConstImagePtr image, bool verticalFlip) override
-    {
-        PYBIND11_OVERLOAD_PURE(
-            bool,
-            mx::ImageLoader,
-            saveImage,
-            filePath,
-            image,
-            verticalFlip
-        );
-    }
-
-    mx::ImagePtr loadImage(const mx::FilePath& filePath) override
-    {
-        PYBIND11_OVERLOAD_PURE(
-            mx::ImagePtr,
-            mx::ImageLoader,
-            loadImage,
-            filePath
-        );
-    }
-
-};
-
 void bindPyImageHandler(py::module& mod)
 {
     py::class_<mx::ImageSamplingProperties>(mod, "ImageSamplingProperties")
@@ -50,7 +18,7 @@ void bindPyImageHandler(py::module& mod)
         .def_readwrite("filterType", &mx::ImageSamplingProperties::filterType)
         .def_readwrite("defaultColor", &mx::ImageSamplingProperties::defaultColor);
 
-    py::class_<mx::ImageLoader, PyImageLoader, mx::ImageLoaderPtr>(mod, "ImageLoader")
+    py::class_<mx::ImageLoader, mx::ImageLoaderPtr>(mod, "ImageLoader")
         .def_readonly_static("BMP_EXTENSION", &mx::ImageLoader::BMP_EXTENSION)
         .def_readonly_static("EXR_EXTENSION", &mx::ImageLoader::EXR_EXTENSION)
         .def_readonly_static("GIF_EXTENSION", &mx::ImageLoader::GIF_EXTENSION)
@@ -76,6 +44,14 @@ void bindPyImageHandler(py::module& mod)
         .def("acquireImage", &mx::ImageHandler::acquireImage)
         .def("bindImage", &mx::ImageHandler::bindImage)
         .def("unbindImage", &mx::ImageHandler::unbindImage)
+        .def("unbindImages", &mx::ImageHandler::unbindImages)
         .def("setSearchPath", &mx::ImageHandler::setSearchPath)
-        .def("getSearchPath", &mx::ImageHandler::getSearchPath);
+        .def("getSearchPath", &mx::ImageHandler::getSearchPath)
+        .def("setFilenameResolver", &mx::ImageHandler::setFilenameResolver)
+        .def("getFilenameResolver", &mx::ImageHandler::getFilenameResolver)
+        .def("createRenderResources", &mx::ImageHandler::createRenderResources)
+        .def("releaseRenderResources", &mx::ImageHandler::releaseRenderResources)
+        .def("clearImageCache", &mx::ImageHandler::clearImageCache)
+        .def("getZeroImage", &mx::ImageHandler::getZeroImage)
+        .def("getInvalidImage", &mx::ImageHandler::getInvalidImage);
 }


### PR DESCRIPTION
This changelist adds support for 16-bit unsigned-integer images in MaterialXRender, allowing 16-bit TIFF files to be loaded and viewed when MaterialX is built with OpenImageIO enabled.

Also:
- Make ImageHandler::clearImageCache a public method.
- Add missing Python bindings for the ImageHandler class.
- Simplify Python bindings for the ImageLoader class.