### PR TITLE
Clarify opacity logic in Standard Surface

### DIFF
--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -309,14 +309,10 @@
     <luminance name="opacity_luminance" type="color3">
       <input name="in" type="color3" interfacename="opacity" />
     </luminance>
-    <swizzle name="opacity_luminance_r" type="float">
-      <input name="in" type="color3" nodename="opacity_luminance" />
-      <param name="channels" type="string" value="r" />
-    </swizzle>
     <surface name="shader_constructor" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="coat_layer" />
       <input name="edf" type="EDF" nodename="emission_edf" />
-      <input name="opacity" type="float" nodename="opacity_luminance_r" />
+      <input name="opacity" type="float" nodename="opacity_luminance" channels="r" />
     </surface>
 
     <!-- Output -->


### PR DESCRIPTION
This changelist clarifies the opacity logic in the Standard Surface nodegraph, replacing a <swizzle> node containing an unused "param" element with the equivalent channel-specific connection.