### PR TITLE
Apply Clang formatting to MaterialXCore

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,7 @@ BreakConstructorInitializersBeforeComma: true
 ColumnLimit: 0
 Cpp11BracedListStyle: false
 IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
 IndentWidth: 4
 LambdaBodyIndentation: OuterScope
 PointerAlignment: Left

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -411,11 +411,11 @@ class MX_CORE_API Member : public TypedElement
 class MX_CORE_API Unit : public Element
 {
   public:
-      Unit(ElementPtr parent, const string& name) :
-          Element(parent, CATEGORY, name)
-      {
-      }
-      virtual ~Unit() { }
+    Unit(ElementPtr parent, const string& name) :
+        Element(parent, CATEGORY, name)
+    {
+    }
+    virtual ~Unit() { }
 
   public:
     static const string CATEGORY;
@@ -572,7 +572,7 @@ class MX_CORE_API AttributeDef : public TypedElement
     /// @{
 
     /// Set the typed value of an element.
-    template<class T> void setValue(const T& value, const string& type = EMPTY_STRING)
+    template <class T> void setValue(const T& value, const string& type = EMPTY_STRING)
     {
         setType(!type.empty() ? type : getTypeString<T>());
         setValueString(toValueString(value));

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -16,7 +16,8 @@ namespace MaterialX
 const string Document::CMS_ATTRIBUTE = "cms";
 const string Document::CMS_CONFIG_ATTRIBUTE = "cmsconfig";
 
-namespace {
+namespace
+{
 
 NodeDefPtr getShaderNodeDef(ElementPtr shaderRef)
 {
@@ -264,7 +265,7 @@ std::pair<int, int> Document::getVersionIntegers() const
 {
     if (!hasVersionString())
     {
-        return {MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION};
+        return { MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION };
     }
     return InterfaceElement::getVersionIntegers();
 }
@@ -480,7 +481,7 @@ void Document::upgradeVersion()
                             elem->removeChild(child->getName());
                         }
                     }
-               }
+                }
             }
         }
 
@@ -1292,10 +1293,10 @@ void Document::upgradeVersion()
         // If they are, rename the nodes.
         for (NodeGraphPtr nodegraph : getNodeGraphs())
         {
-            // Clear out any erroneously set version 
+            // Clear out any erroneously set version
             nodegraph->removeAttribute(InterfaceElement::VERSION_ATTRIBUTE);
 
-            StringSet interfaceNames;            
+            StringSet interfaceNames;
             for (auto child : nodegraph->getChildren())
             {
                 NodePtr node = child->asA<Node>();
@@ -1328,7 +1329,7 @@ void Document::upgradeVersion()
                     node->setName(newNodeName);
                 }
             }
-        }   
+        }
 
         // Convert parameters to inputs, applying uniform markings to converted inputs
         // of nodedefs.

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -329,7 +329,7 @@ class MX_CORE_API Document : public GraphElement
 
     /// Create a NodeDef declaration which is based on a NodeGraph.
     /// @param nodeGraph NodeGraph used to create NodeDef
-    /// @param nodeDefName Declaration name 
+    /// @param nodeDefName Declaration name
     /// @param node Node type for the new declaration
     /// @param version Version for the new declaration
     /// @param isDefaultVersion If a version is specified is thie definition the default version
@@ -555,7 +555,7 @@ class MX_CORE_API Document : public GraphElement
     void removeUnitDef(const string& name)
     {
         removeChildOfType<UnitDef>(name);
-    }    
+    }
 
     /// @}
     /// @name UnitTypeDef Elements

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -214,12 +214,12 @@ void Element::removeAttribute(const string& attrib)
     }
 }
 
-template<class T> shared_ptr<T> Element::asA()
+template <class T> shared_ptr<T> Element::asA()
 {
     return std::dynamic_pointer_cast<T>(getSelf());
 }
 
-template<class T> shared_ptr<const T> Element::asA() const
+template <class T> shared_ptr<const T> Element::asA() const
 {
     return std::dynamic_pointer_cast<const T>(getSelf());
 }
@@ -547,7 +547,7 @@ bool ValueElement::validate(string* message) const
             unitTypeDef = getDocument()->getUnitTypeDef(unittype);
             validateRequire(unitTypeDef != nullptr, res, message, "Unit type definition does not exist in document");
         }
-    }            
+    }
     if (hasUnit())
     {
         bool foundUnit = false;
@@ -581,7 +581,7 @@ void StringResolver::setUvTileString(const string& uvTile)
 {
     setFilenameSubstitution(UV_TILE_TOKEN, uvTile);
 }
-    
+
 string StringResolver::resolve(const string& str, const string& type) const
 {
     if (type == FILENAME_TYPE_STRING)
@@ -610,7 +610,7 @@ bool targetStringsMatch(const string& target1, const string& target2)
     StringSet set2(vec2.begin(), vec2.end());
 
     StringSet matches;
-    std::set_intersection(set1.begin(), set1.end(), set2.begin(), set2.end(), 
+    std::set_intersection(set1.begin(), set1.end(), set2.begin(), set2.end(),
                           std::inserter(matches, matches.end()));
     return !matches.empty();
 }
@@ -644,9 +644,9 @@ template <class T> class ElementRegistry
 // Template instantiations
 //
 
-#define INSTANTIATE_SUBCLASS(T)                                     \
-template MX_CORE_API shared_ptr<T> Element::asA<T>();               \
-template MX_CORE_API shared_ptr<const T> Element::asA<T>() const;
+#define INSTANTIATE_SUBCLASS(T)                           \
+    template MX_CORE_API shared_ptr<T> Element::asA<T>(); \
+    template MX_CORE_API shared_ptr<const T> Element::asA<T>() const;
 
 INSTANTIATE_SUBCLASS(Element)
 INSTANTIATE_SUBCLASS(GeomElement)
@@ -656,10 +656,10 @@ INSTANTIATE_SUBCLASS(PortElement)
 INSTANTIATE_SUBCLASS(TypedElement)
 INSTANTIATE_SUBCLASS(ValueElement)
 
-#define INSTANTIATE_CONCRETE_SUBCLASS(T, category)      \
-const string T::CATEGORY(category);                     \
-ElementRegistry<T> registry##T;                         \
-INSTANTIATE_SUBCLASS(T)
+#define INSTANTIATE_CONCRETE_SUBCLASS(T, category) \
+    const string T::CATEGORY(category);            \
+    ElementRegistry<T> registry##T;                \
+    INSTANTIATE_SUBCLASS(T)
 
 INSTANTIATE_CONCRETE_SUBCLASS(AttributeDef, "attributedef")
 INSTANTIATE_CONCRETE_SUBCLASS(Backdrop, "backdrop")

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -81,6 +81,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
         _root(parent ? parent->getRoot() : nullptr)
     {
     }
+
   public:
     virtual ~Element() { }
     Element(const Element&) = delete;
@@ -372,7 +373,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Return true if this element belongs to the given subclass.
     /// If a category string is specified, then both subclass and category
     /// matches are required.
-    template<class T> bool isA(const string& category = EMPTY_STRING) const
+    template <class T> bool isA(const string& category = EMPTY_STRING) const
     {
         if (!asA<T>())
             return false;
@@ -382,10 +383,10 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     }
 
     /// Dynamic cast to an instance of the given subclass.
-    template<class T> shared_ptr<T> asA();
+    template <class T> shared_ptr<T> asA();
 
     /// Dynamic cast to a const instance of the given subclass.
-    template<class T> shared_ptr<const T> asA() const;
+    template <class T> shared_ptr<const T> asA() const;
 
     /// @}
     /// @name Child Elements
@@ -398,7 +399,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @throws Exception if a child of this element already possesses the
     ///     given name.
     /// @return A shared pointer to the new child element.
-    template<class T> shared_ptr<T> addChild(const string& name = EMPTY_STRING);
+    template <class T> shared_ptr<T> addChild(const string& name = EMPTY_STRING);
 
     /// Add a child element of the given category and name.
     /// @param category The category string of the new child element.
@@ -429,7 +430,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Return the child element, if any, with the given name and subclass.
     /// If a child with the given name exists, but belongs to a different
     /// subclass, then an empty shared pointer is returned.
-    template<class T> shared_ptr<T> getChildOfType(const string& name) const
+    template <class T> shared_ptr<T> getChildOfType(const string& name) const
     {
         ElementPtr child = getChild(name);
         return child ? child->asA<T>() : shared_ptr<T>();
@@ -445,9 +446,9 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Return a vector of all child elements that are instances of the given
     /// subclass, optionally filtered by the given category string.  The returned
     /// vector maintains the order in which children were added.
-    template<class T> vector< shared_ptr<T> > getChildrenOfType(const string& category = EMPTY_STRING) const
+    template <class T> vector<shared_ptr<T>> getChildrenOfType(const string& category = EMPTY_STRING) const
     {
-        vector< shared_ptr<T> > children;
+        vector<shared_ptr<T>> children;
         for (ElementPtr child : _childOrder)
         {
             shared_ptr<T> instance = child->asA<T>();
@@ -474,7 +475,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Remove the child element, if any, with the given name and subclass.
     /// If a child with the given name exists, but belongs to a different
     /// subclass, then this method has no effect.
-    template<class T> void removeChildOfType(const string& name)
+    template <class T> void removeChildOfType(const string& name)
     {
         if (getChildOfType<T>(name))
             removeChild(name);
@@ -510,7 +511,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Set the value of an implicitly typed attribute.  Since an attribute
     /// stores no explicit type, the same type argument must be used in
     /// corresponding calls to getTypedAttribute.
-    template<class T> void setTypedAttribute(const string& attrib, const T& data)
+    template <class T> void setTypedAttribute(const string& attrib, const T& data)
     {
         setAttribute(attrib, toValueString(data));
     }
@@ -518,7 +519,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Return the value of an implicitly typed attribute. If the given
     /// attribute is not present, or cannot be converted to the given data
     /// type, then the zero value for the data type is returned.
-    template<class T> T getTypedAttribute(const string& attrib) const
+    template <class T> T getTypedAttribute(const string& attrib) const
     {
         if (hasAttribute(attrib))
         {
@@ -578,7 +579,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
 
     /// Return the first ancestor of the given subclass, or an empty shared
     /// pointer if no ancestor of this subclass is found.
-    template<class T> shared_ptr<const T> getAncestorOfType() const
+    template <class T> shared_ptr<const T> getAncestorOfType() const
     {
         for (ConstElementPtr elem = getSelf(); elem; elem = elem->getParent())
         {
@@ -763,7 +764,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
 
     /// Resolve a reference to a named element at the root scope of this document,
     /// taking the namespace at the scope of this element into account.
-    template<class T> shared_ptr<T> resolveRootNameReference(const string& name) const
+    template <class T> shared_ptr<T> resolveRootNameReference(const string& name) const
     {
         ConstElementPtr root = getRoot();
         shared_ptr<T> child = root->getChildOfType<T>(getQualifiedName(name));
@@ -833,6 +834,7 @@ class MX_CORE_API TypedElement : public Element
         Element(parent, category, name)
     {
     }
+
   public:
     virtual ~TypedElement() { }
 
@@ -877,7 +879,7 @@ class MX_CORE_API TypedElement : public Element
 
     /// @}
 
-public:
+  public:
     static const string TYPE_ATTRIBUTE;
 };
 
@@ -890,6 +892,7 @@ class MX_CORE_API ValueElement : public TypedElement
         TypedElement(parent, category, name)
     {
     }
+
   public:
     virtual ~ValueElement() { }
 
@@ -970,7 +973,7 @@ class MX_CORE_API ValueElement : public TypedElement
     /// @{
 
     /// Set the typed value of an element.
-    template<class T> void setValue(const T& value, const string& type = EMPTY_STRING)
+    template <class T> void setValue(const T& value, const string& type = EMPTY_STRING)
     {
         setType(!type.empty() ? type : getTypeString<T>());
         setValueString(toValueString(value));
@@ -1136,7 +1139,7 @@ class MX_CORE_API Token : public ValueElement
 ///
 /// The comment text may be accessed with the methods Element::setDocString and
 /// Element::getDocString.
-/// 
+///
 class MX_CORE_API CommentElement : public Element
 {
   public:
@@ -1295,7 +1298,7 @@ class MX_CORE_API ExceptionOrphanedElement : public Exception
     using Exception::Exception;
 };
 
-template<class T> shared_ptr<T> Element::addChild(const string& name)
+template <class T> shared_ptr<T> Element::addChild(const string& name)
 {
     string childName = name;
     if (childName.empty())

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -66,7 +66,7 @@ class MX_CORE_API GeomPath
     {
     }
     ~GeomPath() { }
-    
+
     bool operator==(const GeomPath& rhs) const
     {
         return _vec == rhs._vec &&
@@ -157,6 +157,7 @@ class MX_CORE_API GeomElement : public Element
         Element(parent, category, name)
     {
     }
+
   public:
     virtual ~GeomElement() { }
 
@@ -313,9 +314,9 @@ class MX_CORE_API GeomInfo : public GeomElement
 
     /// Set the value of a GeomProp by its name, creating a child element
     /// to hold the GeomProp if needed.
-    template<class T> GeomPropPtr setGeomPropValue(const string& name,
-                                                   const T& value,
-                                                   const string& type = EMPTY_STRING);
+    template <class T> GeomPropPtr setGeomPropValue(const string& name,
+                                                    const T& value,
+                                                    const string& type = EMPTY_STRING);
 
     /// Set the string value of a Token by its name, creating a child element
     /// to hold the Token if needed.
@@ -360,8 +361,8 @@ class MX_CORE_API GeomProp : public ValueElement
 class MX_CORE_API GeomPropDef : public Element
 {
   public:
-      GeomPropDef(ElementPtr parent, const string& name) :
-          Element(parent, CATEGORY, name)
+    GeomPropDef(ElementPtr parent, const string& name) :
+        Element(parent, CATEGORY, name)
     {
     }
     virtual ~GeomPropDef() { }
@@ -574,9 +575,9 @@ class MX_CORE_API Collection : public Element
     static const string INCLUDE_COLLECTION_ATTRIBUTE;
 };
 
-template<class T> GeomPropPtr GeomInfo::setGeomPropValue(const string& name,
-                                                         const T& value,
-                                                         const string& type)
+template <class T> GeomPropPtr GeomInfo::setGeomPropValue(const string& name,
+                                                          const T& value,
+                                                          const string& type)
 {
     GeomPropPtr geomProp = getChildOfType<GeomProp>(name);
     if (!geomProp)

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -27,8 +27,7 @@ const string Input::DEFAULT_GEOM_PROP_ATTRIBUTE = "defaultgeomprop";
 const string Output::DEFAULT_INPUT_ATTRIBUTE = "defaultinput";
 
 // Map from type strings to swizzle pattern character sets.
-const std::unordered_map<string, CharSet> PortElement::CHANNELS_CHARACTER_SET =
-{
+const std::unordered_map<string, CharSet> PortElement::CHANNELS_CHARACTER_SET = {
     { "float", { '0', '1', 'r', 'x' } },
     { "color3", { '0', '1', 'r', 'g', 'b' } },
     { "color4", { '0', '1', 'r', 'g', 'b', 'a' } },
@@ -38,8 +37,7 @@ const std::unordered_map<string, CharSet> PortElement::CHANNELS_CHARACTER_SET =
 };
 
 // Map from type strings to swizzle pattern lengths.
-const std::unordered_map<string, size_t> PortElement::CHANNELS_PATTERN_LENGTH =
-{
+const std::unordered_map<string, size_t> PortElement::CHANNELS_PATTERN_LENGTH = {
     { "float", 1 },
     { "color3", 3 },
     { "color4", 4 },
@@ -96,7 +94,7 @@ bool PortElement::validate(string* message) const
                 if (output)
                 {
                     validateRequire(connectedNode->getType() == MULTI_OUTPUT_TYPE_STRING, res, message,
-                        "Multi-output type expected in port connection");
+                                    "Multi-output type expected in port connection");
                 }
             }
             else if (hasNodeGraphString())
@@ -108,7 +106,7 @@ bool PortElement::validate(string* message) const
                     if (nodeGraph->getNodeDef())
                     {
                         validateRequire(nodeGraph->getOutputCount() > 1, res, message,
-                            "Multi-output type expected in port connection");
+                                        "Multi-output type expected in port connection");
                     }
                 }
             }
@@ -446,7 +444,6 @@ OutputPtr InterfaceElement::getActiveOutput(const string& name) const
     return nullptr;
 }
 
-
 vector<OutputPtr> InterfaceElement::getActiveOutputs() const
 {
     vector<OutputPtr> activeOutputs;
@@ -486,7 +483,7 @@ OutputPtr InterfaceElement::getConnectedOutput(const string& inputName) const
     {
         return OutputPtr();
     }
-    return input->getConnectedOutput();    
+    return input->getConnectedOutput();
 }
 
 TokenPtr InterfaceElement::getActiveToken(const string& name) const
@@ -581,11 +578,11 @@ std::pair<int, int> InterfaceElement::getVersionIntegers() const
     {
         if (splitVersion.size() == 2)
         {
-            return {std::stoi(splitVersion[0]), std::stoi(splitVersion[1])};
+            return { std::stoi(splitVersion[0]), std::stoi(splitVersion[1]) };
         }
         else if (splitVersion.size() == 1)
         {
-            return {std::stoi(splitVersion[0]), 0};
+            return { std::stoi(splitVersion[0]), 0 };
         }
     }
     catch (std::invalid_argument&)
@@ -594,7 +591,7 @@ std::pair<int, int> InterfaceElement::getVersionIntegers() const
     catch (std::out_of_range&)
     {
     }
-    return {0, 0};
+    return { 0, 0 };
 }
 
 void InterfaceElement::registerChildElement(ElementPtr child)

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -56,6 +56,7 @@ class MX_CORE_API PortElement : public ValueElement
         ValueElement(parent, category, name)
     {
     }
+
   public:
     virtual ~PortElement() { }
 
@@ -154,7 +155,7 @@ class MX_CORE_API PortElement : public ValueElement
 
     /// Return true if the given channels characters are valid for the given
     /// source type string.
-    static bool validChannelsCharacters(const string &channels, const string &sourceType);
+    static bool validChannelsCharacters(const string& channels, const string& sourceType);
 
     /// Return true if the given channels string is valid for the given source
     /// and destination type strings.
@@ -322,6 +323,7 @@ class MX_CORE_API InterfaceElement : public TypedElement
         _outputCount(0)
     {
     }
+
   public:
     virtual ~InterfaceElement() { }
 
@@ -526,9 +528,9 @@ class MX_CORE_API InterfaceElement : public TypedElement
 
     /// Set the typed value of an input by its name, creating a child element
     /// to hold the input if needed.
-    template<class T> InputPtr setInputValue(const string& name,
-                                             const T& value,
-                                             const string& type = EMPTY_STRING);
+    template <class T> InputPtr setInputValue(const string& name,
+                                              const T& value,
+                                              const string& type = EMPTY_STRING);
 
     /// Return the typed value of an input by its name, taking both the calling
     /// element and its declaration into account.
@@ -663,9 +665,9 @@ class MX_CORE_API InterfaceElement : public TypedElement
     size_t _outputCount;
 };
 
-template<class T> InputPtr InterfaceElement::setInputValue(const string& name,
-                                                           const T& value,
-                                                           const string& type)
+template <class T> InputPtr InterfaceElement::setInputValue(const string& name,
+                                                            const T& value,
+                                                            const string& type)
 {
     InputPtr input = getChildOfType<Input>(name);
     if (!input)

--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -22,9 +22,9 @@
 /// Platform-specific macros for declaring imported and exported symbols.
 #if defined(MATERIALX_BUILD_SHARED_LIBS)
     #if defined(_WIN32)
-        #pragma warning(disable:4251)
-        #pragma warning(disable:4275)
-        #pragma warning(disable:4661)
+        #pragma warning(disable : 4251)
+        #pragma warning(disable : 4275)
+        #pragma warning(disable : 4661)
         #define MATERIALX_SYMBOL_EXPORT __declspec(dllexport)
         #define MATERIALX_SYMBOL_IMPORT __declspec(dllimport)
         #define MATERIALX_EXPORT_EXTERN_TEMPLATE(...) template class MATERIALX_SYMBOL_EXPORT __VA_ARGS__

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -371,6 +371,7 @@ class MX_CORE_API MaterialAssign : public GeomElement
     {
         removeChildOfType<VariantAssign>(name);
     }
+
   public:
     static const string CATEGORY;
     static const string MATERIAL_ATTRIBUTE;

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -14,7 +14,7 @@ vector<NodePtr> getShaderNodes(NodePtr materialNode, const string& nodeType, con
     std::set<NodePtr> shaderNodeSet;
 
     vector<InputPtr> inputs = materialNode->getActiveInputs();
-    for (InputPtr input : inputs) 
+    for (InputPtr input : inputs)
     {
         // Scan for a node directly connected to the input.
         // Note that this will handle traversing through interfacename associations.
@@ -25,7 +25,7 @@ vector<NodePtr> getShaderNodes(NodePtr materialNode, const string& nodeType, con
             {
                 continue;
             }
-                
+
             if (!target.empty())
             {
                 NodeDefPtr nodeDef = shaderNode->getNodeDef(target);

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -42,7 +42,7 @@ NodePtr Node::getConnectedNode(const string& inputName) const
     {
         return NodePtr();
     }
-    return input->getConnectedNode();    
+    return input->getConnectedNode();
 }
 
 void Node::setConnectedNodeName(const string& inputName, const string& nodeName)
@@ -86,7 +86,7 @@ OutputPtr Node::getConnectedOutput(const string& inputName) const
     {
         return OutputPtr();
     }
-    return input->getConnectedOutput();    
+    return input->getConnectedOutput();
 }
 
 NodeDefPtr Node::getNodeDef(const string& target) const
@@ -132,7 +132,7 @@ OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)
     if (port)
     {
         // The connecting element is an input/output port,
-        // so get the name of the output connected to this 
+        // so get the name of the output connected to this
         // port. If no explicit output is specified this will
         // return an empty string which is handled below.
         outputName = &port->getOutputString();
@@ -353,15 +353,15 @@ void GraphElement::flattenSubgraphs(const string& target, NodePredicate filter)
                 }
             }
 
-            // Connect any nodegraph outputs within the graph which point to another 
+            // Connect any nodegraph outputs within the graph which point to another
             // flatten node within the nodegraph. As it's been flattened the previous
             // reference is incorrect and needs to be updated.
             if (sourceSubGraph->getOutputCount())
             {
                 for (OutputPtr sourceOutput : getOutputs())
                 {
-                    const string& nodeNameString = sourceOutput->getNodeName(); 
-                    const string& outputString = sourceOutput->getOutputString(); 
+                    const string& nodeNameString = sourceOutput->getNodeName();
+                    const string& outputString = sourceOutput->getOutputString();
 
                     if (nodeNameString != processNode->getName())
                     {
@@ -472,7 +472,7 @@ vector<ElementPtr> GraphElement::topologicalSort() const
         childQueue.pop_front();
         result.push_back(child);
 
-        // Find connected nodes and decrease their in-degree, 
+        // Find connected nodes and decrease their in-degree,
         // adding node to the queue if in-degrees becomes 0.
         if (child->isA<Node>())
         {
@@ -514,7 +514,7 @@ string GraphElement::asStringDot() const
     for (ElementPtr elem : children)
     {
         string uniqueName = elem->getCategory();
-        while(nameSet.count(uniqueName))
+        while (nameSet.count(uniqueName))
         {
             uniqueName = incrementName(uniqueName);
         }
@@ -655,7 +655,7 @@ void NodeGraph::removeInterfaceName(const string& inputPath)
         const string& interfaceName = input->getInterfaceName();
         getNodeDef()->removeChild(interfaceName);
         input->setInterfaceName(EMPTY_STRING);
-    }   
+    }
 }
 
 void NodeGraph::modifyInterfaceName(const string& inputPath, const string& interfaceName)

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -133,7 +133,7 @@ class MX_CORE_API Node : public InterfaceElement
 
     /// Given a connecting element (Input or Output) return the NodeDef output
     /// corresponding to the output the element is connected to. This is only valid if
-    /// the NodeDef has explicit outputs defined, e.g. multiple outputs or an explicitly 
+    /// the NodeDef has explicit outputs defined, e.g. multiple outputs or an explicitly
     /// named output. If this is not the case, nullptr is returned, which implies the
     /// node is a standard node with a single implicit output.
     OutputPtr getNodeDefOutput(ElementPtr connectingElement);
@@ -180,6 +180,7 @@ class MX_CORE_API GraphElement : public InterfaceElement
         InterfaceElement(parent, category, name)
     {
     }
+
   public:
     virtual ~GraphElement() { }
 
@@ -292,7 +293,7 @@ class MX_CORE_API GraphElement : public InterfaceElement
 
     /// Flatten any references to graph-based node definitions within this
     /// node graph, replacing each reference with the equivalent node network.
-    void flattenSubgraphs(const string& target = EMPTY_STRING, NodePredicate filter=nullptr);
+    void flattenSubgraphs(const string& target = EMPTY_STRING, NodePredicate filter = nullptr);
 
     /// Return a vector of all children (nodes and outputs) sorted in
     /// topological order.
@@ -332,7 +333,7 @@ class MX_CORE_API NodeGraph : public GraphElement
 
     /// Return the first implementation for this node graph
     /// @return An implementation for this node, or an empty shared pointer if
-    ///    none was found.  
+    ///    none was found.
     InterfaceElementPtr getImplementation() const;
 
     /// @}

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -195,9 +195,9 @@ class MX_CORE_API PropertySet : public Element
 
     /// Set the typed value of a property by its name, creating a child element
     /// to hold the property if needed.
-    template<class T> PropertyPtr setPropertyValue(const string& name,
-                                                   const T& value,
-                                                   const string& type = EMPTY_STRING)
+    template <class T> PropertyPtr setPropertyValue(const string& name,
+                                                    const T& value,
+                                                    const string& type = EMPTY_STRING)
     {
         PropertyPtr property = getChildOfType<Property>(name);
         if (!property)
@@ -218,7 +218,7 @@ class MX_CORE_API PropertySet : public Element
 
     /// @}
 
-public:
+  public:
     static const string CATEGORY;
 };
 

--- a/source/MaterialXCore/Traversal.h
+++ b/source/MaterialXCore/Traversal.h
@@ -89,7 +89,7 @@ class MX_CORE_API Edge
 class MX_CORE_API TreeIterator
 {
   public:
-    explicit TreeIterator(ElementPtr elem):
+    explicit TreeIterator(ElementPtr elem) :
         _elem(elem),
         _prune(false),
         _holdCount(0)
@@ -192,7 +192,7 @@ class MX_CORE_API TreeIterator
 class MX_CORE_API GraphIterator
 {
   public:
-    explicit GraphIterator(ElementPtr elem):
+    explicit GraphIterator(ElementPtr elem) :
         _upstreamElem(elem),
         _prune(false),
         _holdCount(0)

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -285,9 +285,10 @@ class MX_CORE_API Vector2 : public VectorN<Vector2, float, 2>
   public:
     using VectorN<Vector2, float, 2>::VectorN;
     Vector2() = default;
-    Vector2(float x, float y) : VectorN(Uninit{})
+    Vector2(float x, float y) :
+        VectorN(Uninit{})
     {
-        _arr = {x, y};
+        _arr = { x, y };
     }
 
     /// Return the cross product of two vectors.
@@ -304,9 +305,10 @@ class MX_CORE_API Vector3 : public VectorN<Vector3, float, 3>
   public:
     using VectorN<Vector3, float, 3>::VectorN;
     Vector3() = default;
-    Vector3(float x, float y, float z) : VectorN(Uninit{})
+    Vector3(float x, float y, float z) :
+        VectorN(Uninit{})
     {
-        _arr = {x, y, z};
+        _arr = { x, y, z };
     }
 
     /// Return the cross product of two vectors.
@@ -325,9 +327,10 @@ class MX_CORE_API Vector4 : public VectorN<Vector4, float, 4>
   public:
     using VectorN<Vector4, float, 4>::VectorN;
     Vector4() = default;
-    Vector4(float x, float y, float z, float w) : VectorN(Uninit{})
+    Vector4(float x, float y, float z, float w) :
+        VectorN(Uninit{})
     {
-        _arr = {x, y, z, w};
+        _arr = { x, y, z, w };
     }
 };
 
@@ -338,19 +341,19 @@ class MX_CORE_API Quaternion : public VectorN<Vector4, float, 4>
   public:
     using VectorN<Vector4, float, 4>::VectorN;
     Quaternion() = default;
-    Quaternion(float x, float y, float z, float w) : VectorN(Uninit{})
+    Quaternion(float x, float y, float z, float w) :
+        VectorN(Uninit{})
     {
-        _arr = {x, y, z, w};
+        _arr = { x, y, z, w };
     }
 
     Quaternion operator*(const Quaternion& q) const
     {
-        return 
-        { 
-            _arr[0] * q._arr[3] + _arr[3] * q._arr[0] + _arr[1] * q._arr[2] - _arr[2] * q._arr[1], 
+        return {
+            _arr[0] * q._arr[3] + _arr[3] * q._arr[0] + _arr[1] * q._arr[2] - _arr[2] * q._arr[1],
             _arr[1] * q._arr[3] + _arr[3] * q._arr[1] + _arr[2] * q._arr[0] - _arr[0] * q._arr[2],
-            _arr[2] * q._arr[3] + _arr[3] * q._arr[2] + _arr[0] * q._arr[1] - _arr[1] * q._arr[0], 
-            _arr[3] * q._arr[3] - _arr[0] * q._arr[0] - _arr[1] * q._arr[1] - _arr[2] * q._arr[2] 
+            _arr[2] * q._arr[3] + _arr[3] * q._arr[2] + _arr[0] * q._arr[1] - _arr[1] * q._arr[0],
+            _arr[3] * q._arr[3] - _arr[0] * q._arr[0] - _arr[1] * q._arr[1] - _arr[2] * q._arr[2]
         };
     }
 
@@ -377,9 +380,10 @@ class MX_CORE_API Color3 : public VectorN<Color3, float, 3>
   public:
     using VectorN<Color3, float, 3>::VectorN;
     Color3() = default;
-    Color3(float r, float g, float b) : VectorN(Uninit{})
+    Color3(float r, float g, float b) :
+        VectorN(Uninit{})
     {
-        _arr = {r, g, b};
+        _arr = { r, g, b };
     }
 };
 
@@ -390,9 +394,10 @@ class MX_CORE_API Color4 : public VectorN<Color4, float, 4>
   public:
     using VectorN<Color4, float, 4>::VectorN;
     Color4() = default;
-    Color4(float r, float g, float b, float a) : VectorN(Uninit{})
+    Color4(float r, float g, float b, float a) :
+        VectorN(Uninit{})
     {
-        _arr = {r, g, b, a};
+        _arr = { r, g, b, a };
     }
 };
 
@@ -631,9 +636,9 @@ class MX_CORE_API Matrix33 : public MatrixN<Matrix33, float, 3>
              float m20, float m21, float m22) :
         MatrixN(Uninit{})
     {
-        _arr = {m00, m01, m02,
-                m10, m11, m12,
-                m20, m21, m22};
+        _arr = { m00, m01, m02,
+                 m10, m11, m12,
+                 m20, m21, m22 };
     }
 
     /// @name Vector Transformations
@@ -683,10 +688,10 @@ class MX_CORE_API Matrix44 : public MatrixN<Matrix44, float, 4>
              float m30, float m31, float m32, float m33) :
         MatrixN(Uninit{})
     {
-        _arr = {m00, m01, m02, m03,
-                m10, m11, m12, m13,
-                m20, m21, m22, m23,
-                m30, m31, m32, m33};
+        _arr = { m00, m01, m02, m03,
+                 m10, m11, m12, m13,
+                 m20, m21, m22, m23,
+                 m30, m31, m32, m33 };
     }
 
     /// @name Vector Transformations

--- a/source/MaterialXCore/Unit.cpp
+++ b/source/MaterialXCore/Unit.cpp
@@ -10,7 +10,8 @@
 namespace MaterialX
 {
 
-namespace {
+namespace
+{
 
 const string SCALE_ATTRIBUTE = "scale";
 

--- a/source/MaterialXCore/Unit.h
+++ b/source/MaterialXCore/Unit.h
@@ -88,7 +88,7 @@ class MX_CORE_API LinearUnitConverter : public UnitConverter
   public:
     virtual ~LinearUnitConverter() { }
 
-    /// Creator 
+    /// Creator
     static LinearUnitConverterPtr create(UnitTypeDefPtr UnitDef);
 
     /// Return the unit type string
@@ -104,7 +104,7 @@ class MX_CORE_API LinearUnitConverter : public UnitConverter
     /// @{
 
     /// Return the mappings from unit names to the scale value
-    /// defined by a linear converter. 
+    /// defined by a linear converter.
     const std::unordered_map<string, float>& getUnitScale() const
     {
         return _unitScale;
@@ -172,19 +172,19 @@ class MX_CORE_API UnitConverterRegistry
   public:
     virtual ~UnitConverterRegistry() { }
 
-    /// Creator 
+    /// Creator
     static UnitConverterRegistryPtr create();
 
     /// Add a unit converter for a given UnitDef.
-    /// Returns false if a converter has already been registered for the given UnitDef 
+    /// Returns false if a converter has already been registered for the given UnitDef
     bool addUnitConverter(UnitTypeDefPtr def, UnitConverterPtr converter);
 
     /// Remove a unit converter for a given UnitDef.
-    /// Returns false if a converter does not exist for the given UnitDef 
+    /// Returns false if a converter does not exist for the given UnitDef
     bool removeUnitConverter(UnitTypeDefPtr def);
 
     /// Get a unit converter for a given UnitDef
-    /// Returns any empty pointer if a converter does not exist for the given UnitDef 
+    /// Returns any empty pointer if a converter does not exist for the given UnitDef
     UnitConverterPtr getUnitConverter(UnitTypeDefPtr def);
 
     /// Clear all unit converters from the registry.

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -13,7 +13,8 @@ namespace MaterialX
 
 const string EMPTY_STRING;
 
-namespace {
+namespace
+{
 
 const string LIBRARY_VERSION_STRING = std::to_string(MATERIALX_MAJOR_VERSION) + "." +
                                       std::to_string(MATERIALX_MINOR_VERSION) + "." +
@@ -25,7 +26,7 @@ const std::tuple<int, int, int> LIBRARY_VERSION_TUPLE(MATERIALX_MAJOR_VERSION,
 
 bool invalidNameChar(char c)
 {
-     return !isalnum(c) && c != '_' && c != ':';
+    return !isalnum(c) && c != '_' && c != ':';
 }
 
 } // anonymous namespace
@@ -102,8 +103,8 @@ string replaceSubstrings(string str, const StringMap& stringMap)
         size_t pos = 0;
         while ((pos = str.find(pair.first, pos)) != string::npos)
         {
-             str.replace(pos, pair.first.length(), pair.second);
-             pos += pair.second.length();
+            str.replace(pos, pair.first.length(), pair.second);
+            pos += pair.second.length();
         }
     }
     return str;
@@ -149,7 +150,7 @@ string createNamePath(const StringVec& nameVec)
     string res;
     for (const string& name : nameVec)
     {
-        res = res.empty() ? name: res + NAME_PATH_SEPARATOR + name;
+        res = res.empty() ? name : res + NAME_PATH_SEPARATOR + name;
     }
     return res;
 }

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -49,10 +49,10 @@ MX_CORE_API bool stringEndsWith(const string& str, const string& suffix);
 MX_CORE_API string trimSpaces(const string& str);
 
 /// Combine the hash of a value with an existing seed.
-template<typename T> void hashCombine(size_t& seed, const T& value)
+template <typename T> void hashCombine(size_t& seed, const T& value)
 {
     seed ^= std::hash<T>()(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-} 
+}
 
 /// Split a name path into string vector
 MX_CORE_API StringVec splitNamePath(const string& namePath);

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -16,7 +16,8 @@ Value::CreatorMap Value::_creatorMap;
 Value::FloatFormat Value::_floatFormat = Value::FloatFormatDefault;
 int Value::_floatPrecision = 6;
 
-namespace {
+namespace
+{
 
 template <class T> using enable_if_mx_vector_t =
     typename std::enable_if<std::is_base_of<VectorBase, T>::value, T>::type;
@@ -24,7 +25,7 @@ template <class T> using enable_if_mx_matrix_t =
     typename std::enable_if<std::is_base_of<MatrixBase, T>::value, T>::type;
 
 template <class T> class is_std_vector : public std::false_type { };
-template <class T> class is_std_vector< vector<T> > : public std::true_type { };
+template <class T> class is_std_vector<vector<T>> : public std::true_type { };
 template <class T> using enable_if_std_vector_t =
     typename std::enable_if<is_std_vector<T>::value, T>::type;
 
@@ -169,7 +170,7 @@ template <class T> void dataToString(const enable_if_std_vector_t<T>& data, stri
 // Global functions
 //
 
-template<class T> const string& getTypeString()
+template <class T> const string& getTypeString()
 {
     return TypedValue<T>::TYPE;
 }
@@ -217,12 +218,12 @@ ValuePtr Value::createValueFromStrings(const string& value, const string& type)
     return TypedValue<string>::createFromString(value);
 }
 
-template<class T> bool Value::isA() const
+template <class T> bool Value::isA() const
 {
     return dynamic_cast<const TypedValue<T>*>(this) != nullptr;
 }
 
-template<class T> const T& Value::asA() const
+template <class T> const T& Value::asA() const
 {
     const TypedValue<T>* typedVal = dynamic_cast<const TypedValue<T>*>(this);
     if (!typedVal)
@@ -267,16 +268,16 @@ template <class T> class ValueRegistry
 // Template instantiations
 //
 
-#define INSTANTIATE_TYPE(T, name)                                                               \
-template <> const string TypedValue<T>::TYPE = name;                                            \
-template <> const string& TypedValue<T>::getTypeString() const { return TYPE; }                 \
-template <> string TypedValue<T>::getValueString() const { return toValueString<T>(_data); }    \
-template MX_CORE_API bool Value::isA<T>() const;                                                \
-template MX_CORE_API const T& Value::asA<T>() const;                                            \
-template MX_CORE_API const string& getTypeString<T>();                                          \
-template MX_CORE_API string toValueString(const T& data);                                       \
-template MX_CORE_API T fromValueString(const string& value);                                    \
-ValueRegistry<T> registry##T;
+#define INSTANTIATE_TYPE(T, name)                                                                \
+    template <> const string TypedValue<T>::TYPE = name;                                         \
+    template <> const string& TypedValue<T>::getTypeString() const { return TYPE; }              \
+    template <> string TypedValue<T>::getValueString() const { return toValueString<T>(_data); } \
+    template MX_CORE_API bool Value::isA<T>() const;                                             \
+    template MX_CORE_API const T& Value::asA<T>() const;                                         \
+    template MX_CORE_API const string& getTypeString<T>();                                       \
+    template MX_CORE_API string toValueString(const T& data);                                    \
+    template MX_CORE_API T fromValueString(const string& value);                                 \
+    ValueRegistry<T> registry##T;
 
 // Base types
 INSTANTIATE_TYPE(int, "integer")

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -60,9 +60,9 @@ class MX_CORE_API Value
     virtual ~Value() { }
 
     /// Create a new value from an object of any valid MaterialX type.
-    template<class T> static ValuePtr createValue(const T& data)
+    template <class T> static ValuePtr createValue(const T& data)
     {
-        return std::make_shared< TypedValue<T> >(data);
+        return std::make_shared<TypedValue<T>>(data);
     }
 
     // Create a new value from a C-style string.
@@ -83,12 +83,12 @@ class MX_CORE_API Value
     /// @{
 
     /// Return true if this value is of the given type.
-    template<class T> bool isA() const;
+    template <class T> bool isA() const;
 
     /// Return our underlying data as an object of the given type.
     /// If the given type doesn't match our own data type, then an
     /// exception is thrown.
-    template<class T> const T& asA() const;
+    template <class T> const T& asA() const;
 
     /// Return the type string for this value.
     virtual const string& getTypeString() const = 0;
@@ -97,7 +97,7 @@ class MX_CORE_API Value
     virtual string getValueString() const = 0;
 
     /// Set float formatting for converting values to strings.
-    /// Formats to use are FloatFormatFixed, FloatFormatScientific 
+    /// Formats to use are FloatFormatFixed, FloatFormatScientific
     /// or FloatFormatDefault to set default format.
     static void setFloatFormat(FloatFormat format)
     {
@@ -208,7 +208,7 @@ class MX_CORE_API ScopedFloatFormatting
 };
 
 /// Return the type string associated with the given data type.
-template<class T> MX_CORE_API const string& getTypeString();
+template <class T> MX_CORE_API const string& getTypeString();
 
 /// Convert the given data value to a value string.
 template <class T> MX_CORE_API string toValueString(const T& data);

--- a/source/MaterialXCore/Variant.h
+++ b/source/MaterialXCore/Variant.h
@@ -156,7 +156,7 @@ class MX_CORE_API VariantAssign : public Element
 
     /// @}
 
-public:
+  public:
     static const string CATEGORY;
     static const string VARIANT_SET_ATTRIBUTE;
     static const string VARIANT_ATTRIBUTE;


### PR DESCRIPTION
This changelist applies Clang formatting to the C++ source in MaterialXCore, providing improvements in coding style consistency.  Additionally, a new setting for preprocessor directive formatting has been added to the root clang-format file.