### PR TITLE
Fix default value for USD preview surface roughness implementation

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -12,7 +12,7 @@
     <input name="useSpecularWorkflow" type="integer" value="0" />
     <input name="specularColor" type="color3" value="0, 0, 0" />
     <input name="metallic" type="float" value="0" />
-    <input name="roughness" type="float" value="0.01" />
+    <input name="roughness" type="float" value="0.5" />
     <input name="clearcoat" type="float" value="0" />
     <input name="clearcoatRoughness" type="float" value="0.01" />
     <input name="opacity" type="float" value="1" />

--- a/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_default.mtlx
+++ b/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_default.mtlx
@@ -6,7 +6,7 @@
     <input name="useSpecularWorkflow" type="integer" value="0" />
     <input name="specularColor" type="color3" value="0, 0, 0" />
     <input name="metallic" type="float" value="0" />
-    <input name="roughness" type="float" value="0.01" />
+    <input name="roughness" type="float" value="0.5" />
     <input name="clearcoat" type="float" value="0" />
     <input name="clearcoatRoughness" type="float" value="0.01" />
     <input name="opacity" type="float" value="1" />


### PR DESCRIPTION
Fix to use correct value for roughness of USD preview surface.
Was set to clearcoat-roughness value incorrecly 0.01 vs 0.5 (correct valut according to usd spec.)