### PR TITLE
Fix to only allow inputs and outputs in shadernode / graph interfaces

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -675,8 +675,11 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
             // Handle node input ports
             for (const ValueElementPtr& nodedefPort : nodeDef->getActiveValueElements())
             {
-                if (nodedefPort->isA<Output>())
+                InputPtr nodedefInputPort = nodedefPort->asA<Input>();
+                if (!nodedefInputPort)
+                {
                     continue;
+                }
 
                 ShaderGraphInputSocket* inputSocket = graph->getInputSocket(nodedefPort->getName());
                 ShaderInput* input = newNode->getInput(nodedefPort->getName());

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -238,7 +238,7 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
         {
             newNode->addOutput(port->getName(), portType);
         }
-        else
+        else if (port->isA<Input>())
         {
             ShaderInput* input;
             const string& portValue = port->getResolvedValueString();


### PR DESCRIPTION
Fix regression that tokens can show up in shadernode interfaces.
As tokens are ValueELements these can be added to the interface of  node which is incorrect.
