### PR TITLE
Improved support for compound nodegraphs

### DIFF
--- a/resources/Materials/Examples/StandardSurface/standard_surface_brick_procedural.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_brick_procedural.mtlx
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="lin_rec709" fileprefix="../../../Images/">
-  <nodedef name="ND_BrickShader" node="BrickShader">
-    <input name="brick_color" type="color3" value="0.661876, 0.19088, 0" />
-    <input name="hue_variation" type="float" value="0.083" uimin="0" uimax="1" />
-    <input name="value_variation" type="float" value="0.787" uimin="0" uimax="1" />
-    <input name="roughness_amount" type="float" value="0.853" uimin="0" uimax="1" />
-    <input name="dirt_color" type="color3" value="0.56372, 0.56372, 0.56372" />
-    <input name="dirt_amount" type="float" value="0.248" uimin="0" uimax="1" />
-    <input name="uvtiling" type="vector2" value="3, 3" uimin="0, 0" uimax="25, 25" />
-    <output name="base_color_output" type="color3" value="0, 0, 0" />
-    <output name="specular_roughness_output" type="float" value="0" />
-    <output name="normal_output" type="vector3" value="0, 0, 0" />
-  </nodedef>
-  <nodegraph name="NG_BrickShader" nodedef="ND_BrickShader">
+  <nodegraph name="NG_BrickPattern">
+    <input name="brick_color" type="color3" value="0.661876, 0.19088, 0" uiname="Brick Color" uifolder="Color" />
+    <input name="hue_variation" type="float" value="0.083" uimin="0" uimax="1" uiname="Hue Variation" uifolder="Color" />
+    <input name="value_variation" type="float" value="0.787" uimin="0" uimax="1" uiname="Value Variation" uifolder="Color" />
+    <input name="roughness_amount" type="float" value="0.853" uimin="0" uimax="1" uiname="Roughness Amount" uifolder="Roughness" />
+    <input name="dirt_color" type="color3" value="0.56372, 0.56372, 0.56372" uiname="Dirt Color" uifolder="Dirt" />
+    <input name="dirt_amount" type="float" value="0.248" uimin="0" uimax="1" uiname="Dirt Amount" uifolder="Dirt" />
+    <input name="uvtiling" type="float" value="3" uisoftmin="1" uisoftmax="16" uiname="UV Tiling" uifolder="Texturing" />
     <multiply name="node_multiply_5" type="color3">
       <input name="in1" type="color3" nodename="node_mix_6" />
       <input name="in2" type="float" nodename="node_tiledimage_float_7" />
@@ -90,51 +85,44 @@
     </multiply>
     <normalmap name="node_normalmap_3" type="vector3">
       <input name="in" type="vector3" nodename="node_tiledimage_vector3_27" />
-      <input name="scale" type="float" value="1" />
     </normalmap>
+    <convert name="node_convert_1" type="vector2">
+      <input name="in" type="float" interfacename="uvtiling" />
+    </convert>
     <tiledimage name="node_tiledimage_vector3_27" type="vector3">
       <input name="file" type="filename" value="brick_normal.jpg" />
-      <input name="uvtiling" type="vector2" interfacename="uvtiling" />
+      <input name="uvtiling" type="vector2" nodename="node_convert_1" />
     </tiledimage>
     <tiledimage name="node_tiledimage_float_22" type="float">
       <input name="file" type="filename" value="brick_roughness.jpg" />
-      <input name="uvtiling" type="vector2" interfacename="uvtiling" />
+      <input name="uvtiling" type="vector2" nodename="node_convert_1" />
     </tiledimage>
     <tiledimage name="node_tiledimage_float_10" type="float">
       <input name="file" type="filename" value="brick_mask.jpg" />
-      <input name="uvtiling" type="vector2" interfacename="uvtiling" />
+      <input name="uvtiling" type="vector2" nodename="node_convert_1" />
     </tiledimage>
     <tiledimage name="node_tiledimage_float_7" type="float">
       <input name="file" type="filename" value="brick_base_gray.jpg" />
-      <input name="uvtiling" type="vector2" interfacename="uvtiling" />
+      <input name="uvtiling" type="vector2" nodename="node_convert_1" />
     </tiledimage>
     <tiledimage name="node_tiledimage_float_26" type="float">
       <input name="file" type="filename" value="brick_variation_mask.jpg" />
-      <input name="uvtiling" type="vector2" interfacename="uvtiling" />
+      <input name="uvtiling" type="vector2" nodename="node_convert_1" />
     </tiledimage>
     <tiledimage name="node_tiledimage_float_24" type="float">
       <input name="file" type="filename" value="brick_dirt_mask.jpg" />
-      <input name="uvtiling" type="vector2" interfacename="uvtiling" />
+      <input name="uvtiling" type="vector2" nodename="node_convert_1" />
     </tiledimage>
     <output name="base_color_output" type="color3" nodename="node_clamp_0" />
     <output name="specular_roughness_output" type="float" nodename="node_multiply_1" />
     <output name="normal_output" type="vector3" nodename="node_normalmap_3" />
   </nodegraph>
-  <BrickShader name="N_BrickShader" type="multioutput">
-    <input name="brick_color" type="color3" value="0.661876, 0.19088, 0" />
-    <input name="hue_variation" type="float" value="0.083" />
-    <input name="value_variation" type="float" value="0.787" />
-    <input name="roughness_amount" type="float" value="0.853" />
-    <input name="dirt_color" type="color3" value="0.56372, 0.56372, 0.56372" />
-    <input name="dirt_amount" type="float" value="0.248" />
-    <input name="uvtiling" type="vector2" value="3, 3" />
-  </BrickShader>
   <standard_surface name="N_StandardSurface" type="surfaceshader">
-    <input name="base_color" type="color3" nodename="N_BrickShader" output="base_color_output" />
-    <input name="specular_roughness" type="float" nodename="N_BrickShader" output="specular_roughness_output" />
-    <input name="normal" type="vector3" nodename="N_BrickShader" output="normal_output" />
+    <input name="base_color" type="color3" nodegraph="NG_BrickPattern" output="base_color_output" />
+    <input name="specular_roughness" type="float" nodegraph="NG_BrickPattern" output="specular_roughness_output" />
+    <input name="normal" type="vector3" nodegraph="NG_BrickPattern" output="normal_output" />
   </standard_surface>
-  <surfacematerial name="M_BrickProcedural" type="material">
+  <surfacematerial name="M_BrickPattern" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="N_StandardSurface" />
   </surfacematerial>
 </materialx>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx
@@ -1,30 +1,36 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="lin_rec709">
   <nodegraph name="NG_marble1">
-    <position name="objpos" type="vector3" />
-    <dotproduct name="addxyz" type="float">
-      <input name="in1" type="vector3" nodename="objpos" />
+    <input name="base_color_1" type="color3" value="0.8, 0.8, 0.8" uiname="Color 1" uifolder="Marble Color" />
+    <input name="base_color_2" type="color3" value="0.1, 0.1, 0.3" uiname="Color 2" uifolder="Marble Color" />
+    <input name="noise_scale_1" type="float" value="6.0" uisoftmin="1.0" uisoftmax="10.0" uiname="Scale 1" uifolder="Marble Noise" />
+    <input name="noise_scale_2" type="float" value="4.0" uisoftmin="1.0" uisoftmax="10.0" uiname="Scale 2" uifolder="Marble Noise" />
+    <input name="noise_power" type="float" value="3.0" uisoftmin="1.0" uisoftmax="10.0" uiname="Power" uifolder="Marble Noise" />
+    <input name="noise_octaves" type="integer" value="3" uisoftmin="1" uisoftmax="8" uiname="Octaves" uifolder="Marble Noise" />
+    <position name="obj_pos" type="vector3" />
+    <dotproduct name="add_xyz" type="float">
+      <input name="in1" type="vector3" nodename="obj_pos" />
       <input name="in2" type="vector3" value="1, 1, 1" />
     </dotproduct>
-    <multiply name="scalexyz" type="float">
-      <input name="in1" type="float" nodename="addxyz" />
-      <input name="in2" type="float" value="6.0" />
+    <multiply name="scale_xyz" type="float">
+      <input name="in1" type="float" nodename="add_xyz" />
+      <input name="in2" type="float" interfacename="noise_scale_1" />
     </multiply>
-    <multiply name="scalepos" type="vector3">
-      <input name="in1" type="vector3" nodename="objpos" />
-      <input name="in2" type="float" value="4.0" />
+    <multiply name="scale_pos" type="vector3">
+      <input name="in1" type="vector3" nodename="obj_pos" />
+      <input name="in2" type="float" interfacename="noise_scale_2" />
     </multiply>
     <fractal3d name="noise" type="float">
-      <parameter name="octaves" type="integer" value="3" />
-      <input name="position" type="vector3" nodename="scalepos" />
+      <input name="octaves" type="integer" interfacename="noise_octaves"  />
+      <input name="position" type="vector3" nodename="scale_pos" />
     </fractal3d>
-    <multiply name="scalenoise" type="float">
+    <multiply name="scale_noise" type="float">
       <input name="in1" type="float" nodename="noise" />
       <input name="in2" type="float" value="3.0" />
     </multiply>
     <add name="sum" type="float">
-      <input name="in1" type="float" nodename="scalexyz" />
-      <input name="in2" type="float" nodename="scalenoise" />
+      <input name="in1" type="float" nodename="scale_xyz" />
+      <input name="in2" type="float" nodename="scale_noise" />
     </add>
     <sin name="sin" type="float">
       <input name="in" type="float" nodename="sum" />
@@ -39,25 +45,18 @@
     </add>
     <power name="power" type="float">
       <input name="in1" type="float" nodename="bias" />
-      <input name="in2" type="float" value="3.0" />
+      <input name="in2" type="float" interfacename="noise_power" />
     </power>
-    <constant name="constant_1" type="color3">
-      <input name="value" type="color3" value="0.8, 0.8, 0.8" />
-    </constant>
-    <constant name="constant_2" type="color3">
-      <input name="value" type="color3" value="0.1, 0.1, 0.3" />
-    </constant>
-    <mix name="mix1" type="color3">
-      <input name="bg" type="color3" nodename="constant_1" />
-      <input name="fg" type="color3" nodename="constant_2" />
+    <mix name="color_mix" type="color3">
+      <input name="bg" type="color3" interfacename="base_color_1" />
+      <input name="fg" type="color3" interfacename="base_color_2" />
       <input name="mix" type="float" nodename="power" />
     </mix>
-    <output name="out" type="color3" nodename="mix1" />
+    <output name="out" type="color3" nodename="color_mix" />
   </nodegraph>
   <standard_surface name="SR_marble1" type="surfaceshader">
     <input name="base" type="float" value="1" />
     <input name="base_color" type="color3" nodegraph="NG_marble1" output="out" />
-    <input name="specular_color" type="color3" value="1, 1, 1" />
     <input name="specular_roughness" type="float" value="0.1" />
     <input name="subsurface" type="float" value="0.4" />
     <input name="subsurface_color" type="color3" nodegraph="NG_marble1" output="out" />

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -538,30 +538,6 @@ bool ValueElement::validate(string* message) const
     {
         validateRequire(getValue() != nullptr, res, message, "Invalid value");
     }
-    if (hasInterfaceName())
-    {
-        validateRequire(isA<Input>(), res, message, "Only input elements support interface names");
-        ConstNodeGraphPtr nodeGraph = getAncestorOfType<NodeGraph>();
-        NodeDefPtr nodeDef = nodeGraph ? nodeGraph->getNodeDef() : nullptr;
-        if (nodeDef)
-        {
-            ValueElementPtr valueElem = nodeDef->getActiveValueElement(getInterfaceName());
-            validateRequire(valueElem != nullptr, res, message, "Interface name not found in referenced NodeDef");
-            if (valueElem)
-            {
-                ConstPortElementPtr portElem = asA<PortElement>();
-                if (portElem && portElem->hasChannels())
-                {
-                    bool valid = portElem->validChannelsString(portElem->getChannels(), valueElem->getType(), getType());
-                    validateRequire(valid, res, message, "Invalid channels string for interface name");
-                }
-                else
-                {
-                    validateRequire(getType() == valueElem->getType(), res, message, "Interface name refers to value element of a different type");
-                }
-            }
-        }
-    }
     UnitTypeDefPtr unitTypeDef;
     if (hasUnitType())
     {

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -137,7 +137,7 @@ bool PortElement::validate(string* message) const
             bool valid = validChannelsString(getChannels(), connectedNode->getType(), getType());
             validateRequire(valid, res, message, "Invalid channels string in port connection");
         }
-        else
+        else if (connectedNode->getType() != MULTI_OUTPUT_TYPE_STRING)
         {
             validateRequire(getType() == connectedNode->getType(), res, message, "Mismatched types in port connection");
         }
@@ -335,10 +335,31 @@ bool Input::validate(string* message) const
     {
         validateRequire(getDefaultGeomProp() != nullptr, res, message, "Invalid defaultgeomprop string");
     }
-    InputPtr interfaceInput = getInterfaceInput();
-    if (interfaceInput)
+    if (hasInterfaceName())
     {
-        return interfaceInput->validate() && res;
+        ConstNodeGraphPtr nodeGraph = getAncestorOfType<NodeGraph>();
+        NodeDefPtr nodeDef = nodeGraph ? nodeGraph->getNodeDef() : nullptr;
+        if (nodeDef)
+        {
+            InputPtr interfaceInput = nodeDef->getActiveInput(getInterfaceName());
+            validateRequire(interfaceInput != nullptr, res, message, "Interface name not found in referenced NodeDef");
+            if (interfaceInput)
+            {
+                if (hasChannels())
+                {
+                    bool valid = validChannelsString(getChannels(), interfaceInput->getType(), getType());
+                    validateRequire(valid, res, message, "Invalid channels string for interface name");
+                }
+                else
+                {
+                    validateRequire(getType() == interfaceInput->getType(), res, message, "Interface name refers to input of a different type");
+                }
+            }
+        }
+        else
+        {
+            validateRequire(getInterfaceInput() != nullptr, res, message, "Interface name not found in containing NodeGraph");
+        }
     }
     return PortElement::validate(message) && res;
 }

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -527,30 +527,20 @@ void NodeGraph::setNodeDef(ConstNodeDefPtr nodeDef)
     }
 }
 
-ValueElementPtr Node::addInputFromNodeDef(const string& name)
+InputPtr Node::addInputFromNodeDef(const string& name)
 {
-    ValueElementPtr newChild = nullptr;
-    NodeDefPtr elemNodeDef = getNodeDef();
-    if (elemNodeDef)
+    InputPtr nodeInput = getInput(name);
+    if (!nodeInput)
     {
-        ValueElementPtr nodeDefElem = elemNodeDef->getChildOfType<ValueElement>(name);
-        const string& inputName = nodeDefElem->getName();
-        ElementPtr existingElement = getChild(inputName);
-        if (existingElement && existingElement->isA<ValueElement>())
+        NodeDefPtr nodeDef = getNodeDef();
+        InputPtr nodeDefInput = nodeDef ? nodeDef->getInput(name) : nullptr;
+        if (nodeDefInput)
         {
-            return existingElement->asA<ValueElement>();
-        }
-
-        if (nodeDefElem->isA<Input>())
-        {
-            newChild = addInput(inputName, nodeDefElem->getType());
-        }
-        if (newChild)
-        {
-            newChild->copyContentFrom(nodeDefElem);
+            nodeInput = addInput(nodeDefInput->getName());
+            nodeInput->copyContentFrom(nodeDefInput);
         }
     }
-    return newChild;
+    return nodeInput;
 }
 
 void NodeGraph::addInterfaceName(const string& inputPath, const string& interfaceName)
@@ -632,33 +622,7 @@ bool NodeGraph::validate(string* message) const
             validateRequire(getOutputCount() == nodeDef->getActiveOutputs().size(), res, message, "NodeGraph implementation has a different number of outputs than its NodeDef");
         }
     }
-    // Check interfaces on nodegraphs which are not definitions
-    if (!hasNodeDefString())
-    {
-        for (NodePtr node : getNodes())
-        {
-            for (InputPtr input : node->getInputs())
-            {
-                const string& interfaceName = input->getInterfaceName();
-                if (!interfaceName.empty())
-                {
-                    InputPtr interfaceInput = input->getInterfaceInput();
-                    validateRequire(interfaceInput != nullptr, res, message, "NodeGraph interface input: \"" + interfaceName + "\" does not exist on nodegraph");
-                    string connectedNodeName = interfaceInput ? interfaceInput->getNodeName() : EMPTY_STRING;
-                    if (connectedNodeName.empty())
-                    {
-                        connectedNodeName = interfaceInput->getNodeGraphString();
-                    }
-                    if (interfaceInput && !connectedNodeName.empty())
-                    {
-                        NodePtr connectedNode = input->getConnectedNode();
-                        validateRequire(connectedNode != nullptr, res, message, "Nodegraph input: \"" + interfaceInput->getNamePath() +
-                            "\" specifies connection to non existent node: \"" + connectedNodeName + "\"");
-                    }
-                }
-            }
-        }
-    }
+
     return GraphElement::validate(message) && res;
 }
 

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -155,7 +155,7 @@ class MX_CORE_API Node : public InterfaceElement
 
     /// Add an input based on the corresponding input for the associated node definition.
     /// If the input already exists on the node it will just be returned.
-    ValueElementPtr addInputFromNodeDef(const string& name);
+    InputPtr addInputFromNodeDef(const string& name);
 
     /// @}
     /// @name Validation

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -32,36 +32,28 @@ ShaderGraph::ShaderGraph(const ShaderGraph* parent, const string& name, ConstDoc
 
 void ShaderGraph::addInputSockets(const InterfaceElement& elem, GenContext& context)
 {
-    for (InputPtr nodeInput : elem.getActiveInputs())
+    for (InputPtr input : elem.getActiveInputs())
     {
         ShaderGraphInputSocket* inputSocket = nullptr;
-        ValuePtr portValue = nodeInput->getResolvedValue();
-        if (!portValue)
-        {
-            InputPtr interfaceInput = nodeInput->getInterfaceInput();
-            if (interfaceInput)
-            {
-                portValue = interfaceInput->getValue();
-            }
-        }
+        ValuePtr portValue = input->getResolvedValue();
         const string& portValueString = portValue ? portValue->getValueString() : EMPTY_STRING;
         std::pair<const TypeDesc*, ValuePtr> enumResult;
-        const string& enumNames = nodeInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
-        const TypeDesc* portType = TypeDesc::get(nodeInput->getType());
+        const string& enumNames = input->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+        const TypeDesc* portType = TypeDesc::get(input->getType());
         if (context.getShaderGenerator().getSyntax().remapEnumeration(portValueString, portType, enumNames, enumResult))
         {
-            inputSocket = addInputSocket(nodeInput->getName(), enumResult.first);
+            inputSocket = addInputSocket(input->getName(), enumResult.first);
             inputSocket->setValue(enumResult.second);
         }
         else
         {
-            inputSocket = addInputSocket(nodeInput->getName(), portType);
+            inputSocket = addInputSocket(input->getName(), portType);
             if (!portValueString.empty())
             {
                 inputSocket->setValue(portValue);
             }
         }
-        if (nodeInput->getIsUniform())
+        if (input->getIsUniform())
         {
             inputSocket->setUniform();
         }

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -190,7 +190,8 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
         NodeDefPtr nodeDef = node->getNodeDef();
         if (!nodeDef)
         {
-            throw ExceptionShaderGenError("Could not find a nodedef for shader node '" + node->getNamePath());
+            throw ExceptionShaderGenError("Could not find a nodedef for shader node '" + node->getName() +
+                                          "' with category '" + node->getCategory() + "'");
         }
         InterfaceElementPtr impl = nodeDef->getImplementation(shadergen.getTarget());
         if (!impl)
@@ -395,38 +396,20 @@ void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& eleme
     }
 }
 
-ValueElementPtr findNodeDefChild(const string& path, DocumentPtr doc, const string& target)
+InputPtr getNodeDefInput(InputPtr nodeInput, const string& target)
 {
-    if (path.empty() || !doc)
+    ElementPtr parent = nodeInput ? nodeInput->getParent() : nullptr;
+    NodePtr node = parent ? parent->asA<Node>() : nullptr;
+    if (node)
     {
-        return nullptr;
-    }
-    ElementPtr pathElement = doc->getDescendant(path);
-    if (!pathElement || pathElement == doc)
-    {
-        return nullptr;
-    }
-    ElementPtr parent = pathElement->getParent();
-    if (!parent || parent == doc)
-    {
-        return nullptr;
+        NodeDefPtr nodeDef = node->getNodeDef(target);
+        if (nodeDef)
+        {
+            return nodeDef->getActiveInput(nodeInput->getName());
+        }
     }
 
-    // Note that we must cast to a specific type derived instance as getNodeDef() is not
-    // a virtual method which is overridden in derived classes.
-    NodePtr node = parent->asA<Node>();
-    NodeDefPtr nodeDef = node ? node->getNodeDef(target) : nullptr;
-    if (!nodeDef)
-    {
-        return nullptr;
-    }
-
-    // Use the path element name to look up in the equivalent element
-    // in the nodedef as only the nodedef elements contain the information.
-    const string& valueElementName = pathElement->getName();
-    ValueElementPtr valueElement = nodeDef->getActiveValueElement(valueElementName);
-
-    return valueElement;
+    return nullptr;
 }
 
 namespace

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -12,11 +12,6 @@
 #include <MaterialXGenShader/Export.h>
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Element.h>
-#include <MaterialXCore/Interface.h>
-
-#include <MaterialXFormat/File.h>
-#include <MaterialXFormat/XmlIo.h>
 
 #include <unordered_set>
 
@@ -57,21 +52,20 @@ MX_GENSHADER_API bool elementRequiresShading(ConstTypedElementPtr element);
 /// @param includeReferencedGraphs Whether to check for outputs on referenced graphs
 /// @param processedSources List of elements examined. 
 MX_GENSHADER_API void findRenderableMaterialNodes(ConstDocumentPtr doc,
-                                 vector<TypedElementPtr>& elements, 
-                                 bool includeReferencedGraphs,
-                                 std::unordered_set<ElementPtr>& processedSources);
+                                                  vector<TypedElementPtr>& elements, 
+                                                  bool includeReferencedGraphs,
+                                                  std::unordered_set<ElementPtr>& processedSources);
 
 /// Find any elements which may be renderable from within a document.
 /// This includes all outputs on node graphs and shader references which are not
 /// part of any included library. Light shaders are not considered to be renderable.
 /// The option to include node graphs referened by shader references is disabled by default.
 MX_GENSHADER_API void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& elements,
-                            bool includeReferencedGraphs = false);
+                                             bool includeReferencedGraphs = false);
 
-/// Given a path to a element, find the corresponding element with the same name
-/// on an associated nodedef if it exists. A target string should be provided
-/// if the path is to a Node as definitions for Nodes can be target specific.
-MX_GENSHADER_API ValueElementPtr findNodeDefChild(const string& path, DocumentPtr doc, const string& target);
+/// Given a node input, return the corresponding input within its matching nodedef.
+/// The optional target string can be used to guide the selection of nodedef declarations.
+MX_GENSHADER_API InputPtr getNodeDefInput(InputPtr nodeInput, const string& target);
 
 /// Perform token substitutions on the given source string, using the given substituation map.
 /// Tokens are required to start with '$' and can only consist of alphanumeric characters.

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXRender/Util.h>
 
-#include <MaterialXCore/Util.h>
-#include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 
 namespace MaterialX
@@ -99,25 +97,34 @@ ShaderPtr createBlurShader(GenContext& context,
     return createShader(shaderName, blurContext, output);
 }
 
-unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& uiProperties)
+unsigned int getUIProperties(InputPtr input, const string& target, UIProperties& uiProperties)
 {
-    if (!nodeDefElement)
+    if (!input)
     {
         return 0;
     }
+    InputPtr nodeDefInput = getNodeDefInput(input, target);
+    if (nodeDefInput)
+    {
+        input = nodeDefInput;
+    }
 
     unsigned int propertyCount = 0;
-    uiProperties.uiName = nodeDefElement->getAttribute(ValueElement::UI_NAME_ATTRIBUTE);
+    uiProperties.uiName = input->getAttribute(ValueElement::UI_NAME_ATTRIBUTE);
     if (!uiProperties.uiName.empty())
-        propertyCount++;
-
-    uiProperties.uiFolder = nodeDefElement->getAttribute(ValueElement::UI_FOLDER_ATTRIBUTE);
-    if (!uiProperties.uiFolder.empty())
-        propertyCount++;
-
-    if (nodeDefElement->getIsUniform())
     {
-        string enumString = nodeDefElement->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+        propertyCount++;
+    }
+
+    uiProperties.uiFolder = input->getAttribute(ValueElement::UI_FOLDER_ATTRIBUTE);
+    if (!uiProperties.uiFolder.empty())
+    {
+        propertyCount++;
+    }
+
+    if (input->getIsUniform())
+    {
+        string enumString = input->getAttribute(ValueElement::ENUM_ATTRIBUTE);
         if (!enumString.empty())
         {
             uiProperties.enumeration = splitString(enumString, ",");
@@ -125,10 +132,10 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
                 propertyCount++;
         }
 
-        const string& enumerationValues = nodeDefElement->getAttribute(ValueElement::ENUM_VALUES_ATTRIBUTE);
+        const string& enumerationValues = input->getAttribute(ValueElement::ENUM_VALUES_ATTRIBUTE);
         if (!enumerationValues.empty())
         {
-            const string& elemType = nodeDefElement->getType();
+            const string& elemType = input->getType();
             const TypeDesc* typeDesc = TypeDesc::get(elemType);
             if (typeDesc->isScalar() || typeDesc->isFloat2() || typeDesc->isFloat3() ||
                 typeDesc->isFloat4())
@@ -166,10 +173,10 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
         }
     }
 
-    const string& uiMinString = nodeDefElement->getAttribute(ValueElement::UI_MIN_ATTRIBUTE);
+    const string& uiMinString = input->getAttribute(ValueElement::UI_MIN_ATTRIBUTE);
     if (!uiMinString.empty())
     {
-        ValuePtr value = Value::createValueFromStrings(uiMinString, nodeDefElement->getType());
+        ValuePtr value = Value::createValueFromStrings(uiMinString, input->getType());
         if (value)
         {
             uiProperties.uiMin = value;
@@ -177,10 +184,10 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
         }
     }
 
-    const string& uiMaxString = nodeDefElement->getAttribute(ValueElement::UI_MAX_ATTRIBUTE);
+    const string& uiMaxString = input->getAttribute(ValueElement::UI_MAX_ATTRIBUTE);
     if (!uiMaxString.empty())
     {
-        ValuePtr value = Value::createValueFromStrings(uiMaxString, nodeDefElement->getType());
+        ValuePtr value = Value::createValueFromStrings(uiMaxString, input->getType());
         if (value)
         {
             uiProperties.uiMax = value;
@@ -188,10 +195,10 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
         }
     }
 
-    const string& uiSoftMinString = nodeDefElement->getAttribute(ValueElement::UI_SOFT_MIN_ATTRIBUTE);
+    const string& uiSoftMinString = input->getAttribute(ValueElement::UI_SOFT_MIN_ATTRIBUTE);
     if (!uiSoftMinString.empty())
     {
-        ValuePtr value = Value::createValueFromStrings(uiSoftMinString, nodeDefElement->getType());
+        ValuePtr value = Value::createValueFromStrings(uiSoftMinString, input->getType());
         if (value)
         {
             uiProperties.uiSoftMin = value;
@@ -199,10 +206,10 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
         }
     }
 
-    const string& uiSoftMaxString = nodeDefElement->getAttribute(ValueElement::UI_SOFT_MAX_ATTRIBUTE);
+    const string& uiSoftMaxString = input->getAttribute(ValueElement::UI_SOFT_MAX_ATTRIBUTE);
     if (!uiSoftMaxString.empty())
     {
-        ValuePtr value = Value::createValueFromStrings(uiSoftMaxString, nodeDefElement->getType());
+        ValuePtr value = Value::createValueFromStrings(uiSoftMaxString, input->getType());
         if (value)
         {
             uiProperties.uiSoftMax = value;
@@ -210,10 +217,10 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
         }
     }
 
-    const string& uiStepString = nodeDefElement->getAttribute(ValueElement::UI_STEP_ATTRIBUTE);
+    const string& uiStepString = input->getAttribute(ValueElement::UI_STEP_ATTRIBUTE);
     if (!uiStepString.empty())
     {
-        ValuePtr value = Value::createValueFromStrings(uiStepString, nodeDefElement->getType());
+        ValuePtr value = Value::createValueFromStrings(uiStepString, input->getType());
         if (value)
         {
             uiProperties.uiStep = value;
@@ -221,7 +228,7 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
         }
     }
 
-    const string& uiAdvancedString = nodeDefElement->getAttribute(ValueElement::UI_ADVANCED_ATTRIBUTE);
+    const string& uiAdvancedString = input->getAttribute(ValueElement::UI_ADVANCED_ATTRIBUTE);
     uiProperties.uiAdvanced = (uiAdvancedString == "true");
     if (!uiAdvancedString.empty())
     {
@@ -231,51 +238,90 @@ unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& 
     return propertyCount;
 }
 
-unsigned int getUIProperties(const string& path, DocumentPtr doc, const string& target, UIProperties& uiProperties)
+void createUIPropertyGroups(DocumentPtr doc, const VariableBlock& block, UIPropertyGroup& groups,
+                            UIPropertyGroup& unnamedGroups, const string& pathSeparator, bool showAllInputs)
 {
-    ValueElementPtr valueElement = findNodeDefChild(path, doc, target);
-    if (valueElement)
+    // Generated an ordered map of shader inputs.
+    using ShaderInputPair = std::pair<InputPtr, ShaderPort*>;
+    std::map<int, ShaderInputPair> shaderInputMap;
+    for (ShaderPort* variable : block.getVariableOrder())
     {
-        return getUIProperties(valueElement, uiProperties);
+        if (!variable->getValue())
+        {
+            continue;
+        }
+
+        // Get the input associated with this variable.
+        ElementPtr pathElement = doc->getDescendant(variable->getPath());
+        InputPtr input = pathElement ? pathElement->asA<Input>() : nullptr;
+
+        // Redirect to interface inputs when present.
+        if (input)
+        {
+            InputPtr interfaceInput = input->getInterfaceInput();
+            if (interfaceInput)
+            {
+                input = interfaceInput;
+            }
+        }
+
+        // If requested, add missing inputs from the associated nodedef.
+        if (showAllInputs && !input)
+        {
+            string nodePath = parentNamePath(variable->getPath());
+            ElementPtr parent = doc->getDescendant(nodePath);
+            if (parent)
+            {
+                NodePtr parentNode = parent->asA<Node>();
+                if (parentNode)
+                {
+                    StringVec pathVec = splitNamePath(variable->getPath());
+                    input = parentNode->addInputFromNodeDef(pathVec[pathVec.size() - 1]);
+                }
+            }
+        }
+
+        // Add the shader input if unique.
+        if (input)
+        {
+            int treeIndex = input->getTreeIndex();
+            if (shaderInputMap.count(treeIndex))
+            {
+                continue;
+            }
+            shaderInputMap[treeIndex] = ShaderInputPair(input, variable);
+        }
     }
-    return 0;
-}
 
-void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocument, TypedElementPtr materialElement,
-                            const string& pathSeparator, UIPropertyGroup& groups,
-                            UIPropertyGroup& unnamedGroups, ShaderPort* uniform)
-{
-    if (uniformElement && uniformElement->isA<ValueElement>())
+    // Generate UI properties for each shader input
+    for (const auto& it : shaderInputMap)
     {
+        // Retrieve the shader input pair.
+        ShaderInputPair pair = it.second;
+
+        // Gather the UI properties for this input.
         UIPropertyItem item;
-        item.variable = uniform;
-        item.value = uniformElement->asA<ValueElement>()->getValue();
-        getUIProperties(uniformElement->getNamePath(), contentDocument, EMPTY_STRING, item.ui);
+        item.variable = pair.second;
+        getUIProperties(pair.first, EMPTY_STRING, item.ui);
 
-        string parentLabel;
-        ElementPtr parent = uniformElement->getParent();
-        if (parent && parent != contentDocument && parent != materialElement)
-        {
-            parentLabel = parent->getNamePath();
-        }
-        if (!materialElement || parentLabel == materialElement->getAttribute(PortElement::NODE_NAME_ATTRIBUTE))
-        {
-            parentLabel.clear();
-        }
-        if (!parentLabel.empty())
-        {
-            parentLabel += pathSeparator;
-        }
-
+        // Generate the item label.
         if (!item.ui.uiName.empty())
         {
-            item.label = parentLabel + item.ui.uiName;
+            item.label = item.ui.uiName;
         }
         if (item.label.empty())
         {
-            item.label = parentLabel + uniformElement->getName();
+            item.label = pair.first->getName();
         }
 
+        // Prepend a parent label for unlabeled node inputs.
+        ElementPtr parent = pair.first->getParent();
+        if (item.ui.uiFolder.empty() && parent && parent->isA<Node>())
+        {
+            item.label = parent->getName() + pathSeparator + item.label;
+        }
+
+        // Add the new item.
         if (!item.ui.uiFolder.empty())
         {
             groups.emplace(item.ui.uiFolder, item);
@@ -283,42 +329,6 @@ void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocume
         else
         {
             unnamedGroups.emplace(EMPTY_STRING, item);
-        }
-    }
-}
-
-void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
-                            const string& pathSeparator, UIPropertyGroup& groups, UIPropertyGroup& unnamedGroups, bool addFromDefinition)
-{
-    const vector<ShaderPort*>& blockVariables = block.getVariableOrder();
-    for (const auto& blockVariable : blockVariables)
-    {
-        const string& path = blockVariable->getPath();
-
-        if (!blockVariable->getPath().empty())
-        {
-            // Optionally add the input if it does not exist
-            ElementPtr uniformElement = contentDocument->getDescendant(path);
-            if (!uniformElement && addFromDefinition)
-            {
-                string nodePath = parentNamePath(path);
-                ElementPtr uniformParent = contentDocument->getDescendant(nodePath);
-                if (uniformParent)
-                {
-                    NodePtr uniformNode = uniformParent->asA<Node>();
-                    if (uniformNode)
-                    {
-                        StringVec pathVec = splitNamePath(path);
-                        uniformNode->addInputFromNodeDef(pathVec[pathVec.size() - 1]);
-                    }
-                }
-            }
-
-            uniformElement = contentDocument->getDescendant(path);
-            if (uniformElement && blockVariable->getValue())
-            {
-                createUIPropertyGroups(uniformElement, contentDocument, materialElement, pathSeparator, groups, unnamedGroups, blockVariable);
-            }
         }
     }
 }

--- a/source/MaterialXRender/Util.h
+++ b/source/MaterialXRender/Util.h
@@ -90,20 +90,14 @@ struct MX_RENDER_API UIProperties
     bool uiAdvanced = false;
 };
 
-/// Get the UI properties for a given nodedef element.
+/// Get the UI properties for a given input element and target.
 /// Returns the number of properties found.
-MX_RENDER_API unsigned int getUIProperties(ConstValueElementPtr nodeDefElement, UIProperties& uiProperties);
-
-/// Get the UI properties for a given element path. If the path is to a node, a target
-/// identifier can be provided.
-/// Returns the number of properties found.
-MX_RENDER_API unsigned int getUIProperties(const string& path, DocumentPtr doc, const string& target, UIProperties& uiProperties);
+MX_RENDER_API unsigned int getUIProperties(InputPtr input, const string& target, UIProperties& uiProperties);
 
 /// Interface for holding the UI properties associated shader port
 struct MX_RENDER_API UIPropertyItem
 {
     string label;
-    ValuePtr value;
     ShaderPort* variable = nullptr;
     UIProperties ui;
 };
@@ -111,17 +105,10 @@ struct MX_RENDER_API UIPropertyItem
 /// A grouping of property items by name
 using UIPropertyGroup = std::multimap<string, UIPropertyItem>;
 
-/// Utility to group UI properties items based on Element group name from an element.
-/// Returns a list of named and unnamed groups.
-MX_RENDER_API void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocument, TypedElementPtr materialElement,
-                            const string& pathSeparator, UIPropertyGroup& groups,
-                            UIPropertyGroup& unnamedGroups, ShaderPort* uniform = nullptr);
-
 /// Utility to group UI properties items based on Element group name from a VariableBlock.
 /// Returns a list of named and unnamed groups.
-MX_RENDER_API void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
-                            const string& pathSeparator, UIPropertyGroup& groups,
-                            UIPropertyGroup& unnamedGroups, bool addFromDefinition);
+MX_RENDER_API void createUIPropertyGroups(DocumentPtr doc, const VariableBlock& block, UIPropertyGroup& groups,
+                                          UIPropertyGroup& unnamedGroups, const string& pathSeparator, bool showAllInputs);
 
 /// @}
 

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -11,6 +11,8 @@
 
 #include <MaterialXGenShader/DefaultColorManagementSystem.h>
 
+#include <MaterialXFormat/XmlIo.h>
+
 namespace MaterialX
 {
 

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -611,7 +611,9 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
                         }
 
                         mx::UIProperties uiProperties;
-                        if (getUIProperties(path, doc, target, uiProperties) > 0)
+                        mx::ElementPtr pathElement = doc->getDescendant(path);
+                        mx::InputPtr input = pathElement ? pathElement->asA<mx::Input>() : nullptr;
+                        if (getUIProperties(input, target, uiProperties) > 0)
                         {
                             log << "Program Uniform: " << uniform.first << ". Path: " << path;
                             if (!uiProperties.uiName.empty())

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -663,7 +663,7 @@ void PropertyEditor::updateContents(Viewer* viewer)
     // Shading model display
     mx::TypedElementPtr elem = material->getElement();
     std::string shaderName = elem ? elem->getCategory() : mx::EMPTY_STRING;
-    if (!shaderName.empty() && shaderName != "surface")
+    if (elem->isA<mx::Node>() && !shaderName.empty() && shaderName != "surface")
     {
         ng::Widget* twoColumns = new ng::Widget(_container);
         twoColumns->setLayout(_gridLayout2);
@@ -681,34 +681,34 @@ void PropertyEditor::updateContents(Viewer* viewer)
         mx::UIPropertyGroup groups;
         mx::UIPropertyGroup unnamedGroups;
         const std::string pathSeparator(":");
-        mx::createUIPropertyGroups(*publicUniforms, material->getDocument(), elem,
-                                    pathSeparator, groups, unnamedGroups, false); 
+        bool showAllInputs = viewer->getShowAllInputs();
+        mx::createUIPropertyGroups(elem->getDocument(), *publicUniforms, groups, unnamedGroups,
+                                   pathSeparator, showAllInputs); 
 
+        // First add items with named groups.
         std::string previousFolder;
-        // Make all inputs editable for now. Could make this read-only as well.
-        const bool editable = true;
         for (auto it = groups.begin(); it != groups.end(); ++it)
         {
             const std::string& folder = it->first;
             const mx::UIPropertyItem& item = it->second;
 
-            // Find out if the uniform is editable. Some
-            // inputs may be optimized out during compilation.
+            // Verify that the uniform is editable, as some inputs may be optimized out during compilation.
             if (material->findUniform(item.variable->getPath()))
             {
-                addItemToForm(item, (previousFolder == folder) ? mx::EMPTY_STRING : folder, _container, viewer, editable);
+                addItemToForm(item, (previousFolder == folder) ? mx::EMPTY_STRING : folder, _container, viewer, true);
                 previousFolder.assign(folder);
                 addedItems = true;
             }
         }
 
+        // Then add items with unnamed groups.
         bool addedLabel = false;
         for (auto it2 = unnamedGroups.begin(); it2 != unnamedGroups.end(); ++it2)
         {
             const mx::UIPropertyItem& item = it2->second;
             if (material->findUniform(item.variable->getPath()))
             {
-                addItemToForm(item, addedLabel ? mx::EMPTY_STRING : "Shader Inputs", _container, viewer, editable);
+                addItemToForm(item, addedLabel ? mx::EMPTY_STRING : "Shader Inputs", _container, viewer, true);
                 addedLabel = true;
                 addedItems = true;
             }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -18,7 +18,6 @@
 #include <MaterialXFormat/Environ.h>
 #include <MaterialXFormat/Util.h>
 
-#include <nanogui/combobox.h>
 #include <nanogui/glutil.h>
 #include <nanogui/messagedialog.h>
 #include <nanogui/vscrollpanel.h>
@@ -233,6 +232,7 @@ Viewer::Viewer(const std::string& materialFilename,
     _unitRegistry(mx::UnitConverterRegistry::create()),
     _splitByUdims(true),
     _mergeMaterials(false),
+    _showAllInputs(false),
     _renderTransparency(true),
     _renderDoubleSided(true),
     _outlineSelection(false),
@@ -552,7 +552,10 @@ void Viewer::assignMaterial(mx::MeshPartitionPtr geometry, MaterialPtr material)
     if (geometry == getSelectedGeometry())
     {
         setSelectedMaterial(material);
-        updateDisplayedProperties();
+        if (material)
+        {
+            updateDisplayedProperties();
+        }
     }
 }
 
@@ -591,7 +594,6 @@ void Viewer::createLoadMaterialsInterface(Widget* parent, const std::string& lab
         if (!filename.empty())
         {
             _materialFilename = filename;
-            assignMaterial(getSelectedGeometry(), nullptr);
             loadDocument(_materialFilename, _stdLib);
         }
         mProcessEvents = true;
@@ -706,6 +708,13 @@ void Viewer::createAdvancedSettings(Widget* parent)
     mergeMaterialsBox->setCallback([this](bool enable)
     {
         _mergeMaterials = enable;
+    });    
+
+    ng::CheckBox* showInputsBox = new ng::CheckBox(advancedPopup, "Show All Inputs");
+    showInputsBox->setChecked(_showAllInputs);
+    showInputsBox->setCallback([this](bool enable)
+    {
+        _showAllInputs = enable;
     });    
 
     Widget* unitGroup = new Widget(advancedPopup);
@@ -1673,7 +1682,7 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
             }
             assignMaterial(getSelectedGeometry(), getSelectedMaterial());
             updateMaterialSelectionUI();
-       }
+        }
         return true;
     }
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -95,6 +95,12 @@ class Viewer : public ng::Screen
         _modifiers = modifiers;
     }
 
+    // Return true if all inputs should be shown in the property editor.
+    bool getShowAllInputs() const
+    {
+        return _showAllInputs;
+    }
+
     // Return the underlying NanoGUI window.
     ng::Window* getWindow() const
     {
@@ -311,6 +317,7 @@ class Viewer : public ng::Screen
 
     // Material options
     bool _mergeMaterials;
+    bool _showAllInputs;
 
     // Unit options
     mx::StringVec _distanceUnitOptions;

--- a/source/PyMaterialX/PyMaterialXGenShader/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyUtil.cpp
@@ -20,7 +20,7 @@ void bindPyUtil(py::module& mod)
     mod.def("findRenderableMaterialNodes", &mx::findRenderableMaterialNodes);
     mod.def("findRenderableMaterialNodes", &mx::findRenderableMaterialNodes);
     mod.def("findRenderableElements", &mx::findRenderableElements);
-    mod.def("findNodeDefChild", &mx::findNodeDefChild);
+    mod.def("getNodeDefInput", &mx::getNodeDefInput);
     mod.def("tokenSubstitution", &mx::tokenSubstitution);
     mod.def("getUdimCoordinates", &mx::getUdimCoordinates);
     mod.def("getUdimScaleAndOffset", &mx::getUdimScaleAndOffset);


### PR DESCRIPTION
- Update shader code and UI generation to support compound nodegraphs with input bindings.
- Convert the standard_surface_brick_procedural and standard_surface_marble_solid examples to compound nodegraphs with input bindings, giving them an improved UI in the property editor.
- Add viewer option "Show All Inputs", which allows unbound shader inputs to be displayed in the property editor.

Standard Surface Brick in MaterialXView with UI:
![StandardSurface_BrickProcedural_UI](https://user-images.githubusercontent.com/6146549/118420013-89d69300-b672-11eb-96c5-6c64a934811b.png)

Standard Surface Marble in MaterialXView with UI:
![StandardSurface_MarbleSolid_UI](https://user-images.githubusercontent.com/6146549/118420022-8fcc7400-b672-11eb-90db-a48821312907.png)