### PR TITLE
Fix channel names in OpenImageIO writing

### DIFF
--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -25,11 +25,7 @@ bool OiioImageLoader::saveImage(const FilePath& filePath,
                                 ConstImagePtr image,
                                 bool verticalFlip)
 {
-    OIIO::ImageSpec imageSpec;
-    imageSpec.width = image->getWidth();
-    imageSpec.height = image->getHeight();
-    imageSpec.nchannels = image->getChannelCount();
-
+    OIIO::ImageSpec imageSpec(image->getWidth(), image->getHeight(), image->getChannelCount());
     OIIO::TypeDesc format;
     switch (image->getBaseType())
     {


### PR DESCRIPTION
This changelist addresses the assignment of incorrect channel names in OpenImageIO writing, by switching from the default ImageSpec constructor to one that assigns default channel names after the channel count is known.