### PR TITLE
Improved rational curve fit for sheen albedo

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -27,9 +27,13 @@ float mx_imageworks_sheen_brdf(float NdotL, float NdotV, float NdotH, float roug
 // Rational curve fit approximation for the directional albedo of Imageworks sheen.
 float mx_imageworks_sheen_dir_albedo_curve_fit(float NdotV, float roughness)
 {
-    float a = 5.25248 - 7.66024 * NdotV + 14.26377 * roughness;
-    float b = 1.0 + 30.66449 * NdotV + 32.53420 * roughness;
-    return a / b;
+    vec2 r = vec2(13.67300, 1.0) +
+             vec2(-68.78018, 61.57746) * NdotV +
+             vec2(799.08825, 442.78211) * roughness +
+             vec2(-905.00061, 2597.49308) * NdotV * roughness +
+             vec2(60.28956, 121.81241) * mx_square(NdotV) +
+             vec2(1086.96473, 3045.55075) * mx_square(roughness);
+    return r.x / r.y;
 }
 
 float mx_imageworks_sheen_dir_albedo_table_lookup(float NdotV, float roughness)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -37,7 +37,7 @@ const int MIN_ENV_SAMPLES = 4;
 const int MAX_ENV_SAMPLES = 1024;
 
 const int SHADOW_MAP_SIZE = 2048;
-const int ALBEDO_TABLE_SIZE = 64;
+const int ALBEDO_TABLE_SIZE = 128;
 const int IRRADIANCE_MAP_WIDTH = 256;
 const int IRRADIANCE_MAP_HEIGHT = 128;
 


### PR DESCRIPTION
This changelist improves the rational curve fit for sheen directional albedo, generating results that are significantly closer to Monte Carlo reference for low roughness values.

Additionally, it increases the size of the directional albedo table to 128, allowing a correct match for sheen direction albedo when table-based rendering is used.