### PR TITLE
Simplify material examples

### DIFF
--- a/resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx
@@ -6,7 +6,7 @@
       <input name="uvtiling" type="vector2" value="1.0, 1.0" />
     </tiledimage>
     <tiledimage name="image_roughness" type="float">
-      <input name="file" type="filename" value="brass_roughness.jpg" colorspace="srgb_texture" />
+      <input name="file" type="filename" value="brass_roughness.jpg" />
       <input name="uvtiling" type="vector2" value="1.0, 1.0" />
     </tiledimage>
     <output name="out_color" type="color3" nodename="image_color" />

--- a/resources/Materials/Examples/StandardSurface/standard_surface_wood_tiled.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_wood_tiled.mtlx
@@ -6,7 +6,7 @@
       <input name="uvtiling" type="vector2" value="4.0, 4.0" />
     </tiledimage>
     <tiledimage name="image_roughness" type="float">
-      <input name="file" type="filename" value="wood_roughness.jpg" colorspace="srgb_texture" />
+      <input name="file" type="filename" value="wood_roughness.jpg" />
       <input name="uvtiling" type="vector2" value="4.0, 4.0" />
     </tiledimage>
     <output name="out_color" type="color3" nodename="image_color" />

--- a/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_brass_tiled.mtlx
+++ b/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_brass_tiled.mtlx
@@ -6,7 +6,7 @@
       <input name="uvtiling" type="vector2" value="1.0, 1.0" />
     </tiledimage>
     <tiledimage name="image_roughness" type="float">
-      <input name="file" type="filename" value="brass_roughness.jpg" colorspace="srgb_texture" />
+      <input name="file" type="filename" value="brass_roughness.jpg" />
       <input name="uvtiling" type="vector2" value="1.0, 1.0" />
     </tiledimage>
     <output name="out_color" type="color3" nodename="image_color" />
@@ -14,8 +14,6 @@
   </nodegraph>
   <UsdPreviewSurface name="SR_brass1" type="surfaceshader">
     <input name="diffuseColor" type="color3" nodegraph="NG_brass1" output="out_color" />
-    <input name="useSpecularWorkflow" type="integer" value="0" />
-    <input name="specularColor" type="color3" value="0, 0, 0" />
     <input name="metallic" type="float" value="1" />
     <input name="roughness" type="float" nodegraph="NG_brass1" output="out_roughness" />
   </UsdPreviewSurface>

--- a/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_gold.mtlx
+++ b/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_gold.mtlx
@@ -2,8 +2,6 @@
 <materialx version="1.38" colorspace="lin_rec709">
   <UsdPreviewSurface name="SR_gold" type="surfaceshader">
     <input name="diffuseColor" type="color3" value="0.944, 0.776, 0.373" />
-    <input name="useSpecularWorkflow" type="integer" value="0" />
-    <input name="specularColor" type="color3" value="0, 0, 0" />
     <input name="metallic" type="float" value="1" />
     <input name="roughness" type="float" value="0.02" />
   </UsdPreviewSurface>

--- a/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_plastic.mtlx
+++ b/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_plastic.mtlx
@@ -2,11 +2,7 @@
 <materialx version="1.38" colorspace="lin_rec709">
   <UsdPreviewSurface name="SR_plastic" type="surfaceshader">
     <input name="diffuseColor" type="color3" value="0.10470402, 0.24188282, 0.81800002" />
-    <input name="useSpecularWorkflow" type="integer" value="0" />
-    <input name="metallic" type="float" value="0" />
     <input name="roughness" type="float" value="0.32467532157897949" />
-    <input name="clearcoat" type="float" value="0" />
-    <input name="clearcoatRoughness" type="float" value="0.01" />
     <input name="ior" type="float" value="1.5" />
   </UsdPreviewSurface>
   <surfacematerial name="USD_Plastic" type="material">


### PR DESCRIPTION
- Remove colorspace assignments on scalar images (only color values and images are affected by colorspace assignments).
- Remove input bindings to default values.