### PR TITLE
Remove invalid interfacename attribute

### DIFF
--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx
@@ -102,7 +102,7 @@
 
   <!-- Nodegraph to node connection -->
   <image name="upstream_image" type="color3">
-    <input name="file" type="filename" interfacename="file" value="resources/Images/cloth.png" />
+    <input name="file" type="filename" value="resources/Images/cloth.png" />
   </image>
   <nodegraph name="graph_to_node">
     <input name="input" type="color3" nodename="upstream_image" value="0, 1, 0" />


### PR DESCRIPTION
This changelist removes an invalid interfacename attribute from the nodegraph_nodegraph example, allowing improvements to document validation logic in the future.