### PR TITLE
Move ScopedTimer to MaterialXRender

### DIFF
--- a/source/MaterialXRender/Timer.cpp
+++ b/source/MaterialXRender/Timer.cpp
@@ -16,10 +16,7 @@ ScopedTimer::ScopedTimer(double* externalCounter) :
 
 ScopedTimer::~ScopedTimer()
 {
-    if (_externalCounter)
-    {
-        endTimer();
-    }
+    endTimer();
 }
 
 double ScopedTimer::elapsedTime()
@@ -31,16 +28,17 @@ double ScopedTimer::elapsedTime()
 
 void ScopedTimer::startTimer()
 {
+    _active = true;
     _startTime = clock::now();
 }
 
 void ScopedTimer::endTimer()
 {
-    if (_externalCounter)
+    if (_active && _externalCounter)
     {
         *_externalCounter += elapsedTime();
     }
-    _startTime = clock::now();
+    _active = false;
 }
 
 } // namespace MaterialX

--- a/source/MaterialXRender/Timer.cpp
+++ b/source/MaterialXRender/Timer.cpp
@@ -1,0 +1,46 @@
+//
+// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXRender/Timer.h>
+
+namespace MaterialX
+{
+
+ScopedTimer::ScopedTimer(double* externalCounter) :
+    _externalCounter(externalCounter)
+{
+    startTimer();
+}
+
+ScopedTimer::~ScopedTimer()
+{
+    if (_externalCounter)
+    {
+        endTimer();
+    }
+}
+
+double ScopedTimer::elapsedTime()
+{
+    std::chrono::time_point<clock> endTime = clock::now();
+    std::chrono::duration<double> elapsedTime = endTime - _startTime;
+    return elapsedTime.count();
+}
+
+void ScopedTimer::startTimer()
+{
+    _startTime = clock::now();
+}
+
+void ScopedTimer::endTimer()
+{
+    if (_externalCounter)
+    {
+        *_externalCounter += elapsedTime();
+    }
+    _startTime = clock::now();
+}
+
+} // namespace MaterialX

--- a/source/MaterialXRender/Timer.h
+++ b/source/MaterialXRender/Timer.h
@@ -1,0 +1,46 @@
+//
+// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_TIMER_H
+#define MATERIALX_TIMER_H
+
+/// @file
+/// Support for event timing
+
+#include <MaterialXRender/Export.h>
+
+#include <chrono>
+
+namespace MaterialX
+{
+
+/// @class ScopedTimer
+/// A class for scoped event timing
+class MX_RENDER_API ScopedTimer
+{
+  public:
+    using clock = std::chrono::high_resolution_clock;
+
+    ScopedTimer(double* externalCounter = nullptr);
+    ~ScopedTimer();
+
+    /// Return the elapsed time in seconds since our start time.
+    double elapsedTime();
+
+    /// Set our start time to the current moment.
+    void startTimer();
+
+    /// Add the current elapsed time to our external counter, and reset
+    /// our start time to the current moment.
+    void endTimer();
+
+  protected:
+    double* _externalCounter;
+    std::chrono::time_point<clock> _startTime;
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXRender/Timer.h
+++ b/source/MaterialXRender/Timer.h
@@ -29,14 +29,14 @@ class MX_RENDER_API ScopedTimer
     /// Return the elapsed time in seconds since our start time.
     double elapsedTime();
 
-    /// Set our start time to the current moment.
+    /// Activate the timer, and set our start time to the current moment.
     void startTimer();
 
-    /// Add the current elapsed time to our external counter, and reset
-    /// our start time to the current moment.
+    /// Deactivate the timer, and add the elapsed time to our external counter.
     void endTimer();
 
   protected:
+    bool _active;
     double* _externalCounter;
     std::chrono::time_point<clock> _startTime;
 };

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -6,11 +6,7 @@
 #include <MaterialXTest/Catch/catch.hpp>
 #include <MaterialXTest/MaterialXRender/RenderUtil.h>
 
-#include <MaterialXCore/Unit.h>
-
 #include <MaterialXFormat/Util.h>
-
-#include <MaterialXRender/Image.h>
 
 namespace mx = MaterialX;
 
@@ -113,7 +109,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     // Profiling times
     RenderUtil::RenderProfileTimes profileTimes;
     // Global setup timer
-    RenderUtil::AdditiveScopedTimer totalTime(profileTimes.totalTime, "Global total time");
+    mx::ScopedTimer totalTime(&profileTimes.totalTime);
 
     // Add files to override the files in the test suite to be tested.
     mx::StringSet testfileOverride;
@@ -122,7 +118,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
         testfileOverride.insert(filterFile);
     }
 
-    RenderUtil::AdditiveScopedTimer ioTimer(profileTimes.ioTime, "Global I/O time");
+    mx::ScopedTimer ioTimer(&profileTimes.ioTime);
     mx::FilePathVec dirs;
     if (options.externalTestPaths.size() == 0)
     {
@@ -159,7 +155,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     ioTimer.endTimer();
 
     // Create renderers and generators
-    RenderUtil::AdditiveScopedTimer setupTime(profileTimes.languageTimes.setupTime, "Setup time");
+    mx::ScopedTimer setupTime(&profileTimes.languageTimes.setupTime);
 
     createRenderer(log);
 
@@ -197,8 +193,8 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     pathMap["/"] = "_";
     pathMap[":"] = "_";
 
-    RenderUtil::AdditiveScopedTimer validateTimer(profileTimes.validateTime, "Global validation time");
-    RenderUtil::AdditiveScopedTimer renderableSearchTimer(profileTimes.renderableSearchTime, "Global renderable search time");
+    mx::ScopedTimer validateTimer(&profileTimes.validateTime);
+    mx::ScopedTimer renderableSearchTimer(&profileTimes.renderableSearchTime);
 
     mx::StringSet usedImpls;
 

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -8,21 +8,9 @@
 
 #include <MaterialXTest/MaterialXGenShader/GenShaderUtil.h>
 
-#include <MaterialXCore/Document.h>
-
-#include <MaterialXFormat/XmlIo.h>
-
-#include <MaterialXGenShader/Util.h>
-#include <MaterialXGenShader/HwShaderGenerator.h>
-#include <MaterialXGenShader/DefaultColorManagementSystem.h>
-#include <MaterialXGenShader/UnitSystem.h>
-
-#include <MaterialXRender/Util.h>
-#include <MaterialXRender/LightHandler.h>
 #include <MaterialXRender/ImageHandler.h>
-
-#include <chrono>
-#include <ctime>
+#include <MaterialXRender/Timer.h>
+#include <MaterialXRender/Util.h>
 
 #define LOG_TO_FILE
 
@@ -42,56 +30,6 @@ namespace mx = MaterialX;
 //
 namespace RenderUtil
 {
-
-// Scoped timer which adds a duration to a given externally reference timing duration
-//
-class AdditiveScopedTimer
-{
-  public:
-    AdditiveScopedTimer(double& durationRefence, const std::string& label)
-        : _duration(durationRefence)
-        , _debugUpdate(false)
-        , _label(label)
-    {
-        startTimer();
-    }
-
-    ~AdditiveScopedTimer()
-    {
-        endTimer();
-    }
-
-    void startTimer()
-    {
-        _startTime = std::chrono::system_clock::now();
-
-        if (_debugUpdate)
-        {
-            std::cout << "Start time for timer (" << _label << ") is: " << _duration << std::endl;
-        }
-    }
-
-    void endTimer()
-    {
-        std::chrono::time_point<std::chrono::system_clock> endTime = std::chrono::system_clock::now();
-        std::chrono::duration<double> timeDuration = endTime - _startTime;
-        double currentDuration = timeDuration.count();
-        _duration += currentDuration;
-        _startTime = endTime;
-
-        if (_debugUpdate)
-        {
-            std::cout << "Current duration for timer (" << _label << ") is: " << currentDuration << ". Total duration: " << _duration << std::endl;
-        }
-    }
-
-  protected:
-    double &_duration;
-    bool _debugUpdate;
-    std::string _label;
-    std::chrono::time_point<std::chrono::system_clock> _startTime;
-};
-
 
 // Per language profile times
 //
@@ -213,7 +151,7 @@ class ShaderRenderTester
         mx::DocumentPtr doc,
         std::ostream& log,
         const GenShaderUtil::TestSuiteOptions& testOptions,
-        RenderUtil::RenderProfileTimes& profileTimes,
+        RenderProfileTimes& profileTimes,
         const mx::FileSearchPath& imageSearchPath,
         const std::string& outputPath = ".",
         mx::ImageVec* imageVec = nullptr) = 0;

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -6,17 +6,14 @@
 #include <MaterialXTest/Catch/catch.hpp>
 #include <MaterialXTest/MaterialXRender/RenderUtil.h>
 
-#include <MaterialXGenShader/TypeDesc.h>
-#include <MaterialXGenShader/Util.h>
-
-#include <MaterialXGenOsl/OslShaderGenerator.h>
-
 #include <MaterialXRenderOsl/OslRenderer.h>
 
 #include <MaterialXRender/StbImageLoader.h>
 #if defined(MATERIALX_BUILD_OIIO)
 #include <MaterialXRender/OiioImageLoader.h>
 #endif
+
+#include <MaterialXGenOsl/OslShaderGenerator.h>
 
 namespace mx = MaterialX;
 
@@ -130,7 +127,7 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
                                          const std::string& outputPath,
                                          mx::ImageVec* imageVec)
 {
-    RenderUtil::AdditiveScopedTimer totalOSLTime(profileTimes.languageTimes.totalTime, "OSL total time");
+    mx::ScopedTimer totalOSLTime(&profileTimes.languageTimes.totalTime);
 
     const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
 
@@ -159,7 +156,7 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
             mx::ShaderPtr shader;
             try
             {
-                RenderUtil::AdditiveScopedTimer genTimer(profileTimes.languageTimes.generationTime, "OSL generation time");
+                mx::ScopedTimer genTimer(&profileTimes.languageTimes.generationTime);
                 mx::GenOptions& contextOptions = context.getOptions();
                 contextOptions = options;
                 contextOptions.targetColorSpaceOverride = "lin_rec709";
@@ -188,7 +185,7 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
             // Note: mkdir will fail if the directory already exists which is ok.
             {
-                RenderUtil::AdditiveScopedTimer ioDir(profileTimes.languageTimes.ioTime, "OSL dir time");
+                mx::ScopedTimer ioDir(&profileTimes.languageTimes.ioTime);
                 outputFilePath.createDirectory();
             }
 
@@ -197,7 +194,7 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
             // Write out osl file
             if (testOptions.dumpGeneratedCode)
             {
-                RenderUtil::AdditiveScopedTimer ioTimer(profileTimes.languageTimes.ioTime, "OSL I/O time");
+                mx::ScopedTimer ioTimer(&profileTimes.languageTimes.ioTime);
                 std::ofstream file;
                 file.open(shaderPath + ".osl");
                 file << shader->getSourceCode();
@@ -219,7 +216,7 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
                 // Validate compilation
                 {
-                    RenderUtil::AdditiveScopedTimer compileTimer(profileTimes.languageTimes.compileTime, "OSL compile time");
+                    mx::ScopedTimer compileTimer(&profileTimes.languageTimes.compileTime);
                     _renderer->createProgram(shader);
                 }
 
@@ -296,7 +293,7 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
                         // Validate rendering
                         {
-                            RenderUtil::AdditiveScopedTimer renderTimer(profileTimes.languageTimes.renderTime, "OSL render time");
+                            mx::ScopedTimer renderTimer(&profileTimes.languageTimes.renderTime);
                             _renderer->render();
                             if (imageVec)
                             {


### PR DESCRIPTION
This changelist refactors the ScopedTimer class and moves it from MaterialXTest to MaterialXRender, making timing facilities available across rendering implementations.