### PR TITLE
Add Element::getTreeIndex method

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -676,6 +676,18 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @endcode
     InheritanceIterator traverseInheritance() const;
 
+    /// Return the breadth-first index of this element within the document tree.
+    int getTreeIndex() const
+    {
+        ConstElementPtr parent = getParent();
+        if (!parent)
+        {
+            return 0;
+        }
+        return parent->getTreeIndex() * (int) (parent->getChildren().size() + 1) +
+               parent->getChildIndex(getName()) + 1;
+    }
+
     /// @}
     /// @name Source URI
     /// @{

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -85,6 +85,7 @@ void bindPyElement(py::module& mod)
         .def("getUpstreamElement", &mx::Element::getUpstreamElement,
             py::arg("index") = 0)
         .def("traverseInheritance", &mx::Element::traverseInheritance)
+        .def("getTreeIndex", &mx::Element::getTreeIndex)
         .def("setSourceUri", &mx::Element::setSourceUri)
         .def("hasSourceUri", &mx::Element::hasSourceUri)
         .def("getSourceUri", &mx::Element::getSourceUri)


### PR DESCRIPTION
This changelist adds the Element::getTreeIndex method, which returns the breadth-first index of an element within the document tree.