### PR TITLE
Improvements to sheen rendering

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
@@ -70,3 +70,14 @@ vec2 mx_spherical_fibonacci(int i, int numSamples)
 {
     return vec2((float(i) + 0.5) / float(numSamples), mx_golden_ratio_sequence(i));
 }
+
+// Generate a uniform-weighted sample in the unit hemisphere.
+vec3 mx_uniform_sample_hemisphere(vec2 Xi)
+{
+    float phi = 2.0 * M_PI * Xi.x;
+    float cosTheta = 1.0 - Xi.y;
+    float sinTheta = sqrt(1.0 - mx_square(cosTheta));
+    return vec3(cos(phi) * sinTheta,
+                sin(phi) * sinTheta,
+                cosTheta);
+}

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -32,7 +32,7 @@ float mx_burley_diffuse(vec3 L, vec3 V, vec3 N, float NdotL, float roughness)
 
 // Compute the directional albedo component of Burley diffuse for the given
 // view angle and roughness.  Curve fit provided by Stephen Hill.
-float mx_burley_diffuse_directional_albedo(float NdotV, float roughness)
+float mx_burley_diffuse_dir_albedo(float NdotV, float roughness)
 {
     float x = NdotV;
     float fit0 = 0.97619 - 0.488095 * mx_pow5(1.0 - x);

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -29,7 +29,7 @@ float mx_imageworks_sheen_dir_albedo_curve_fit(float NdotV, float roughness)
 {
     float a = 5.25248 - 7.66024 * NdotV + 14.26377 * roughness;
     float b = 1.0 + 30.66449 * NdotV + 32.53420 * roughness;
-    return clamp(a / b, 0.0, 1.0);
+    return a / b;
 }
 
 float mx_imageworks_sheen_dir_albedo_table_lookup(float NdotV, float roughness)
@@ -78,10 +78,11 @@ float mx_imageworks_sheen_dir_albedo_monte_carlo(float NdotV, float roughness)
 float mx_imageworks_sheen_dir_albedo(float NdotV, float roughness)
 {
 #if DIRECTIONAL_ALBEDO_METHOD == 0
-    return mx_imageworks_sheen_dir_albedo_curve_fit(NdotV, roughness);
+    float dirAlbedo = mx_imageworks_sheen_dir_albedo_curve_fit(NdotV, roughness);
 #elif DIRECTIONAL_ALBEDO_METHOD == 1
-    return mx_imageworks_sheen_dir_albedo_table_lookup(NdotV, roughness);
+    float dirAlbedo = mx_imageworks_sheen_dir_albedo_table_lookup(NdotV, roughness);
 #else
-    return mx_imageworks_sheen_dir_albedo_monte_carlo(NdotV, roughness);
+    float dirAlbedo = mx_imageworks_sheen_dir_albedo_monte_carlo(NdotV, roughness);
 #endif
+    return clamp(dirAlbedo, 0.0, 1.0);
 }

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -2,18 +2,86 @@
 
 // http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
 // Equation 2
-float mx_imageworks_sheen_NDF(float cosTheta, float roughness)
+float mx_imageworks_sheen_NDF(float NdotH, float roughness)
 {
-    float invRoughness = 1.0 / max(roughness, 0.0001);
-    float cos2 = cosTheta * cosTheta;
+    float invRoughness = 1.0 / max(roughness, 0.005);
+    float cos2 = NdotH * NdotH;
     float sin2 = 1.0 - cos2;
     return (2.0 + invRoughness) * pow(sin2, invRoughness * 0.5) / (2.0 * M_PI);
 }
 
-// Rational curve fit approximation for the directional albedo of Imageworks sheen.
-float mx_imageworks_sheen_directional_albedo(float cosTheta, float roughness)
+float mx_imageworks_sheen_brdf(float NdotL, float NdotV, float NdotH, float roughness)
 {
-    float a = 1.59053 - 2.00439 * cosTheta + 3.45331 * roughness;
-    float b = 1.0 + 7.99160 * cosTheta + 8.25488 * roughness;
+    // Microfacet distribution.
+    float D = mx_imageworks_sheen_NDF(NdotH, roughness);
+
+    // Fresnel and geometry terms are ignored.
+    float F = 1.0;
+    float G = 1.0;
+
+    // We use a smoother denominator, as in:
+    // https://blog.selfshadow.com/publications/s2013-shading-course/rad/s2013_pbs_rad_notes.pdf
+    return D * F * G / (4.0 * (NdotL + NdotV - NdotL*NdotV));
+}
+
+// Rational curve fit approximation for the directional albedo of Imageworks sheen.
+float mx_imageworks_sheen_dir_albedo_curve_fit(float NdotV, float roughness)
+{
+    float a = 5.25248 - 7.66024 * NdotV + 14.26377 * roughness;
+    float b = 1.0 + 30.66449 * NdotV + 32.53420 * roughness;
     return clamp(a / b, 0.0, 1.0);
+}
+
+float mx_imageworks_sheen_dir_albedo_table_lookup(float NdotV, float roughness)
+{
+#if DIRECTIONAL_ALBEDO_METHOD == 1
+    vec2 res = textureSize($albedoTable, 0);
+    if (res.x > 1)
+    {
+        return texture($albedoTable, vec2(NdotV, roughness)).b;
+    }
+#endif
+    return 0.0;
+}
+
+float mx_imageworks_sheen_dir_albedo_monte_carlo(float NdotV, float roughness)
+{
+    NdotV = clamp(NdotV, M_FLOAT_EPS, 1.0);
+    vec3 V = vec3(sqrt(1.0f - mx_square(NdotV)), 0, NdotV);
+
+    float sum = 0.0;
+    const int SAMPLE_COUNT = 64;
+    for (int i = 0; i < SAMPLE_COUNT; i++)
+    {
+        vec2 Xi = mx_spherical_fibonacci(i, SAMPLE_COUNT);
+
+        // Compute the half vector and incoming light direction.
+        vec3 H = mx_uniform_sample_hemisphere(Xi);
+        vec3 L = -reflect(V, H);
+        
+        // Compute dot products for this sample.
+        float NdotL = clamp(L.z, M_FLOAT_EPS, 1.0);
+        float NdotH = clamp(H.z, M_FLOAT_EPS, 1.0);
+        float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
+
+        // Compute sheen reflectance.
+        float reflectance = mx_imageworks_sheen_brdf(NdotL, NdotV, NdotH, roughness);
+
+        // Add the radiance contribution of this sample.
+        sum += reflectance * NdotL * 8.0 * M_PI * VdotH;
+    }
+
+    // Return the final directional albedo.
+    return sum / float(SAMPLE_COUNT);
+}
+
+float mx_imageworks_sheen_dir_albedo(float NdotV, float roughness)
+{
+#if DIRECTIONAL_ALBEDO_METHOD == 0
+    return mx_imageworks_sheen_dir_albedo_curve_fit(NdotV, roughness);
+#elif DIRECTIONAL_ALBEDO_METHOD == 1
+    return mx_imageworks_sheen_dir_albedo_table_lookup(NdotV, roughness);
+#else
+    return mx_imageworks_sheen_dir_albedo_monte_carlo(NdotV, roughness);
+#endif
 }

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -49,7 +49,7 @@ float mx_imageworks_sheen_dir_albedo_monte_carlo(float NdotV, float roughness)
     NdotV = clamp(NdotV, M_FLOAT_EPS, 1.0);
     vec3 V = vec3(sqrt(1.0f - mx_square(NdotV)), 0, NdotV);
 
-    float sum = 0.0;
+    float radiance = 0.0;
     const int SAMPLE_COUNT = 64;
     for (int i = 0; i < SAMPLE_COUNT; i++)
     {
@@ -68,11 +68,14 @@ float mx_imageworks_sheen_dir_albedo_monte_carlo(float NdotV, float roughness)
         float reflectance = mx_imageworks_sheen_brdf(NdotL, NdotV, NdotH, roughness);
 
         // Add the radiance contribution of this sample.
-        sum += reflectance * NdotL * 8.0 * M_PI * VdotH;
+        //   uniform_pdf = 1 / (2 * PI)
+        //   Jacobian = 1 / (4 * VdotH)
+        //   radiance = reflectance / (uniform_pdf * Jacobian)
+        radiance += reflectance * NdotL * 8.0 * M_PI * VdotH;
     }
 
     // Return the final directional albedo.
-    return sum / float(SAMPLE_COUNT);
+    return radiance / float(SAMPLE_COUNT);
 }
 
 float mx_imageworks_sheen_dir_albedo(float NdotV, float roughness)

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -55,23 +55,21 @@ float mx_imageworks_sheen_dir_albedo_monte_carlo(float NdotV, float roughness)
     {
         vec2 Xi = mx_spherical_fibonacci(i, SAMPLE_COUNT);
 
-        // Compute the half vector and incoming light direction.
-        vec3 H = mx_uniform_sample_hemisphere(Xi);
-        vec3 L = -reflect(V, H);
+        // Compute the incoming light direction and half vector.
+        vec3 L = mx_uniform_sample_hemisphere(Xi);
+        vec3 H = normalize(L + V);
         
         // Compute dot products for this sample.
         float NdotL = clamp(L.z, M_FLOAT_EPS, 1.0);
         float NdotH = clamp(H.z, M_FLOAT_EPS, 1.0);
-        float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
         // Compute sheen reflectance.
         float reflectance = mx_imageworks_sheen_brdf(NdotL, NdotV, NdotH, roughness);
 
         // Add the radiance contribution of this sample.
         //   uniform_pdf = 1 / (2 * PI)
-        //   Jacobian = 1 / (4 * VdotH)
-        //   radiance = reflectance * NdotL / (uniform_pdf * Jacobian)
-        radiance += reflectance * NdotL * 8.0 * M_PI * VdotH;
+        //   radiance = reflectance * NdotL / uniform_pdf;
+        radiance += reflectance * NdotL * 2.0 * M_PI;
     }
 
     // Return the final directional albedo.

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -70,7 +70,7 @@ float mx_imageworks_sheen_dir_albedo_monte_carlo(float NdotV, float roughness)
         // Add the radiance contribution of this sample.
         //   uniform_pdf = 1 / (2 * PI)
         //   Jacobian = 1 / (4 * VdotH)
-        //   radiance = reflectance / (uniform_pdf * Jacobian)
+        //   radiance = reflectance * NdotL / (uniform_pdf * Jacobian)
         radiance += reflectance * NdotL * 8.0 * M_PI * VdotH;
     }
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -40,7 +40,7 @@ float mx_ggx_smith_G(float NdotL, float NdotV, float alpha)
 }
 
 // https://www.unrealengine.com/blog/physically-based-shading-on-mobile
-vec3 mx_ggx_directional_albedo_curve_fit(float NdotV, float roughness, vec3 F0, vec3 F90)
+vec3 mx_ggx_dir_albedo_curve_fit(float NdotV, float roughness, vec3 F0, vec3 F90)
 {
     const vec4 c0 = vec4(-1, -0.0275, -0.572, 0.022);
     const vec4 c1 = vec4( 1,  0.0425,  1.04, -0.04 );
@@ -50,7 +50,7 @@ vec3 mx_ggx_directional_albedo_curve_fit(float NdotV, float roughness, vec3 F0, 
     return F0 * AB.x + F90 * AB.y;
 }
 
-vec3 mx_ggx_directional_albedo_table_lookup(float NdotV, float roughness, vec3 F0, vec3 F90)
+vec3 mx_ggx_dir_albedo_table_lookup(float NdotV, float roughness, vec3 F0, vec3 F90)
 {
 #if DIRECTIONAL_ALBEDO_METHOD == 1
     vec2 res = textureSize($albedoTable, 0);
@@ -64,7 +64,7 @@ vec3 mx_ggx_directional_albedo_table_lookup(float NdotV, float roughness, vec3 F
 }
 
 // https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
-vec3 mx_ggx_directional_albedo_importance_sample(float NdotV, float roughness, vec3 F0, vec3 F90)
+vec3 mx_ggx_dir_albedo_monte_carlo(float NdotV, float roughness, vec3 F0, vec3 F90)
 {
     NdotV = clamp(NdotV, M_FLOAT_EPS, 1.0);
     vec3 V = vec3(sqrt(1.0f - mx_square(NdotV)), 0, NdotV);
@@ -101,27 +101,27 @@ vec3 mx_ggx_directional_albedo_importance_sample(float NdotV, float roughness, v
     return F0 * AB.x + F90 * AB.y;
 }
 
-vec3 mx_ggx_directional_albedo(float NdotV, float roughness, vec3 F0, vec3 F90)
+vec3 mx_ggx_dir_albedo(float NdotV, float roughness, vec3 F0, vec3 F90)
 {
 #if DIRECTIONAL_ALBEDO_METHOD == 0
-    return mx_ggx_directional_albedo_curve_fit(NdotV, roughness, F0, F90);
+    return mx_ggx_dir_albedo_curve_fit(NdotV, roughness, F0, F90);
 #elif DIRECTIONAL_ALBEDO_METHOD == 1
-    return mx_ggx_directional_albedo_table_lookup(NdotV, roughness, F0, F90);
+    return mx_ggx_dir_albedo_table_lookup(NdotV, roughness, F0, F90);
 #else
-    return mx_ggx_directional_albedo_importance_sample(NdotV, roughness, F0, F90);
+    return mx_ggx_dir_albedo_monte_carlo(NdotV, roughness, F0, F90);
 #endif
 }
 
-float mx_ggx_directional_albedo(float NdotV, float roughness, float F0, float F90)
+float mx_ggx_dir_albedo(float NdotV, float roughness, float F0, float F90)
 {
-    return mx_ggx_directional_albedo(NdotV, roughness, vec3(F0), vec3(F90)).x;
+    return mx_ggx_dir_albedo(NdotV, roughness, vec3(F0), vec3(F90)).x;
 }
 
 // https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
 // Equations 14 and 16
 vec3 mx_ggx_energy_compensation(float NdotV, float roughness, vec3 Fss)
 {
-    float Ess = mx_ggx_directional_albedo(NdotV, roughness, 1.0, 1.0);
+    float Ess = mx_ggx_dir_albedo(NdotV, roughness, 1.0, 1.0);
     return 1.0 + Fss * (1.0 - Ess) / Ess;
 }
 

--- a/libraries/pbrlib/genglsl/lib/mx_table.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_table.glsl
@@ -1,7 +1,10 @@
+#include "pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
 #include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
-vec2 mx_ggx_directional_albedo_generate_table()
+vec3 mx_generate_dir_albedo_table()
 {
     vec2 uv = gl_FragCoord.xy / $albedoTableSize;
-    return mx_ggx_directional_albedo_importance_sample(uv.x, uv.y, vec3(1, 0, 0), vec3(0, 1, 0)).xy;
+    vec2 ggxDirAlbedo = mx_ggx_dir_albedo_monte_carlo(uv.x, uv.y, vec3(1, 0, 0), vec3(0, 1, 0)).xy;
+    float sheenDirAlbedo = mx_imageworks_sheen_dir_albedo_monte_carlo(uv.x, uv.y);
+    return vec3(ggxDirAlbedo, sheenDirAlbedo);
 }

--- a/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
@@ -30,6 +30,6 @@ void mx_burley_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float rou
     float NdotV = clamp(dot(normal, V), M_FLOAT_EPS, 1.0);
 
     vec3 Li = mx_environment_irradiance(normal) *
-              mx_burley_diffuse_directional_albedo(NdotV, roughness);
+              mx_burley_diffuse_dir_albedo(NdotV, roughness);
     result = Li * color * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -28,7 +28,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
 
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
 
     // Note: NdotL is cancelled out
     result = D * F * G * comp * tint * occlusion * weight / (4.0 * NdotV) // Top layer reflection
@@ -71,7 +71,7 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
     float avgRoughness = mx_average_roughness(safeRoughness);
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
 
     result = base * (1.0 - dirAlbedo * weight); // Transmission attenuated by reflection amount
 }
@@ -100,7 +100,7 @@ void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
     float avgRoughness = mx_average_roughness(safeRoughness);
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
 
     vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);
 

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -27,7 +27,7 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
     float G = mx_ggx_smith_G(NdotL, NdotV, avgRoughness);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
     // Note: NdotL is cancelled out
@@ -56,7 +56,7 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgRoughness = mx_average_roughness(safeRoughness);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
     result = base * (1.0 - avgDirAlbedo * weight); // Transmission attenuated by top layer
@@ -79,7 +79,7 @@ void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec
     vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgRoughness = mx_average_roughness(safeRoughness);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
 
     vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);

--- a/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
@@ -16,13 +16,8 @@ void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float wei
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
     float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
 
-    float D = mx_imageworks_sheen_NDF(NdotH, roughness);
-
-    // Geometry term is skipped and we use a smoother denominator, as in:
-    // https://blog.selfshadow.com/publications/s2013-shading-course/rad/s2013_pbs_rad_notes.pdf
-    vec3 fr = D * color / (4.0 * (NdotL + NdotV - NdotL*NdotV));
-
-    float dirAlbedo = mx_imageworks_sheen_directional_albedo(NdotV, roughness);
+    vec3 fr = color * mx_imageworks_sheen_brdf(NdotL, NdotV, NdotH, roughness);
+    float dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
 
     // We need to include NdotL from the light integral here
     // as in this case it's not cancelled out by the BRDF denominator.
@@ -42,7 +37,7 @@ void mx_sheen_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, v
 
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    float dirAlbedo = mx_imageworks_sheen_directional_albedo(NdotV, roughness);
+    float dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
 
     vec3 Li = mx_environment_irradiance(N);
     result = Li * color * dirAlbedo * weight        // Top layer reflection

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
@@ -5,10 +5,11 @@ float mx_imageworks_sheen_dir_albedo_curve_fit(float NdotV, float roughness)
 {
     float a = 5.25248 - 7.66024 * NdotV + 14.26377 * roughness;
     float b = 1.0 + 30.66449 * NdotV + 32.53420 * roughness;
-    return clamp(a / b, 0.0, 1.0);
+    return a / b;
 }
 
 float mx_imageworks_sheen_dir_albedo(float NdotV, float roughness)
 {
-    return mx_imageworks_sheen_dir_albedo_curve_fit(NdotV, roughness);
+    float dirAlbedo = mx_imageworks_sheen_dir_albedo_curve_fit(NdotV, roughness);
+    return clamp(dirAlbedo, 0.0, 1.0);
 }

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
@@ -1,0 +1,14 @@
+#include "pbrlib/genosl/lib/mx_microfacet.osl"
+
+// Rational curve fit approximation for the directional albedo of Imageworks sheen.
+float mx_imageworks_sheen_dir_albedo_curve_fit(float NdotV, float roughness)
+{
+    float a = 5.25248 - 7.66024 * NdotV + 14.26377 * roughness;
+    float b = 1.0 + 30.66449 * NdotV + 32.53420 * roughness;
+    return clamp(a / b, 0.0, 1.0);
+}
+
+float mx_imageworks_sheen_dir_albedo(float NdotV, float roughness)
+{
+    return mx_imageworks_sheen_dir_albedo_curve_fit(NdotV, roughness);
+}

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
@@ -23,7 +23,7 @@ float mx_ggx_smith_G(float NdotL, float NdotV, float alpha)
 }
 
 // https://www.unrealengine.com/blog/physically-based-shading-on-mobile
-color mx_ggx_directional_albedo_curve_fit(float NdotV, float roughness, color F0, color F90)
+color mx_ggx_dir_albedo_curve_fit(float NdotV, float roughness, color F0, color F90)
 {
     vector4 c0 = vector4(-1, -0.0275, -0.572, 0.022);
     vector4 c1 = vector4( 1,  0.0425,  1.04, -0.04 );
@@ -33,7 +33,7 @@ color mx_ggx_directional_albedo_curve_fit(float NdotV, float roughness, color F0
     return F0 * AB.x + F90 * AB.y;
 }
 
-color mx_ggx_directional_albedo_table_lookup(float NdotV, float roughness, color F0, color F90)
+color mx_ggx_dir_albedo_table_lookup(float NdotV, float roughness, color F0, color F90)
 {
     vector2 st = vector2(NdotV, roughness);
     vector AB = texture(GGX_DIRECTIONAL_ALBEDO_TABLE, st.x, st.y);
@@ -41,7 +41,7 @@ color mx_ggx_directional_albedo_table_lookup(float NdotV, float roughness, color
 }
 
 // https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
-color mx_ggx_directional_albedo_importance_sample(float _NdotV, float roughness, color F0, color F90)
+color mx_ggx_dir_albedo_monte_carlo(float _NdotV, float roughness, color F0, color F90)
 {
     float NdotV = clamp(_NdotV, M_FLOAT_EPS, 1.0);
     vector V = vector(sqrt(1.0 - mx_square(NdotV)), 0.0, NdotV);
@@ -78,26 +78,26 @@ color mx_ggx_directional_albedo_importance_sample(float _NdotV, float roughness,
     return F0 * AB.x + F90 * AB.y;
 }
 
-color mx_ggx_directional_albedo(float NdotV, float roughness, color F0, color F90)
+color mx_ggx_dir_albedo(float NdotV, float roughness, color F0, color F90)
 {
 #if GGX_DIRECTIONAL_ALBEDO_METHOD == 0
-    return mx_ggx_directional_albedo_curve_fit(NdotV, roughness, F0, F90);
+    return mx_ggx_dir_albedo_curve_fit(NdotV, roughness, F0, F90);
 #elif GGX_DIRECTIONAL_ALBEDO_METHOD == 1
-    return mx_ggx_directional_albedo_table_lookup(NdotV, roughness, F0, F90);
+    return mx_ggx_dir_albedo_table_lookup(NdotV, roughness, F0, F90);
 #else
-    return mx_ggx_directional_albedo_importance_sample(NdotV, roughness, F0, F90);
+    return mx_ggx_dir_albedo_monte_carlo(NdotV, roughness, F0, F90);
 #endif
 }
 
-float mx_ggx_directional_albedo(float NdotV, float roughness, float F0, float F90)
+float mx_ggx_dir_albedo(float NdotV, float roughness, float F0, float F90)
 {
-    color result = mx_ggx_directional_albedo(NdotV, roughness, color(F0), color(F90));
+    color result = mx_ggx_dir_albedo(NdotV, roughness, color(F0), color(F90));
     return result[0];
 }
 
-float mx_ggx_directional_albedo(float NdotV, float roughness, float ior)
+float mx_ggx_dir_albedo(float NdotV, float roughness, float ior)
 {
-    color result = mx_ggx_directional_albedo(NdotV, roughness, color(mx_ior_to_f0(ior)), color(1.0));
+    color result = mx_ggx_dir_albedo(NdotV, roughness, color(mx_ior_to_f0(ior)), color(1.0));
     return result[0];
 }
 
@@ -105,7 +105,7 @@ float mx_ggx_directional_albedo(float NdotV, float roughness, float ior)
 // Equations 14 and 16
 color mx_ggx_energy_compensation(float NdotV, float roughness, color Fss)
 {
-    float Ess = mx_ggx_directional_albedo(NdotV, roughness, 1.0, 1.0);
+    float Ess = mx_ggx_dir_albedo(NdotV, roughness, 1.0, 1.0);
     return 1.0 + Fss * (1.0 - Ess) / Ess;
 }
 

--- a/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
@@ -23,7 +23,7 @@ void mx_dielectric_bsdf(float weight, color tint, float ior, vector2 roughness, 
     {
         // Calculate directional albedo since we need
         // to attenuate the base layer according to this.
-        float dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, ior) * comp;
+        float dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, ior) * comp;
 
         result = tint * weight * comp * microfacet(distribution, N, U, roughness.x, roughness.y, ior, 0)
                  + base * (1.0 - dirAlbedo * weight);

--- a/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
@@ -23,7 +23,7 @@ void mx_generalized_schlick_bsdf(float weight, color color0, color color90, floa
 
     // Calculate directional albedo since we need
     // to attenuate the base layer according to this.
-    color dirAlbedo = mx_ggx_directional_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    color dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, color(1.0 / 3.0));
 
     // Set ior to 0.0 to disable the internal dielectric fresnel

--- a/libraries/pbrlib/genosl/mx_sheen_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_sheen_bsdf.osl
@@ -1,10 +1,4 @@
-// Rational curve fit approximation for the directional albedo of Imageworks sheen.
-float mx_imageworks_sheen_directional_albedo(float cosTheta, float roughness)
-{
-    float a = 1.59053 - 2.00439 * cosTheta + 3.45331 * roughness;
-    float b = 1.0 + 7.99160 * cosTheta + 8.25488 * roughness;
-    return clamp(a / b, 0.0, 1.0);
-}
+#include "pbrlib/genosl/lib/mx_microfacet_sheen.osl"
 
 // TODO: Vanilla OSL doesn't have a proper sheen closure,
 // so use 'diffuse' scaled by sheen directional albedo for now.
@@ -19,7 +13,7 @@ void mx_sheen_bsdf(float weight, color Ks, float roughness, vector N, BSDF base,
 
         float NdotV = fabs(dot(N,V));
         float alpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-        float albedo = weight * mx_imageworks_sheen_directional_albedo(NdotV, alpha);
+        float albedo = weight * mx_imageworks_sheen_dir_albedo(NdotV, alpha);
         result = albedo * Ks * diffuse(N) + (1.0 - albedo) * base;
     }
     else

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -559,7 +559,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     }
     else if (context.getOptions().hwWriteAlbedoTable)
     {
-        emitLine(outputSocket->getVariable() + " = vec4(mx_ggx_directional_albedo_generate_table(), 0.0, 1.0)", stage);
+        emitLine(outputSocket->getVariable() + " = vec4(mx_generate_dir_albedo_table(), 1.0)", stage);
     }
     else
     {

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -55,8 +55,8 @@ enum HwDirectionalAlbedoMethod
     /// Use a table look-up for directional albedo.
     DIRECTIONAL_ALBEDO_TABLE,
 
-    /// Use importance sampling for directional albedo.
-    DIRECTIONAL_ALBEDO_IS
+    /// Use Monte Carlo integration for directional albedo.
+    DIRECTIONAL_ALBEDO_MONTE_CARLO
 };
 
 /// @class GenOptions 

--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -10,6 +10,7 @@
 #include <MaterialXGenShader/Nodes/ConvolutionNode.h>
 
 #include <cstring>
+#include <fstream>
 #include <limits>
 
 namespace MaterialX
@@ -438,6 +439,22 @@ ImagePair Image::splitByLuminance(float luminance)
     }
 
     return std::make_pair(underflowImage, overflowImage);
+}
+
+void Image::writeTable(const FilePath& filePath, unsigned int channel)
+{
+    std::ofstream ofs(filePath.asString());
+    ofs << "X Y Z" << std::endl;
+    for (unsigned int y = 0; y < getHeight(); y++)
+    {
+        for (unsigned int x = 0; x < getWidth(); x++)
+        {
+            double dx = ((double) x + 0.5) / (double) getWidth();
+            double dy = ((double) y + 0.5) / (double) getHeight();
+            double dz = getTexelColor(x, y)[channel];
+            ofs << dx << " " << dy << " " << dz << std::endl;
+        }
+    }
 }
 
 void Image::createResourceBuffer()

--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -9,9 +9,11 @@
 /// @file
 /// Image class
 
-#include <MaterialXCore/Types.h>
-
 #include <MaterialXRender/Export.h>
+
+#include <MaterialXFormat/File.h>
+
+#include <MaterialXCore/Types.h>
 
 namespace MaterialX
 {
@@ -136,6 +138,10 @@ class MX_RENDER_API Image
     /// Split this image by the given luminance threshold, returning the
     /// resulting underflow and overflow images.
     ImagePair splitByLuminance(float luminance);
+
+    /// Save a channel of this image to disk as a text table, in a format
+    /// that can be used for curve and surface fitting.
+    void writeTable(const FilePath& filePath, unsigned int channel);
 
     /// @}
     /// @name Resource Buffers

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -30,6 +30,11 @@ GLTextureHandler::GLTextureHandler(ImageLoaderPtr imageLoader) :
 
 bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties)
 {
+    if (!image)
+    {
+        return false;
+    }
+
     // Create renderer resources if needed.
     if (image->getResourceId() == GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID)
     {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -867,7 +867,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
     referenceQualityBox->setChecked(false);
     referenceQualityBox->setCallback([this](bool enable)
     {
-        _genContext.getOptions().hwDirectionalAlbedoMethod = enable ? mx::DIRECTIONAL_ALBEDO_IS : mx::DIRECTIONAL_ALBEDO_TABLE;
+        _genContext.getOptions().hwDirectionalAlbedoMethod = enable ? mx::DIRECTIONAL_ALBEDO_MONTE_CARLO : mx::DIRECTIONAL_ALBEDO_TABLE;
         reloadShaders();
     });
 
@@ -2393,7 +2393,7 @@ void Viewer::updateAlbedoTable()
     }
 
     // Create framebuffer.
-    mx::GLFrameBufferPtr framebuffer = mx::GLFramebuffer::create(ALBEDO_TABLE_SIZE, ALBEDO_TABLE_SIZE, 2, mx::Image::BaseType::FLOAT);
+    mx::GLFrameBufferPtr framebuffer = mx::GLFramebuffer::create(ALBEDO_TABLE_SIZE, ALBEDO_TABLE_SIZE, 3, mx::Image::BaseType::FLOAT);
     framebuffer->bind();
     glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);


### PR DESCRIPTION
- Add a ground-truth GPU Monte Carlo mode for sheen albedo.
- Add a GPU-generated table mode for sheen albedo, and make this the default in the viewer.
- Update curve constants for sheen albedo based on newly-generated data.
- Increase the minimum sheen roughness to 0.005, in order to avoid rendering artifacts in Monte Carlo mode.
- Minor clarity improvements to directional albedo functions.