### PR TITLE
Fix real-world unit target inheritance

### DIFF
--- a/source/MaterialXGenShader/UnitSystem.cpp
+++ b/source/MaterialXGenShader/UnitSystem.cpp
@@ -143,23 +143,33 @@ UnitSystemPtr UnitSystem::create(const string& language)
     return UnitSystemPtr(new UnitSystem(language));
 }
 
-string UnitSystem::getImplementationName(const UnitTransform& transform, const string& unitname) const
+ImplementationPtr UnitSystem::getImplementation(const UnitTransform& transform, const string& unitname) const
 {
-    return "IM_" + unitname + "_unit_" + transform.type->getName() + "_" + _target;
+    // Search up the targetdef derivation hierarchy for a matching implementation.
+    TargetDefPtr targetDef = _document->getTargetDef(_target);
+    const StringVec targets = targetDef->getMatchingTargets();
+    for (const string& target : targets)
+    {
+        const string implName = "IM_" + unitname + "_unit_" + transform.type->getName() + "_" + target;
+        ImplementationPtr impl = _document->getImplementation(implName);
+        if (impl)
+        {
+            return impl;
+        }
+    }
+    return nullptr;
 }
 
 bool UnitSystem::supportsTransform(const UnitTransform& transform) const
 {
-    const string implName = getImplementationName(transform, transform.unitType);
-    ImplementationPtr impl = _document->getImplementation(implName);
+    ImplementationPtr impl = getImplementation(transform, transform.unitType);
     return impl != nullptr;
 }
 
 ShaderNodePtr UnitSystem::createNode(ShaderGraph* parent, const UnitTransform& transform, const string& name,
                                      GenContext& context) const
 {
-    const string implName = getImplementationName(transform, transform.unitType);
-    ImplementationPtr impl = _document->getImplementation(implName);
+    ImplementationPtr impl = getImplementation(transform, transform.unitType);
     if (!impl)
     {
         throw ExceptionShaderGenError("No implementation found for transform: ('" + transform.sourceUnit + "', '" + transform.targetUnit + "').");
@@ -175,12 +185,12 @@ ShaderNodePtr UnitSystem::createNode(ShaderGraph* parent, const UnitTransform& t
 
     // Check if it's created and cached already,
     // otherwise create and cache it.
-    ShaderNodeImplPtr nodeImpl = context.findNodeImplementation(implName);
+    ShaderNodeImplPtr nodeImpl = context.findNodeImplementation(impl->getName());
     if (!nodeImpl)
     {
         nodeImpl = ScalarUnitNode::create(scalarConverter);
         nodeImpl->initialize(*impl, context);
-        context.addNodeImplementation(implName, nodeImpl);
+        context.addNodeImplementation(impl->getName(), nodeImpl);
     }
 
     // Create the node.

--- a/source/MaterialXGenShader/UnitSystem.h
+++ b/source/MaterialXGenShader/UnitSystem.h
@@ -79,8 +79,8 @@ class MX_GENSHADER_API UnitSystem
     ShaderNodePtr createNode(ShaderGraph* parent, const UnitTransform& transform, const string& name,
                              GenContext& context) const;
 
-    /// Returns an implementation name for a given transform
-    virtual string getImplementationName(const UnitTransform& transform, const string& unitname) const;
+    /// Returns an implementation for a given transform
+    virtual ImplementationPtr getImplementation(const UnitTransform& transform, const string& unitname) const;
 
     static const string UNITSYTEM_NAME;
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -269,10 +269,6 @@ Viewer::Viewer(const std::string& materialFilename,
     _genContextMdl.getOptions().targetColorSpaceOverride = "lin_rec709";
     _genContextMdl.getOptions().fileTextureVerticalFlip = false;
 #endif
-#if MATERIALX_BUILD_GEN_ARNOLD
-    _genContextArnold.getOptions().targetColorSpaceOverride = "lin_rec709";
-    _genContextArnold.getOptions().fileTextureVerticalFlip = false;
-#endif
 
     // Register the GLSL implementation for <viewdir> used by the environment shader.
     _genContext.getShaderGenerator().registerImplementation("IM_viewdir_vector3_" + mx::GlslShaderGenerator::TARGET, ViewDirGlsl::create);
@@ -752,9 +748,6 @@ void Viewer::createAdvancedSettings(Widget* parent)
 #endif
 #if MATERIALX_BUILD_GEN_MDL
         _genContextMdl.getOptions().targetDistanceUnit = _distanceUnitOptions[index];
-#endif
-#if MATERIALX_BUILD_GEN_ARNOLD
-        _genContextArnold.getOptions().targetDistanceUnit = _distanceUnitOptions[index];
 #endif
         for (MaterialPtr material : _materials)
         {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -269,6 +269,10 @@ Viewer::Viewer(const std::string& materialFilename,
     _genContextMdl.getOptions().targetColorSpaceOverride = "lin_rec709";
     _genContextMdl.getOptions().fileTextureVerticalFlip = false;
 #endif
+#if MATERIALX_BUILD_GEN_ARNOLD
+    _genContextArnold.getOptions().targetColorSpaceOverride = "lin_rec709";
+    _genContextArnold.getOptions().fileTextureVerticalFlip = false;
+#endif
 
     // Register the GLSL implementation for <viewdir> used by the environment shader.
     _genContext.getShaderGenerator().registerImplementation("IM_viewdir_vector3_" + mx::GlslShaderGenerator::TARGET, ViewDirGlsl::create);
@@ -748,6 +752,9 @@ void Viewer::createAdvancedSettings(Widget* parent)
 #endif
 #if MATERIALX_BUILD_GEN_MDL
         _genContextMdl.getOptions().targetDistanceUnit = _distanceUnitOptions[index];
+#endif
+#if MATERIALX_BUILD_GEN_ARNOLD
+        _genContextArnold.getOptions().targetDistanceUnit = _distanceUnitOptions[index];
 #endif
         for (MaterialPtr material : _materials)
         {


### PR DESCRIPTION
Target inheritance for unit system patched. Similar to previous patch for color system.
Inherited targets will properly find ancestor implementations.
 