### PR TITLE
Add GLSL roughness guards

### DIFF
--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -21,8 +21,9 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
     FresnelData fd = tf.thickness > 0.0 ? mx_init_fresnel_conductor_airy(ior_n, ior_k, tf.thickness, tf.ior) : mx_init_fresnel_conductor(ior_n, ior_k);
     vec3 F = mx_compute_fresnel(VdotH, fd);
 
-    float avgRoughness = mx_average_roughness(roughness);
-    float D = mx_ggx_NDF(X, Y, H, NdotH, roughness.x, roughness.y);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
+    float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
     float G = mx_ggx_smith_G(NdotL, NdotV, avgRoughness);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
@@ -46,10 +47,11 @@ void mx_conductor_bsdf_indirect(vec3 V, float weight, vec3 ior_n, vec3 ior_k, ve
     FresnelData fd = tf.thickness > 0.0 ? mx_init_fresnel_conductor_airy(ior_n, ior_k, tf.thickness, tf.ior) : mx_init_fresnel_conductor(ior_n, ior_k);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    vec3 Li = mx_environment_radiance(N, V, X, roughness, distribution, fd);
-
-    float avgRoughness = mx_average_roughness(roughness);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
+
+    vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);
 
     result = Li * comp * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -18,11 +18,12 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
     float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
-    float avgRoughness = mx_average_roughness(roughness);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
 
     FresnelData fd = tf.thickness > 0.0 ? mx_init_fresnel_dielectric_airy(ior, tf.thickness, tf.ior) : mx_init_fresnel_dielectric(ior);
     vec3  F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(X, Y, H, NdotH, roughness.x, roughness.y);
+    float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
     float G = mx_ggx_smith_G(NdotL, NdotV, avgRoughness);
 
     float F0 = mx_ior_to_f0(ior);
@@ -61,7 +62,8 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
     FresnelData fd = tf.thickness > 0.0 ? mx_init_fresnel_dielectric_airy(ior, tf.thickness, tf.ior) : mx_init_fresnel_dielectric(ior);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    float avgRoughness = mx_average_roughness(roughness);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
     vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
@@ -84,12 +86,13 @@ void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
     FresnelData fd = tf.thickness > 0.0 ? mx_init_fresnel_dielectric_airy(ior, tf.thickness, tf.ior) : mx_init_fresnel_dielectric(ior);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    float avgRoughness = mx_average_roughness(roughness);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
     vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
 
-    vec3 Li = mx_environment_radiance(N, V, X, roughness, distribution, fd);
+    vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);
 
     result = Li * tint * comp * weight          // Top layer reflection
            + base * (1.0 - dirAlbedo * weight); // Base layer reflection attenuated by top layer

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -18,11 +18,12 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
     float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
-    float avgRoughness = mx_average_roughness(roughness);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
 
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3  F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(X, Y, H, NdotH, roughness.x, roughness.y);
+    float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
     float G = mx_ggx_smith_G(NdotL, NdotV, avgRoughness);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
@@ -52,7 +53,8 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    float avgRoughness = mx_average_roughness(roughness);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
     vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
@@ -74,12 +76,13 @@ void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    float avgRoughness = mx_average_roughness(roughness);
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
     vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
-    vec3 Li = mx_environment_radiance(N, V, X, roughness, distribution, fd);
+    vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);
 
     result = Li * comp * weight                     // Top layer reflection
            + base * (1.0 - avgDirAlbedo * weight);  // Base layer reflection attenuated by top layer


### PR DESCRIPTION
This changelist adds guards for invalid roughness values in the GLSL implementations of conductor_bsdf, dielectric_bsdf, and generalized_schlick_bsdf, providing more consistent visual behavior for shading models that implement their own roughness computations.