### PR TITLE
Optimization to texture baking

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -165,8 +165,8 @@ void TextureBaker::bakeShaderInputs(NodePtr material, NodePtr shader, GenContext
         }
     }
 
-    // Unbind all images used to generate this set of shader inputs.
-    _imageHandler->unbindImages();
+    // Release all images used to generate this set of shader inputs.
+    _imageHandler->clearImageCache();
 }
 
 void TextureBaker::bakeGraphOutput(OutputPtr output, GenContext& context, const FilePath& texturefilepath)


### PR DESCRIPTION
Clear the image cache after each set of shader inputs is baked, in order to reduce the system memory overhead for processing materials with multiple UDIMs.