### PR TITLE
Improvements to viewer commands

### DIFF
--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -64,10 +64,10 @@ By default, the MaterialX viewer loads and saves image files using `stb_image`, 
 ### Keyboard Shortcuts
 
 - `R`: Reload the current material from file.  Hold `SHIFT` to reload all standard libraries as well.
-- `S`: Save the current GLSL shader source to file.
+- `G`: Save the current GLSL shader source to file.
 - `O`: Save the current OSL shader source to file.
 - `M`: Save the current MDL shader source to file.
-- `L`: Load shader source from file.  Editing the source files before loading provides a way to debug and experiment with shader source code.
+- `L`: Load GLSL shader source from file.  Editing the source files before loading provides a way to debug and experiment with shader source code.
 - `D`: Save each node graph in the current material as a DOT file.  See www.graphviz.org for more details on this format.
 - `F`: Capture the current frame and save to file.
 - `W`: Create a wedge rendering and save to file.

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -559,6 +559,18 @@ void Viewer::assignMaterial(mx::MeshPartitionPtr geometry, MaterialPtr material)
     }
 }
 
+mx::FilePath Viewer::getBaseOutputPath()
+{
+    mx::FilePath baseFilename = _searchPath.find(_materialFilename);
+    baseFilename.removeExtension();
+    mx::FilePath outputPath = mx::getEnviron("MATERIALX_VIEW_OUTPUT_PATH");
+    if (!outputPath.isEmpty())
+    {
+        baseFilename = outputPath / baseFilename.getBaseName();
+    }
+    return baseFilename;
+}
+
 void Viewer::createLoadMeshInterface(Widget* parent, const std::string& label)
 {
     ng::Button* meshButton = new ng::Button(parent, label);
@@ -1363,30 +1375,32 @@ void Viewer::saveShaderSource(mx::GenContext& context)
             mx::ShaderPtr shader = createShader(elem->getNamePath(), context, elem);
             if (shader)
             {
-                const std::string path = mx::getEnviron("MATERIALX_VIEW_OUTPUT_PATH");
-                const std::string baseName = (path.empty() ? _searchPath[0] : mx::FilePath(path)) / elem->getName();
+                mx::FilePath sourceFilename = getBaseOutputPath();
                 if (context.getShaderGenerator().getTarget() == mx::GlslShaderGenerator::TARGET)
                 {
-                    const std::string& vertexShader = shader->getSourceCode(mx::Stage::VERTEX);
                     const std::string& pixelShader = shader->getSourceCode(mx::Stage::PIXEL);
-                    writeTextFile(vertexShader, baseName + "_vs.glsl");
-                    writeTextFile(pixelShader, baseName + "_ps.glsl");
-                    new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved GLSL source: ", baseName);
+                    const std::string& vertexShader = shader->getSourceCode(mx::Stage::VERTEX);
+                    writeTextFile(pixelShader, sourceFilename.asString() + "_ps.glsl");
+                    writeTextFile(vertexShader, sourceFilename.asString() + "_vs.glsl");
+                    new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved GLSL source: ",
+                        sourceFilename.asString() + "_*.glsl");
                 }
 #if MATERIALX_BUILD_GEN_OSL
                 else if (context.getShaderGenerator().getTarget() == mx::OslShaderGenerator::TARGET)
                 {
                     const std::string& pixelShader = shader->getSourceCode(mx::Stage::PIXEL);
-                    writeTextFile(pixelShader, baseName + ".osl");
-                    new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved OSL source: ", baseName);
+                    sourceFilename.addExtension("osl");
+                    writeTextFile(pixelShader, sourceFilename);
+                    new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved OSL source: ", sourceFilename);
                 }
 #endif
 #if MATERIALX_BUILD_GEN_MDL
                 else if (context.getShaderGenerator().getTarget() == mx::MdlShaderGenerator::TARGET)
                 {
                     const std::string& pixelShader = shader->getSourceCode(mx::Stage::PIXEL);
-                    writeTextFile(pixelShader, baseName + ".mdl");
-                    new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved MDL source: ", baseName);
+                    sourceFilename.addExtension("mdl");
+                    writeTextFile(pixelShader, sourceFilename);
+                    new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved MDL source: ", sourceFilename);
                 }
 #endif
             }
@@ -1406,12 +1420,10 @@ void Viewer::loadShaderSource()
         mx::TypedElementPtr elem = material ? material->getElement() : nullptr;
         if (elem)
         {
-            const std::string path = mx::getEnviron("MATERIALX_VIEW_OUTPUT_PATH");
-            const std::string baseName = (path.empty() ? _searchPath[0] : mx::FilePath(path)) / elem->getName();
-            std::string vertexShaderFile = baseName + "_vs.glsl";
-            std::string pixelShaderFile = baseName + "_ps.glsl";
-            bool hasTransparency = false;
-            if (material->loadSource(vertexShaderFile, pixelShaderFile, hasTransparency))
+            mx::FilePath sourceFilename = getBaseOutputPath();
+            mx::FilePath pixelSourceFilename = sourceFilename.asString() + "_ps.glsl";
+            mx::FilePath vertexSourceFilename = sourceFilename.asString() + "_vs.glsl";
+            if (material->loadSource(vertexSourceFilename, pixelSourceFilename, material->hasTransparency()))
             {
                 assignMaterial(getSelectedGeometry(), material);
             }
@@ -1429,33 +1441,32 @@ void Viewer::saveDotFiles()
     {
         MaterialPtr material = getSelectedMaterial();
         mx::TypedElementPtr elem = material ? material->getElement() : nullptr;
-        if (elem)
+        mx::NodePtr shaderNode = elem->asA<mx::Node>();
+        if (shaderNode)
         {
-            mx::NodePtr shaderNode = elem->asA<mx::Node>();
-            if (shaderNode && material->getMaterialNode())
+            mx::FilePath baseFilename = getBaseOutputPath();
+            for (mx::InputPtr input : shaderNode->getInputs())
             {
-                for (mx::InputPtr input : shaderNode->getInputs())
-                {
-                    mx::OutputPtr output = input->getConnectedOutput();
-                    mx::ConstNodeGraphPtr nodeGraph = output ? output->getAncestorOfType<mx::NodeGraph>() : nullptr;
-                    if (nodeGraph)
-                    {
-                        std::string dot = nodeGraph->asStringDot();
-                        std::string baseName = _searchPath[0] / nodeGraph->getName();
-                        writeTextFile(dot, baseName + ".dot");
-                    }
-                }
-
-                mx::NodeDefPtr nodeDef = shaderNode->getNodeDef();
-                mx::InterfaceElementPtr implement = nodeDef ? nodeDef->getImplementation() : nullptr;
-                mx::NodeGraphPtr nodeGraph = implement ? implement->asA<mx::NodeGraph>() : nullptr;
+                mx::OutputPtr output = input->getConnectedOutput();
+                mx::ConstNodeGraphPtr nodeGraph = output ? output->getAncestorOfType<mx::NodeGraph>() : nullptr;
                 if (nodeGraph)
                 {
-                    std::string dot = nodeGraph->asStringDot();
-                    std::string baseName = _searchPath[0] / nodeDef->getName();
-                    writeTextFile(dot, baseName + ".dot");
+                    std::string dotString = nodeGraph->asStringDot();
+                    std::string dotFilename = baseFilename.asString() + "_" + nodeGraph->getName() + ".dot";
+                    writeTextFile(dotString, dotFilename);
                 }
             }
+
+            mx::NodeDefPtr nodeDef = shaderNode->getNodeDef();
+            mx::InterfaceElementPtr implement = nodeDef ? nodeDef->getImplementation() : nullptr;
+            mx::NodeGraphPtr nodeGraph = implement ? implement->asA<mx::NodeGraph>() : nullptr;
+            if (nodeGraph)
+            {
+                std::string dotString = nodeGraph->asStringDot();
+                std::string dotFilename = baseFilename.asString() + "_" + nodeDef->getName() + ".dot";
+                writeTextFile(dotString, dotFilename);
+            }
+            new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved dot files: ", baseFilename.asString() + "_*.dot");
         }
     }
     catch (std::exception& e)
@@ -1565,8 +1576,8 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         return true;
     }
 
-    // Save the current shader source to file.
-    if (key == GLFW_KEY_S && action == GLFW_PRESS)
+    // Save GLSL shader source to file.
+    if (key == GLFW_KEY_G && action == GLFW_PRESS)
     {
         saveShaderSource(_genContext);
         return true;
@@ -1590,11 +1601,18 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
     }
 #endif
 
-    // Load shader source from file.  Editing the source files before loading
-    // provides a way to debug and experiment with shader source code.
+    // Load GLSL shader source from file.  Editing the source files before
+    // loading provides a way to debug and experiment with shader source code.
     if (key == GLFW_KEY_L && action == GLFW_PRESS)
     {
         loadShaderSource();
+        return true;
+    }
+
+    // Clear the image cache, reloading all required images from the file system.
+    if (key == GLFW_KEY_I && action == GLFW_PRESS && modifiers == GLFW_MOD_SHIFT)
+    {
+        _imageHandler->clearImageCache();
         return true;
     }
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -168,6 +168,7 @@ class Viewer : public ng::Screen
     // existing assignment if the given material is nullptr.
     void assignMaterial(mx::MeshPartitionPtr geometry, MaterialPtr material);
 
+    // Mark the given material as currently selected in the viewer.
     void setSelectedMaterial(MaterialPtr material)
     {
         for (size_t i = 0; i < _materials.size(); i++)
@@ -179,6 +180,9 @@ class Viewer : public ng::Screen
             }
         }
     }
+
+    // Generate a base output filepath for data derived from the current material.
+    mx::FilePath getBaseOutputPath();
 
     void initCamera();
     void updateViewHandlers();


### PR DESCRIPTION
- Unify the handling of output folders for all generated data (e.g. GLSL, OSL, MDL, and DOT files), defaulting to the source folder of the current material, and applying the MATERIALX_VIEW_OUTPUT_PATH environment variable if set.
- Add an 'I' hotkey which reloads all images from the file system.
- Change the GLSL shader-generation hotkey from 'S' to 'G' for consistency with OSL and MDL.