### PR TITLE
Add in gamma shader to use for viewer renders when sRGB buffers not available

### DIFF
--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -104,6 +104,7 @@ The following are common command-line options for MaterialXView, and a complete 
 - `--msaa [INTEGER]` : Specify the multisampling count for screen anti-aliasing (defaults to 0)
 - `--refresh [INTEGER]` : Specify the refresh period for the viewer in milliseconds (defaults to 50, set to -1 to disable)
 - `--remap [TOKEN1:TOKEN2]` : Specify the remapping from one token to another when MaterialX document is loaded
+- `--srgbBuffer : Specify to use an SRGB hardware frame buffer. The default value of false indicates to use a shader to transform colors for display
 - `--skip [NAME]` : Specify to skip elements matching the given name attribute
 - `--terminator [STRING]` : Specify to enforce the given terminator string for file prefixes
 - `--help` : Display the complete list of command-line options

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -33,6 +33,48 @@ ShaderPtr createConstantShader(GenContext& context,
     return createShader(shaderName, context, output);
 }
 
+ShaderPtr createGammaShader(GenContext& context,
+                            DocumentPtr stdLib,
+                            const string& shaderName,
+                            const Color3& gamma,
+                            bool verticalFlip)
+{
+    DocumentPtr doc = createDocument();
+    doc->importLibrary(stdLib);
+
+    // Construct a nodegraph which performs gamma correction on an input image.
+    // This graph reuses the range node which has gamma correction as
+    // part of the node. Additional scale+offset nodes which act on the input
+    // texture coordinates can the math required to perform a flip in V coordiates
+    // if desired.
+    NodeGraphPtr nodeGraph = doc->addNodeGraph();
+    NodePtr texcoordNode = nodeGraph->addNode("texcoord", "texcoord", "vector2");
+    NodePtr multiplyNode = nodeGraph->addNode("multiply", "multiply", "vector2");
+    multiplyNode->setNodeDefString("ND_multiply_vector2");
+    multiplyNode->setConnectedNode("in1", texcoordNode);
+    NodePtr addNode = nodeGraph->addNode("add", "add", "vector2");
+    addNode->setNodeDefString("ND_add_vector2");
+    addNode->setConnectedNode("in1", multiplyNode);
+    NodePtr imageNode = nodeGraph->addNode("image", "image", "color3");
+    imageNode->setConnectedNode("texcoord", addNode);
+    NodePtr rangeNode = nodeGraph->addNode("range", EMPTY_STRING, "color3");
+    rangeNode->setConnectedNode("in", imageNode);
+    rangeNode->setInputValue("gamma", gamma);
+    OutputPtr output = nodeGraph->addOutput();
+    output->setConnectedNode(rangeNode);
+
+    // Optional vertical flip settings. Note thta the default scale and offset values
+    // will not change any of the texture coordinates (i.e. scale by identify and offsets by zero).
+    if (verticalFlip)
+    {
+        multiplyNode->setInputValue("in2", "1.0, -1.0");
+        addNode->setInputValue("in2", "0.0, 1.0");
+    }
+
+    // Generate the shader
+    return createShader(shaderName, context, output);
+}
+
 ShaderPtr createDepthShader(GenContext& context,
                             DocumentPtr stdLib,
                             const string& shaderName)

--- a/source/MaterialXRender/Util.h
+++ b/source/MaterialXRender/Util.h
@@ -35,7 +35,7 @@ MX_RENDER_API ShaderPtr createConstantShader(GenContext& context,
 
 /// Create a shader to perform simple gamma correction, using the given standard libraries
 /// for code generation.
-ShaderPtr createGammaShader(GenContext& context,
+MX_RENDER_API ShaderPtr createGammaShader(GenContext& context,
                             DocumentPtr stdLib,
                             const string& shaderName,
                             const Color3& gamma,

--- a/source/MaterialXRender/Util.h
+++ b/source/MaterialXRender/Util.h
@@ -33,6 +33,14 @@ MX_RENDER_API ShaderPtr createConstantShader(GenContext& context,
                                const string& shaderName,
                                const Color3& color);
 
+/// Create a shader to perform simple gamma correction, using the given standard libraries
+/// for code generation.
+ShaderPtr createGammaShader(GenContext& context,
+                            DocumentPtr stdLib,
+                            const string& shaderName,
+                            const Color3& gamma,
+                            bool verticalFlip=true);
+
 /// Create a shader with depth value output, using the given standard libraries
 /// for code generation.
 MX_RENDER_API ShaderPtr createDepthShader(GenContext& context,

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -34,6 +34,7 @@ const std::string options =
 "    --remap [TOKEN1:TOKEN2]        Specify the remapping from one token to another when MaterialX document is loaded\n"
 "    --skip [NAME]                  Specify to skip elements matching the given name attribute\n"
 "    --terminator [STRING]          Specify to enforce the given terminator string for file prefixes\n"
+"    --srgbBuffer                   Specify to use an SRGB hardware frame buffer. The default value of false indicates to use a shader to transform colors for display\n"
 "    --help                         Display the complete list of command-line options\n";
 
 template<class T> void parseToken(std::string token, std::string type, T& res)
@@ -99,6 +100,7 @@ int main(int argc, char* const argv[])
     std::string bakeFilename;
     int multiSampleCount = 0;
     int refresh = 50;
+    bool srgbBuffer = false;
 
     for (size_t i = 0; i < tokens.size(); i++)
     {
@@ -219,6 +221,10 @@ int main(int argc, char* const argv[])
         {
             modifiers.filePrefixTerminator = nextToken;
         }
+        else if (token == "--srgbBuffer")
+        {
+            srgbBuffer = true;
+        }
         else if (token == "--help")
         {
             std::cout << " MaterialXView version " << mx::getVersionString() << std::endl;
@@ -266,6 +272,7 @@ int main(int argc, char* const argv[])
         viewer->setBakeWidth(bakeWidth);
         viewer->setBakeHeight(bakeHeight);
         viewer->setBakeFilename(bakeFilename);
+        viewer->setSRGBBuffer(srgbBuffer);
         viewer->initialize();
         if (!bakeFilename.empty()) 
         {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -210,6 +210,9 @@ Viewer::Viewer(const std::string& materialFilename,
     _saveGeneratedLights(false),
     _shadowSoftness(1),
     _ambientOcclusionGain(0.6f),
+    _gammaValue(2.2f),
+    _srgbFrameBuffer(false),
+    _screenColor(screenColor),
     _selectedGeom(0),
     _geomLabel(nullptr),
     _geometrySelectionBox(nullptr),
@@ -720,7 +723,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
     mergeMaterialsBox->setCallback([this](bool enable)
     {
         _mergeMaterials = enable;
-    });    
+    });
 
     ng::CheckBox* showInputsBox = new ng::CheckBox(advancedPopup, "Show All Inputs");
     showInputsBox->setChecked(_showAllInputs);
@@ -834,6 +837,34 @@ void Viewer::createAdvancedSettings(Widget* parent)
     ng::Label* renderLabel = new ng::Label(advancedPopup, "Render Options");
     renderLabel->setFontSize(20);
     renderLabel->setFont("sans-bold");
+
+    // Generate gamma correction material.
+    try
+    {
+        const mx::Color3 gamma(_gammaValue, _gammaValue, _gammaValue);
+        mx::ShaderPtr hwShader = mx::createGammaShader(_genContext, _stdLib, "__GAMMA_CORRECT_SHADER__", gamma);
+        _gammaMaterial = Material::create();
+        _gammaMaterial->generateShader(hwShader);
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "Failed to generate gamma shader: " << e.what() << std::endl;
+        _gammaMaterial = nullptr;
+    }
+
+    if (_gammaMaterial)
+    {
+        ng::Widget* gammaRow = new ng::Widget(advancedPopup);
+        gammaRow->setLayout(new ng::BoxLayout(ng::Orientation::Horizontal));
+        ui.uiMin = mx::Value::createValue(0.01f);
+        ui.uiMax = mx::Value::createValue(2.2f);
+        ng::FloatBox<float>* gammaBox = createFloatWidget(gammaRow, "Gamma:",
+            _gammaValue, &ui, [this](float value)
+        {
+            _gammaValue = value;
+        });
+        gammaBox->setEditable(true);
+    }
 
     ng::CheckBox* transparencyBox = new ng::CheckBox(advancedPopup, "Render Transparency");
     transparencyBox->setChecked(_renderTransparency);
@@ -1756,7 +1787,19 @@ void Viewer::renderFrame()
     glDepthFunc(GL_LEQUAL);
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     glDisable(GL_CULL_FACE);
-    glDisable(GL_FRAMEBUFFER_SRGB);
+    if (_srgbFrameBuffer)
+    {
+        glDisable(GL_FRAMEBUFFER_SRGB);
+    }
+    else
+    {
+        // Set background without gamma.
+        float r = std::pow(std::max(0.0f, _screenColor[0]), _gammaValue);
+        float g = std::pow(std::max(0.0f, _screenColor[1]), _gammaValue);
+        float b = std::pow(std::max(0.0f, _screenColor[2]), _gammaValue);
+        glClearColor(r, g, b, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+    }
 
     // Update shading tables
     updateAlbedoTable();
@@ -1786,7 +1829,10 @@ void Viewer::renderFrame()
     const mx::Matrix44& view = _cameraViewHandler->viewMatrix;
     const mx::Matrix44& proj = _cameraViewHandler->projectionMatrix;
 
-    glEnable(GL_FRAMEBUFFER_SRGB);
+    if (_srgbFrameBuffer)
+    {
+        glEnable(GL_FRAMEBUFFER_SRGB);
+    }
 
     // Environment background
     if (_drawEnvironment && _envMaterial)
@@ -1884,7 +1930,11 @@ void Viewer::renderFrame()
     {
         glDisable(GL_CULL_FACE);
     }
-    glDisable(GL_FRAMEBUFFER_SRGB);
+
+    if (_srgbFrameBuffer)
+    {
+        glDisable(GL_FRAMEBUFFER_SRGB);
+    }
 
     // Wireframe pass
     if (_outlineSelection)
@@ -1895,6 +1945,33 @@ void Viewer::renderFrame()
         _wireMaterial->bindViewInformation(world, view, proj);
         _wireMaterial->drawPartition(getSelectedGeometry());
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    }
+
+    // Gamma pass
+    if (!_srgbFrameBuffer && _gammaMaterial)
+    {
+        mx::ImageSamplingProperties samplingProperties;
+        samplingProperties.uaddressMode = mx::ImageSamplingProperties::AddressMode::CLAMP;
+        samplingProperties.vaddressMode = mx::ImageSamplingProperties::AddressMode::CLAMP;
+        samplingProperties.filterType = mx::ImageSamplingProperties::FilterType::CLOSEST;
+
+        mx::ImagePtr originalBuffer = getFrameImage();
+
+        _gammaMaterial->bindShader();
+        mx::Color3 gammaColor(_gammaValue, _gammaValue, _gammaValue);
+        _gammaMaterial->getProgram()->bindUniform("node1_gamma", mx::Value::createValue(gammaColor));
+        if (_imageHandler->bindImage(originalBuffer, samplingProperties))
+        {
+            mx::GLTextureHandlerPtr textureHandler = std::static_pointer_cast<mx::GLTextureHandler>(_imageHandler);
+            int textureLocation = textureHandler->getBoundTextureLocation(originalBuffer->getResourceId());
+            if (textureLocation >= 0)
+            {
+                _gammaMaterial->getProgram()->bindUniform("image_file", mx::Value::createValue(textureLocation));
+            }
+        }
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+        renderScreenSpaceQuad(_gammaMaterial);
+        _imageHandler->releaseRenderResources(originalBuffer);
     }
 }
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -119,6 +119,12 @@ class Viewer : public ng::Screen
         return _showAllInputs;
     }
 
+    //  Set to use a hardware sRGB buffer for rendering
+    void setSRGBBuffer(bool val)
+    {
+        _srgbFrameBuffer = val;
+    }
+
     // Return the underlying NanoGUI window.
     ng::Window* getWindow() const
     {
@@ -297,6 +303,12 @@ class Viewer : public ng::Screen
 
     // Ambient occlusion
     float _ambientOcclusionGain;
+
+    // Gamma correction shader used if not using SRGB framebuffer
+    MaterialPtr _gammaMaterial;
+    float _gammaValue;
+    bool _srgbFrameBuffer;
+    mx::Color3 _screenColor;
 
     // Geometry selections
     std::vector<mx::MeshPartitionPtr> _geometryList;


### PR DESCRIPTION
Allow post color transform for viewer to use a shader vs a sRGB buffer.
The latter is not always available for software implementations. This allows for CI to render using the MaterialXView in these cases.

New command line option added (`--srgbBuffer`) as well as interactive UI.
![image](https://user-images.githubusercontent.com/14275104/126911837-acebb14f-40fe-415c-951c-11740f96ed30.png)
