### PR TITLE
Use VNDF sampling for GGX directional albedo

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -45,7 +45,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distrib
         vec3 F = mx_compute_fresnel(VdotH, fd);
 
         // Compute the geometric term.
-        float G = mx_ggx_smith_G(NdotL, NdotV, mx_average_roughness(roughness));
+        float G = mx_ggx_smith_G2(NdotL, NdotV, mx_average_roughness(roughness));
         
         // Add the radiance contribution of this sample.
         // From https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -16,7 +16,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distrib
 
     float avgRoughness = mx_average_roughness(roughness);
     vec3 F = mx_compute_fresnel(NdotV, fd);
-    float G = mx_ggx_smith_G(NdotV, NdotV, avgRoughness);
+    float G = mx_ggx_smith_G2(NdotV, NdotV, avgRoughness);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
     vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_compute_lod(avgRoughness), $envRadiance);
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -29,6 +29,35 @@ vec3 mx_ggx_importance_sample_NDF(vec2 Xi, vec3 X, vec3 Y, vec3 N, float alphaX,
     return normalize(H);
 }
 
+// http://jcgt.org/published/0007/04/01/paper.pdf
+// Appendix A Listing 1
+vec3 mx_ggx_importance_sample_VNDF(vec2 Xi, vec3 V, float alphaX, float alphaY)
+{
+    // Transform the view direction to the hemisphere configuration.
+    vec3 Vh = normalize(vec3(alphaX * V.x, alphaY * V.y, V.z));
+
+    // Orthonormal basis (with special case if cross product is zero).
+    float lensq = Vh.x * Vh.x + Vh.y * Vh.y;
+    vec3 T1 = lensq > 0.0 ? vec3(-Vh.y, Vh.x, 0.0) / sqrt(lensq) : vec3(1.0, 0.0, 0.0);
+    vec3 T2 = cross(Vh, T1);
+
+    // Parameterization of the projected area.
+    float r = sqrt(Xi.y);
+    float phi = 2.0 * M_PI * Xi.x;
+    float t1 = r * cos(phi);
+    float t2 = r * sin(phi);
+    float s = 0.5 * (1.0 + Vh.z);
+    t2 = (1.0 - s) * sqrt(1.0 - t1 * t1) + s * t2;
+
+    // Reprojection onto hemisphere.
+    vec3 Nh = t1 * T1 + t2 * T2 + sqrt(max(0.0, 1.0 - t1 * t1 - t2 * t2)) * Vh;
+
+    // Transform the normal back to the ellipsoid configuration.
+    vec3 H = normalize(vec3(alphaX * Nh.x, alphaY * Nh.y, max(0.0, Nh.z)));
+
+    return H;
+}
+
 // http://jcgt.org/published/0003/02/03/paper.pdf
 // Equations 72 and 99
 float mx_ggx_smith_G(float NdotL, float NdotV, float alpha)
@@ -39,22 +68,31 @@ float mx_ggx_smith_G(float NdotL, float NdotV, float alpha)
     return 2.0 / (lambdaL / NdotL + lambdaV / NdotV);
 }
 
-// Rational curve fit approximation for GGX directional albedo.
+// https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
+// Equation 34
+float mx_ggx_smith_G_separable(float cosTheta, float alpha)
+{
+    float cosTheta2 = mx_square(cosTheta);
+    float tanTheta2 = (1.0 - cosTheta2) / cosTheta2;
+    return 2.0 / (1.0 + sqrt(1.0 + mx_square(alpha) * tanTheta2));
+}
+
+// Rational quadratic fit to Monte Carlo data for GGX directional albedo.
 vec3 mx_ggx_dir_albedo_curve_fit(float NdotV, float roughness, vec3 F0, vec3 F90)
 {
     float x = NdotV;
     float y = roughness;
     float x2 = mx_square(NdotV);
     float y2 = mx_square(roughness);
-    vec4 r = vec4(0.08450, 0.96298, 1.0, 1.0) +
-             vec4(-0.36165, -2.43215, -1.93044, 0.57282) * x +
-             vec4(9.89773, 0.60451, 7.45723, 13.97512) * y +
-             vec4(-0.89027, 0.11949, 16.71279, -43.43587) * x * y +
-             vec4(25.88029, 1.51522, 26.08112, 11.47484) * x2 +
-             vec4(-7.59353, -0.03927, -6.00600, 22.68142) * y2 +
-             vec4(-9.67803, -0.89065, -25.40702, 29.05581) * x2 * y +
-             vec4(26.63159, -1.39136, 22.64064, 225.10503) * x * y2 +
-             vec4(-26.72404, 1.63585, 21.08303, -189.10043) * x2 * y2;
+    vec4 r = vec4(0.10901, 0.92163, 1.0, 1.0) +
+             vec4(-0.72019, -2.29412, -1.81963, -0.02130) * x +
+             vec4(9.54750, 1.78914, 8.10489, 15.21516) * y +
+             vec4(-0.93177, -2.62475, 12.89250, -45.75644) * x * y +
+             vec4(29.60456, 1.40796, 29.11995, 13.53548) * x2 +
+             vec4(-8.10263, -0.48479, -7.40042, 34.87345) * y2 +
+             vec4(-27.96958, 0.71494, -36.69717, 26.50811) * x2 * y +
+             vec4(18.28144, -0.50156, 13.79722, 253.01230) * x * y2 +
+             vec4(-4.85579, 1.22080, 32.57057, -162.71012) * x2 * y2;
     vec2 AB = r.xy / r.zw;
     return F0 * AB.x + F90 * AB.y;
 }
@@ -85,7 +123,7 @@ vec3 mx_ggx_dir_albedo_monte_carlo(float NdotV, float roughness, vec3 F0, vec3 F
         vec2 Xi = mx_spherical_fibonacci(i, SAMPLE_COUNT);
 
         // Compute the half vector and incoming light direction.
-        vec3 H = mx_ggx_importance_sample_NDF(Xi, vec3(1, 0, 0), vec3(0, 1, 0), vec3(0, 0, 1), roughness, roughness);
+        vec3 H = mx_ggx_importance_sample_VNDF(Xi, V, roughness, roughness);
         vec3 L = -reflect(V, H);
         
         // Compute dot products for this sample.
@@ -96,8 +134,9 @@ vec3 mx_ggx_dir_albedo_monte_carlo(float NdotV, float roughness, vec3 F0, vec3 F
         // Compute the Fresnel term.
         float Fc = mx_fresnel_schlick(VdotH, 0.0, 1.0);
 
-        // Compute the geometric visibility term.
-        float Gvis = mx_ggx_smith_G(NdotL, NdotV, roughness) * VdotH / (NdotH * NdotV);
+        // Compute the geometric visibility term, folding in the BRDF denominator and PDF.
+        // http://jcgt.org/published/0007/04/01/paper.pdf, Equation 19
+        float Gvis = mx_ggx_smith_G(NdotL, NdotV, roughness) / mx_ggx_smith_G_separable(NdotV, roughness);
         
         // Add the contribution of this sample.
         AB += vec2(Gvis * (1.0 - Fc), Gvis * Fc);

--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -29,7 +29,7 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
     vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgRoughness = mx_average_roughness(safeRoughness);
     float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
-    float G = mx_ggx_smith_G(NdotL, NdotV, avgRoughness);
+    float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
 

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -24,7 +24,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
     FresnelData fd = tf.thickness > 0.0 ? mx_init_fresnel_dielectric_airy(ior, tf.thickness, tf.ior) : mx_init_fresnel_dielectric(ior);
     vec3  F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
-    float G = mx_ggx_smith_G(NdotL, NdotV, avgRoughness);
+    float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
 
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -24,7 +24,7 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3  F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
-    float G = mx_ggx_smith_G(NdotL, NdotV, avgRoughness);
+    float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
     vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
@@ -12,9 +12,10 @@ vector mx_ggx_importance_sample_NDF(vector2 Xi, vector X, vector Y, vector N, fl
     return normalize(H);
 }
 
+// Height-correlated Smith masking-shadowing
 // http://jcgt.org/published/0003/02/03/paper.pdf
 // Equations 72 and 99
-float mx_ggx_smith_G(float NdotL, float NdotV, float alpha)
+float mx_ggx_smith_G2(float NdotL, float NdotV, float alpha)
 {
     float alpha2 = mx_square(alpha);
     float lambdaL = sqrt(alpha2 + (1.0 - alpha2) * mx_square(NdotL));
@@ -65,7 +66,7 @@ color mx_ggx_dir_albedo_monte_carlo(float _NdotV, float roughness, color F0, col
         float Fc = mx_fresnel_schlick(VdotH, 0.0, 1.0);
 
         // Compute the geometric visibility term.
-        float Gvis = mx_ggx_smith_G(NdotL, NdotV, roughness) * VdotH / (NdotH * NdotV);
+        float Gvis = mx_ggx_smith_G2(NdotL, NdotV, roughness) * VdotH / (NdotH * NdotV);
         
         // Add the contribution of this sample.
         AB += vector2(Gvis * (1 - Fc), Gvis * Fc);


### PR DESCRIPTION
This changelist updates the Monte Carlo computation for GGX directional albedo to use VNDF sampling (http://jcgt.org/published/0007/04/01/paper.pdf), creating a notable improvement in its accuracy.  Additionally, the rational quadratic fit for for GGX directional albedo has been rebuilt from the latest Monte Carlo data, creating a smoother, more accurate fit.