### PR TITLE
Improvements to render exceptions

### DIFF
--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -144,26 +144,26 @@ class MX_RENDER_API ShaderRenderer
     ViewHandlerPtr _viewHandler;
 };
 
-/// @class ExceptionShaderRenderError
-/// An exception that is thrown when shader rendering fails.
-/// An error log of shader errors is cached as part of the exception.
-/// For example, if shader compilation fails, then a list of compilation errors is cached.
-class MX_RENDER_API ExceptionShaderRenderError : public Exception
+/// @class ExceptionRenderError
+/// An exception that is thrown when a rendering operation fails.
+/// Optionally stores an additional error log, which can be used to
+/// store and retrieve shader compilation errors.
+class MX_RENDER_API ExceptionRenderError : public Exception
 {
   public:
-    ExceptionShaderRenderError(const string& msg, const StringVec& errorList) :
+    ExceptionRenderError(const string& msg, const StringVec& errorLog = StringVec()) :
         Exception(msg),
-        _errorLog(errorList)
+        _errorLog(errorLog)
     {
     }
 
-    ExceptionShaderRenderError(const ExceptionShaderRenderError& e) :
+    ExceptionRenderError(const ExceptionRenderError& e) :
         Exception(e),
         _errorLog(e._errorLog)
     {
     }
 
-    ExceptionShaderRenderError& operator=(const ExceptionShaderRenderError& e)         
+    ExceptionRenderError& operator=(const ExceptionRenderError& e)         
     {
         Exception::operator=(e);
         _errorLog = e._errorLog;

--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -33,9 +33,6 @@ GLFramebuffer::GLFramebuffer(unsigned int width, unsigned int height, unsigned i
     _colorTexture(0),
     _depthTexture(0)
 {
-    StringVec errors;
-    const string errorType("OpenGL target creation failure.");
-
     if (!glGenFramebuffers)
     {
         glewInit();
@@ -76,40 +73,39 @@ GLFramebuffer::GLFramebuffer(unsigned int width, unsigned int height, unsigned i
         glDeleteFramebuffers(1, &_frameBuffer);
         _frameBuffer = GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
 
-        string errorMessage("Frame buffer object setup failed: ");
+        string errorMessage;
         switch (status)
         {
         case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:
-            errorMessage += "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
+            errorMessage = "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
             break;
         case GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT:
-            errorMessage += "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
+            errorMessage = "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
             break;
         case GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER:
-            errorMessage += "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER";
+            errorMessage = "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER";
             break;
         case GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER:
-            errorMessage += "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER";
+            errorMessage = "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER";
             break;
         case GL_FRAMEBUFFER_UNSUPPORTED:
-            errorMessage += "GL_FRAMEBUFFER_UNSUPPORTED";
+            errorMessage = "GL_FRAMEBUFFER_UNSUPPORTED";
             break;
         case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
-            errorMessage += "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE";
+            errorMessage = "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE";
             break;
         case GL_FRAMEBUFFER_UNDEFINED:
-            errorMessage += "GL_FRAMEBUFFER_UNDEFINED";
+            errorMessage = "GL_FRAMEBUFFER_UNDEFINED";
             break;
         case GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS:
-            errorMessage += "GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS";
+            errorMessage = "GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS";
             break;
         default:
-            errorMessage += std::to_string(status);
+            errorMessage = std::to_string(status);
             break;
         }
 
-        errors.push_back(errorMessage);
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Frame buffer object setup failed: " + errorMessage);
     }
 
     // Unbind on cleanup
@@ -158,9 +154,7 @@ void GLFramebuffer::bind()
 {
     if (!_frameBuffer)
     {
-        StringVec errors;
-        errors.push_back("No framebuffer exists to bind.");
-        throw ExceptionShaderRenderError("OpenGL target bind failure.", errors);
+        throw ExceptionRenderError("No framebuffer exists to bind");
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -51,9 +51,6 @@ GlslRenderer::GlslRenderer(unsigned int width, unsigned int height, Image::BaseT
 
 void GlslRenderer::initialize()
 {
-    StringVec errors;
-    const string errorType("OpenGL utilities initialization.");
-
     if (!_initialized)
     {
         // Create window
@@ -61,16 +58,14 @@ void GlslRenderer::initialize()
 
         if (!_window->initialize("Renderer Window", _width, _height, nullptr))
         {
-            errors.push_back("Failed to create window for testing.");
-            throw ExceptionShaderRenderError(errorType, errors);
+            throw ExceptionRenderError("Failed to initialize renderer window");
         }
 
         // Create offscreen context
         _context = GLContext::create(_window);
         if (!_context)
         {
-            errors.push_back("Failed to create OpenGL context for testing.");
-            throw ExceptionShaderRenderError(errorType, errors);
+            throw ExceptionRenderError("Failed to create OpenGL context for renderer");
         }
 
         if (_context->makeCurrent())
@@ -80,14 +75,12 @@ void GlslRenderer::initialize()
 #if !defined(__APPLE__)
             if (!glewIsSupported("GL_VERSION_4_0"))
             {
-                errors.push_back("OpenGL version 4.0 not supported");
-                throw ExceptionShaderRenderError(errorType, errors);
+                throw ExceptionRenderError("OpenGL version 4.0 is required");
             }
 #endif
             glClearStencil(0);
 
             _frameBuffer = GLFramebuffer::create(_width, _height, 4, _baseType);
-
             _initialized = true;
         }
     }
@@ -95,19 +88,9 @@ void GlslRenderer::initialize()
 
 void GlslRenderer::createProgram(ShaderPtr shader)
 {
-    StringVec errors;
-    const string errorType("GLSL program creation error.");
-
-    if (!_context)
+    if (!_context || !_context->makeCurrent())
     {
-        errors.push_back("No valid OpenGL context to create program with.");
-        throw ExceptionShaderRenderError(errorType, errors);
-
-    }
-    if (!_context->makeCurrent())
-    {
-        errors.push_back("Cannot make OpenGL context current to create program.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Invalid OpenGL context in createProgram");
     }
 
     _program->setStages(shader);
@@ -116,19 +99,9 @@ void GlslRenderer::createProgram(ShaderPtr shader)
 
 void GlslRenderer::createProgram(const StageMap& stages)
 {
-    StringVec errors;
-    const string errorType("GLSL program creation error.");
-
-    if (!_context)
+    if (!_context || !_context->makeCurrent())
     {
-        errors.push_back("No valid OpenGL context to create program with.");
-        throw ExceptionShaderRenderError(errorType, errors);
-
-    }
-    if (!_context->makeCurrent())
-    {
-        errors.push_back("Cannot make OpenGL context current to create program.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Invalid OpenGL context in createProgram");
     }
 
     for (const auto& it : stages)
@@ -152,18 +125,9 @@ void GlslRenderer::renderTextureSpace()
 
 void GlslRenderer::validateInputs()
 {
-    StringVec errors;
-    const string errorType("GLSL program input error.");
-
-    if (!_context)
+    if (!_context || !_context->makeCurrent())
     {
-        errors.push_back("No valid OpenGL context to validate inputs.");
-        throw ExceptionShaderRenderError(errorType, errors);
-    }
-    if (!_context->makeCurrent())
-    {
-        errors.push_back("Cannot make OpenGL context current to validate inputs.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Invalid OpenGL context in validateInputs");
     }
 
     // Check that the generated uniforms and attributes are valid
@@ -217,18 +181,9 @@ void GlslRenderer::updateWorldInformation()
 
 void GlslRenderer::render()
 {
-    StringVec errors;
-    const string errorType("GLSL rendering error.");
-
-    if (!_context)
+    if (!_context || !_context->makeCurrent())
     {
-        errors.push_back("No valid OpenGL context to render to.");
-        throw ExceptionShaderRenderError(errorType, errors);
-    }
-    if (!_context->makeCurrent())
-    {
-        errors.push_back("Cannot make OpenGL context current to render to.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Invalid OpenGL context in render");
     }
 
     // Set up target
@@ -253,8 +208,7 @@ void GlslRenderer::render()
             // there is nothing to draw
             if (!_program->hasActiveAttributes())
             {
-                errors.push_back("Program has no input vertex data.");
-                throw ExceptionShaderRenderError(errorType, errors);
+                throw ExceptionRenderError("Program has no input vertex data");
             }
             else
             {
@@ -280,10 +234,10 @@ void GlslRenderer::render()
             }
         }
     }
-    catch (ExceptionShaderRenderError& /*e*/)
+    catch (ExceptionRenderError& e)
     {
         _frameBuffer->unbind();
-        throw;
+        throw e;
     }
 
     // Unset target
@@ -292,15 +246,6 @@ void GlslRenderer::render()
 
 ImagePtr GlslRenderer::captureImage(ImagePtr image)
 {
-    StringVec errors;
-    const string errorType("GLSL image capture error.");
-
-    if (!_imageHandler)
-    {
-        errors.push_back("No image handler specified.");
-        throw ExceptionShaderRenderError(errorType, errors);
-    }
-
     return _frameBuffer->getColorImage(image);
 }
 

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -49,31 +49,23 @@ void OslRenderer::setSize(unsigned int width, unsigned int height)
 
 void OslRenderer::initialize()
 {
-    StringVec errors;
-    const string errorType("OSL initialization error.");
     if (_oslIncludePath.isEmpty())
     {
-        errors.push_back("OSL validation include path is empty.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("OSL validation include path is empty");
     }
     if (_oslTestShadeExecutable.isEmpty() && _oslCompilerExecutable.isEmpty())
     {
-        errors.push_back("OSL validation executables not set.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("OSL validation executables not set");
     }
 }
 
 void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, const string& outputName)
 {
-    StringVec errors;
-    const string errorType("OSL rendering error.");
-
     // If command options missing, skip testing.
     if (_oslTestRenderExecutable.isEmpty() || _oslIncludePath.isEmpty() ||
         _oslTestRenderSceneTemplateFile.isEmpty() || _oslUtilityOSOPath.isEmpty())
     {
-        errors.push_back("Command input arguments are missing");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Command input arguments are missing");
     }
 
     static const StringSet RENDERABLE_TYPES = { "float", "color", "vector", "closure color", "color4", "vector2", "vector4" };
@@ -82,8 +74,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     // If the output type is not which can be supported for rendering then skip testing.
     if (RENDERABLE_TYPES.count(_oslShaderOutputType) == 0)
     {
-        errors.push_back("Output type to render is not supported: " + _oslShaderOutputType);
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Output type to render is not supported: " + _oslShaderOutputType);
     }
 
     const bool isColorClosure = _oslShaderOutputType == "closure color";
@@ -150,9 +141,8 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     string sceneString = replaceSubstrings(sceneTemplateString, replacementMap);
     if ((sceneString == sceneTemplateString) || sceneTemplateString.empty())
     {
-        errors.push_back("Scene template file: " + _oslTestRenderSceneTemplateFile.asString() +
-                         " does not include proper tokens for rendering.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Scene template file: " + _oslTestRenderSceneTemplateFile.asString() +
+                                         " does not include proper tokens for rendering");
     }
 
     // Write scene file
@@ -202,6 +192,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     }
     if (!result.empty())
     {
+        StringVec errors;
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
         errors.push_back("Shader failed to render:");
@@ -209,7 +200,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
         {
             errors.push_back(result[i]);
         }
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("OSL rendering error", errors);
     }
 }
 
@@ -264,7 +255,6 @@ void OslRenderer::shadeOSL(const FilePath& dirPath, const string& shaderName, co
 
     if (!results.empty())
     {
-        const string errorType("OSL rendering error.");
         StringVec errors;
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
@@ -273,7 +263,7 @@ void OslRenderer::shadeOSL(const FilePath& dirPath, const string& shaderName, co
         {
             errors.push_back(resultLine);
         }
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("OSL rendering error", errors);
     }
 }
 
@@ -306,13 +296,12 @@ void OslRenderer::compileOSL(const FilePath& oslFilePath)
 
     if (!result.empty())
     {
-        const string errorType("OSL compilation error.");
         StringVec errors;
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
         errors.push_back("Shader failed to compile:");
         errors.push_back(result);
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("OSL compilation error", errors);
     }
 }
 
@@ -326,19 +315,15 @@ void OslRenderer::createProgram(const StageMap& stages)
 {
     // There is only one stage in an OSL shader so only
     // the first stage is examined.
-    StringVec errors;
-    const string errorType("OSL compilation error.");
     if (stages.empty() || stages.begin()->second.empty())
     {
-        errors.push_back("No shader code to validate");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("No shader code to validate");
     }
 
     bool haveCompiler = !_oslCompilerExecutable.isEmpty() && !_oslIncludePath.isEmpty();
     if (!haveCompiler)
     {
-        errors.push_back("No OSL compiler specified for validation.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("No OSL compiler specified for validation");
     }
 
     // Dump string to disk. For OSL assume shader is in stage 0 slot.
@@ -371,27 +356,18 @@ void OslRenderer::createProgram(const StageMap& stages)
 
 void OslRenderer::validateInputs()
 {
-    StringVec errors;
-    const string errorType("OSL validation error.");
-
-    errors.push_back("OSL input validation is not supported at this time.");
-    throw ExceptionShaderRenderError(errorType, errors);
+    throw ExceptionRenderError("OSL input validation is not yet supported");
 }
 
 void OslRenderer::render()
 {
-    StringVec errors;
-    const string errorType("OSL rendering error.");
-
     if (_oslOutputFilePath.isEmpty())
     {
-        errors.push_back("OSL output file path string has not been specified.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("OSL output file path string has not been specified");
     }
     if (_oslShaderOutputName.empty())
     {
-        errors.push_back("OSL shader output name has not been specified.");
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("OSL shader output name has not been specified");
     }
 
     _oslOutputFileName.assign(EMPTY_STRING);
@@ -407,8 +383,7 @@ void OslRenderer::render()
     {
         if (_oslShaderName.empty())
         {
-            errors.push_back("OSL shader name has not been specified.");
-            throw ExceptionShaderRenderError(errorType, errors);
+            throw ExceptionRenderError("OSL shader name has not been specified");
         }
         renderOSL(_oslOutputFilePath, _oslShaderName, _oslShaderOutputName);
     }
@@ -417,20 +392,15 @@ void OslRenderer::render()
 ImagePtr OslRenderer::captureImage(ImagePtr)
 {
     // As rendering goes to disk need to read the image back from disk
-    StringVec errors;
-    const string errorType("OSL image save error.");
-
     if (!_imageHandler || _oslOutputFileName.isEmpty())
     {
-        errors.push_back("Failed to read image: " + _oslOutputFileName.asString());
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Failed to read image: " + _oslOutputFileName.asString());
     }
 
     ImagePtr returnImage = _imageHandler->acquireImage(_oslOutputFileName);
     if (!returnImage)
     {
-        errors.push_back("Failed to save image to file: " + _oslOutputFileName.asString());
-        throw ExceptionShaderRenderError(errorType, errors);
+        throw ExceptionRenderError("Failed to save image to file: " + _oslOutputFileName.asString());
     }
 
     return returnImage;

--- a/source/MaterialXTest/MaterialXRender/Render.cpp
+++ b/source/MaterialXTest/MaterialXRender/Render.cpp
@@ -114,7 +114,7 @@ TEST_CASE("Render: Geometry Handler Load", "[rendercore]")
 
         geomLoaded = true;
     }
-    catch (mx::ExceptionShaderRenderError& e)
+    catch (mx::ExceptionRenderError& e)
     {
         for (const auto& error : e.errorLog())
         {
@@ -209,7 +209,7 @@ TEST_CASE("Render: Image Handler Load", "[rendercore]")
 #endif
         imagesLoaded = true;
     }
-    catch (mx::ExceptionShaderRenderError& e)
+    catch (mx::ExceptionRenderError& e)
     {
         for (const auto& error : e.errorLog())
         {

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -145,7 +145,7 @@ void GlslShaderRenderTester::createRenderer(std::ostream& log)
 
         initialized = true;
     }
-    catch (mx::ExceptionShaderRenderError& e)
+    catch (mx::ExceptionRenderError& e)
     {
         for (const auto& error : e.errorLog())
         {
@@ -676,7 +676,7 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
 
                 validated = true;
             }
-            catch (mx::ExceptionShaderRenderError& e)
+            catch (mx::ExceptionRenderError& e)
             {
                 // Always dump shader stages on error
                 std::ofstream file;

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -108,7 +108,7 @@ void OslShaderRenderTester::createRenderer(std::ostream& log)
             _renderer->setOslUtilityOSOPath(shaderPath);
         }
     }
-    catch (mx::ExceptionShaderRenderError& e)
+    catch (mx::ExceptionRenderError& e)
     {
         for (const auto& error : e.errorLog())
         {
@@ -313,7 +313,7 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
                 validated = true;
             }
-            catch (mx::ExceptionShaderRenderError& e)
+            catch (mx::ExceptionRenderError& e)
             {
                 // Always dump shader on error
                 std::ofstream file;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1314,7 +1314,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
             }
         }
     }
-    catch (mx::ExceptionShaderRenderError& e)
+    catch (mx::ExceptionRenderError& e)
     {
         for (const std::string& error : e.errorLog())
         {
@@ -1345,7 +1345,7 @@ void Viewer::reloadShaders()
         }
         return;
     }
-    catch (mx::ExceptionShaderRenderError& e)
+    catch (mx::ExceptionRenderError& e)
     {
         for (const std::string& error : e.errorLog())
         {

--- a/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
@@ -28,7 +28,7 @@ void bindPyShaderRenderer(py::module& mod)
         .def("setSize", &mx::ShaderRenderer::setSize)
         .def("render", &mx::ShaderRenderer::render);
 
-    static py::exception<mx::ExceptionShaderRenderError> pyExceptionShaderRenderError(mod, "ExceptionShaderRenderError");
+    static py::exception<mx::ExceptionRenderError> pyExceptionRenderError(mod, "ExceptionRenderError");
 
     py::register_exception_translator(
         [](std::exception_ptr errPtr)
@@ -38,7 +38,7 @@ void bindPyShaderRenderer(py::module& mod)
                 if (errPtr != NULL)
                     std::rethrow_exception(errPtr);
             }
-            catch (const mx::ExceptionShaderRenderError& err)
+            catch (const mx::ExceptionRenderError& err)
             {
                 std::string errorMsg = err.what();
                 for (std::string error : err.errorLog())


### PR DESCRIPTION
- Rename ExceptionShaderRenderError to ExceptionRenderError, clarifying that it handles non-shading render exceptions as well.
- Make the error log argument of the ExceptionRenderError constructor optional.
- Simplify the use of ExceptionRenderError in GLSL and OSL rendering.