### PR TITLE
Improvements to shader translation and baking

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -516,41 +516,13 @@ void getUdimScaleAndOffset(const vector<Vector2>& udimCoordinates, Vector2& scal
     offsetUV[1] = -minUV[1];
 }
 
-NodePtr connectsToNodeOfCategory(OutputPtr output, const StringSet& categories)
+NodePtr connectsToWorldSpaceNode(OutputPtr output)
 {
-    ElementPtr connectedElement = output ? output->getConnectedNode() : nullptr;
-    NodePtr connectedNode = connectedElement ? connectedElement->asA<Node>() : nullptr;
-    if (!connectedNode)
-    {
-        return nullptr;
-    }
-    
-    // Check the direct node type
-    if (categories.count(connectedNode->getCategory()))
+    const StringSet WORLD_SPACE_NODE_CATEGORIES{ "normalmap" };
+    NodePtr connectedNode = output ? output->getConnectedNode() : nullptr;
+    if (connectedNode && WORLD_SPACE_NODE_CATEGORIES.count(connectedNode->getCategory()))
     {
         return connectedNode;
-    }
-
-    // Check if it's a definition which has a root which of the node type
-    NodeDefPtr nodedef = connectedNode->getNodeDef();
-    if (nodedef)
-    {
-        InterfaceElementPtr inter = nodedef->getImplementation();
-        if (inter)
-        {
-            NodeGraphPtr graph = inter->asA<NodeGraph>();
-            if (graph)
-            {
-                for (OutputPtr outputPtr : graph->getOutputs())
-                {
-                    NodePtr outputNode = outputPtr->getConnectedNode();
-                    if (outputNode && categories.count(outputNode->getCategory()))
-                    {
-                        return outputNode;
-                    }
-                }
-            }
-        }
     }
     return nullptr;
 }

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -81,11 +81,11 @@ MX_GENSHADER_API vector<Vector2> getUdimCoordinates(const StringVec& udimIdentif
 /// 0..1 space.
 MX_GENSHADER_API void getUdimScaleAndOffset(const vector<Vector2>& udimCoordinates, Vector2& scaleUV, Vector2& offsetUV);
 
-/// Check if an output is connected to nodes of a given category.
+/// Determine whether the given output is directly connected to a node that
+/// generates world-space coordinates (e.g. the "normalmap" node).
 /// @param output Output to check
-/// @param categories Categories to check
 /// @return Return the node if found.
-MX_GENSHADER_API NodePtr connectsToNodeOfCategory(OutputPtr output, const StringSet& categories);
+MX_GENSHADER_API NodePtr connectsToWorldSpaceNode(OutputPtr output);
 
 /// Returns true if there is are any value elements with a given set of attributes either on the
 /// starting node or any graph upsstream of that node.

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -21,7 +21,6 @@ namespace {
 const string SRGB_TEXTURE = "srgb_texture";
 const string LIN_REC709 = "lin_rec709";
 const string BAKED_POSTFIX = "_baked";
-const string NORMAL_MAP_CATEGORY = "normalmap";
 
 StringVec getRenderablePaths(ConstDocumentPtr doc)
 {
@@ -117,24 +116,19 @@ void TextureBaker::bakeShaderInputs(NodePtr material, NodePtr shader, GenContext
     }
 
     std::set<OutputPtr> bakedOutputs;
-    StringSet categories;
-    categories.insert(NORMAL_MAP_CATEGORY);
-
     for (InputPtr input : shader->getInputs())
     {
         OutputPtr output = input->getConnectedOutput();
         if (output && !bakedOutputs.count(output))
         {
             bakedOutputs.insert(output);
-            NodePtr normalMapNode = connectsToNodeOfCategory(output, categories);
-            if (normalMapNode)
+
+            // When possible, nodes with world-space outputs are applied outside of the baking process.
+            NodePtr worldSpaceNode = connectsToWorldSpaceNode(output);
+            if (worldSpaceNode)
             {
-                NodePtr sampleNode = output->getParent()->getChild(output->getNodeName())->asA<Node>();
-                if (sampleNode == normalMapNode)
-                {
-                    output->setNodeName(sampleNode->getInput("in")->getNodeName());
-                }
-                _worldSpaceShaderInputs[input->getName()] = sampleNode;
+                output->setConnectedNode(worldSpaceNode->getConnectedNode("in"));
+                _worldSpaceNodes[input->getName()] = worldSpaceNode;
             }
             FilePath texturefilepath = FilePath(_outputImagePath / generateTextureFilename(output, shader->getName(), udim));
             bakeGraphOutput(output, context, texturefilepath);
@@ -364,23 +358,22 @@ DocumentPtr TextureBaker::bakeMaterial(NodePtr shader, const StringVec& udimSet)
                 InputPtr input = bakedImage->addInput("file", "filename");
                 input->setValueString(generateTextureFilename(output, shader->getName(), udimSet.empty() ? EMPTY_STRING : UDIM_TOKEN));
 
-                // Check if is a normal node and transform normals into world space
-                auto worldSpaceShaderInput = _worldSpaceShaderInputs.find(sourceInput->getName());
-                if (worldSpaceShaderInput != _worldSpaceShaderInputs.end())
+                // Reconstruct any world-space nodes that were excluded from the baking process.
+                auto worldSpacePair = _worldSpaceNodes.find(sourceInput->getName());
+                if (worldSpacePair != _worldSpaceNodes.end())
                 {
-                    NodePtr origNormalMapNode = worldSpaceShaderInput->second;
-                    NodePtr normalMapNode = bakedNodeGraph->addNode(NORMAL_MAP_CATEGORY, sourceName + BAKED_POSTFIX + "_map", sourceType);
-                    if (origNormalMapNode && (origNormalMapNode->getCategory() == NORMAL_MAP_CATEGORY))
+                    NodePtr origWorldSpaceNode = worldSpacePair->second;
+                    if (origWorldSpaceNode)
                     {
-                        normalMapNode->copyContentFrom(origNormalMapNode);
+                        NodePtr newWorldSpaceNode = bakedNodeGraph->addNode(origWorldSpaceNode->getCategory(), sourceName + BAKED_POSTFIX + "_map", sourceType);
+                        newWorldSpaceNode->copyContentFrom(origWorldSpaceNode);
+                        InputPtr mapInput = newWorldSpaceNode->getInput("in");
+                        if (mapInput)
+                        {
+                            mapInput->setNodeName(bakedImage->getName());
+                        }
+                        bakedImage = newWorldSpaceNode;
                     }
-                    InputPtr mapInput = normalMapNode->getInput("in");
-                    if (!mapInput)
-                    {
-                        mapInput = normalMapNode->addInput("in", sourceType);
-                    }
-                    mapInput->setNodeName(bakedImage->getName());
-                    bakedImage = normalMapNode;
                 }
 
                 // Add the graph output.
@@ -423,7 +416,7 @@ DocumentPtr TextureBaker::bakeMaterial(NodePtr shader, const StringVec& udimSet)
     // Clear cached information after each material bake
     _bakedImageMap.clear();
     _bakedConstantMap.clear();
-    _worldSpaceShaderInputs.clear();
+    _worldSpaceNodes.clear();
     _material = nullptr;
 
     // Return the baked document on success.

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -230,8 +230,6 @@ class MX_RENDERGLSL_API TextureBaker : public GlslRenderer
     using BakedImageMap = std::unordered_map<OutputPtr, BakedImageVec>;
     using BakedConstantMap = std::unordered_map<OutputPtr, BakedConstant>;
 
-    using WorldSpaceInputs = std::unordered_map<string, NodePtr>;
-
   protected:
     string _extension;
     string _colorSpace;
@@ -247,9 +245,10 @@ class MX_RENDERGLSL_API TextureBaker : public GlslRenderer
 
     ShaderGeneratorPtr _generator;
     ConstNodePtr _material;
-    WorldSpaceInputs _worldSpaceShaderInputs;
     BakedImageMap _bakedImageMap;
     BakedConstantMap _bakedConstantMap;
+
+    std::unordered_map<string, NodePtr> _worldSpaceNodes;
 };
 
 } // namespace MaterialX

--- a/source/PyMaterialX/PyMaterialXGenShader/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyUtil.cpp
@@ -24,6 +24,6 @@ void bindPyUtil(py::module& mod)
     mod.def("tokenSubstitution", &mx::tokenSubstitution);
     mod.def("getUdimCoordinates", &mx::getUdimCoordinates);
     mod.def("getUdimScaleAndOffset", &mx::getUdimScaleAndOffset);
-    mod.def("connectsToNodeOfCategory", &mx::connectsToNodeOfCategory);
+    mod.def("connectsToWorldSpaceNode", &mx::connectsToWorldSpaceNode);
     mod.def("hasElementAttributes", &mx::hasElementAttributes);
 }


### PR DESCRIPTION
- Add support for graph outputs with multiple bindings in shader translation.
- Remove extra dot nodes that were created in shader translation, as they're no longer needed in MaterialX v1.38.
- Simplify the handling of world-space nodes in shader translation and texture baking.
- Rename MaterialX::connectsToNodeOfCategory to MaterialX::connectsToWorldSpaceNode for clarity.