### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -88,7 +88,7 @@ bool PortElement::validate(string* message) const
         const string& outputString = getOutputString();
         if (!outputString.empty())
         {
-            OutputPtr output = OutputPtr();
+            OutputPtr output;
             if (hasNodeName())
             {
                 NodeDefPtr nodeDef = connectedNode->getNodeDef();

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -139,7 +139,7 @@ OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)
 
         // Handle case where it's an input to a top level output
         InputPtr connectedInput = connectingElement->asA<Input>();
-        OutputPtr output = OutputPtr();
+        OutputPtr output;
         if (connectedInput)
         {
             InputPtr interfaceInput = nullptr;

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -13,8 +13,6 @@
 #include <MaterialXCore/Document.h>
 #include <MaterialXCore/Definition.h>
 
-#include <queue>
-
 namespace MaterialX
 {
 
@@ -149,7 +147,6 @@ namespace Stage
 }
 
 const HwClosureContext::Arguments HwClosureContext::EMPTY_ARGUMENTS;
-
 
 //
 // HwShaderGenerator methods
@@ -368,7 +365,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     //
 
     // Start with top level graphs.
-    std::deque<ShaderGraph*> graphQueue = { graph.get() };
+    vector<ShaderGraph*> graphStack = { graph.get() };
     if (lightShaders)
     {
         for (const auto& it : lightShaders->get())
@@ -377,15 +374,15 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
             ShaderGraph* lightGraph = node->getImplementation().getGraph();
             if (lightGraph)
             {
-                graphQueue.push_back(lightGraph);
+                graphStack.push_back(lightGraph);
             }
         }
     }
 
-    while (!graphQueue.empty())
+    while (!graphStack.empty())
     {
-        ShaderGraph* g = graphQueue.back();
-        graphQueue.pop_back();
+        ShaderGraph* g = graphStack.back();
+        graphStack.pop_back();
 
         for (ShaderNode* node : g->getNodes())
         {
@@ -405,11 +402,11 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
                     }
                 }
             }
-            // Push subgraphs on the queue to process these as well.
+            // Push subgraphs on the stack to process these as well.
             ShaderGraph* subgraph = node->getImplementation().getGraph();
             if (subgraph)
             {
-                graphQueue.push_back(subgraph);
+                graphStack.push_back(subgraph);
             }
         }
     }

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -165,8 +165,7 @@ namespace
         return false;
     }
 
-    bool isTransparentShaderGraph(OutputPtr output, const string& target,
-                                  NodePtr& interfaceNode)
+    bool isTransparentShaderGraph(OutputPtr output, const string& target, NodePtr interfaceNode)
     {
         for (GraphIterator it = output->traverseGraph().begin(); it != GraphIterator::end(); ++it)
         {
@@ -196,12 +195,10 @@ namespace
                         if (impl && impl->isA<NodeGraph>())
                         {
                             NodeGraphPtr graph = impl->asA<NodeGraph>();
-
                             vector<OutputPtr> outputs = graph->getActiveOutputs();
                             if (outputs.size() > 0)
                             {
                                 const OutputPtr& graphOutput = outputs[0];
-                                OpaqueTestPairList opaqueInputList;
                                 if (isTransparentShaderGraph(graphOutput, target, node))
                                 {
                                     return true;


### PR DESCRIPTION
- Remove unused assignments of output pointers.
- Use a standard vector to represent a graph stack.
- Remove an unused variable from isTransparentShaderGraph.
- Clarify the interface of isTransparentShaderGraph.