### PR TITLE
Apply Clang formatting to MaterialXFormat

### DIFF
--- a/source/MaterialXFormat/Environ.cpp
+++ b/source/MaterialXFormat/Environ.cpp
@@ -8,8 +8,8 @@
 #include <MaterialXCore/Util.h>
 
 #if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
 #endif
 
 namespace MaterialX

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -10,17 +10,17 @@
 #include <MaterialXCore/Exception.h>
 
 #if defined(_WIN32)
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <direct.h>
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+    #include <direct.h>
 #else
-#include <unistd.h>
-#include <sys/stat.h>
-#include <dirent.h>
+    #include <unistd.h>
+    #include <sys/stat.h>
+    #include <dirent.h>
 #endif
 
 #if defined(__APPLE__)
-#include <mach-o/dyld.h>
+    #include <mach-o/dyld.h>
 #endif
 
 #include <array>
@@ -197,7 +197,7 @@ FilePathVec FilePath::getSubDirectories() const
         return FilePathVec();
     }
 
-    FilePathVec dirs { *this };
+    FilePathVec dirs{ *this };
 
 #if defined(_WIN32)
     WIN32_FIND_DATA fd;
@@ -262,7 +262,7 @@ void FilePath::createDirectory() const
 #endif
 }
 
-bool FilePath::setCurrentPath() 
+bool FilePath::setCurrentPath()
 {
 #if defined(_WIN32)
     return (_chdir(asString().c_str()) == 0);

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -38,11 +38,11 @@ class MX_FORMAT_API FilePath
     {
         FormatWindows = 0,
         FormatPosix = 1,
-    #if defined(_WIN32)
+#if defined(_WIN32)
         FormatNative = FormatWindows
-    #else
+#else
         FormatNative = FormatPosix
-    #endif
+#endif
     };
 
   public:
@@ -51,7 +51,7 @@ class MX_FORMAT_API FilePath
     {
     }
     ~FilePath() { }
-    
+
     bool operator==(const FilePath& rhs) const
     {
         return _vec == rhs._vec &&
@@ -275,7 +275,7 @@ class MX_FORMAT_API FileSearchPath
     {
         _paths.insert(_paths.begin(), path);
     }
-    
+
     /// Clear all paths from the sequence.
     void clear()
     {
@@ -299,7 +299,7 @@ class MX_FORMAT_API FileSearchPath
     {
         return _paths[index];
     }
-    
+
     /// Return the const path at the given index.
     const FilePath& operator[](size_t index) const
     {
@@ -312,7 +312,7 @@ class MX_FORMAT_API FileSearchPath
     /// filename is returned unmodified.
     FilePath find(const FilePath& filename) const
     {
-        if (_paths.empty() || filename.isEmpty()) 
+        if (_paths.empty() || filename.isEmpty())
         {
             return filename;
         }

--- a/source/MaterialXFormat/Util.h
+++ b/source/MaterialXFormat/Util.h
@@ -29,27 +29,27 @@ MX_FORMAT_API void getSubdirectories(const FilePathVec& rootDirectories, const F
 
 /// Scans for all documents under a root path and returns documents which can be loaded
 MX_FORMAT_API void loadDocuments(const FilePath& rootPath,
-                   const FileSearchPath& searchPath,
-                   const StringSet& skipFiles,
-                   const StringSet& includeFiles,
-                   vector<DocumentPtr>& documents,
-                   StringVec& documentsPaths,
-                   const XmlReadOptions* readOptions = nullptr,
-                   StringVec* errors = nullptr);
+                                 const FileSearchPath& searchPath,
+                                 const StringSet& skipFiles,
+                                 const StringSet& includeFiles,
+                                 vector<DocumentPtr>& documents,
+                                 StringVec& documentsPaths,
+                                 const XmlReadOptions* readOptions = nullptr,
+                                 StringVec* errors = nullptr);
 
 /// Load a given MaterialX library into a document
 MX_FORMAT_API void loadLibrary(const FilePath& file,
-                 DocumentPtr doc,
-                 const FileSearchPath& searchPath = FileSearchPath(), 
-                 const XmlReadOptions* readOptions = nullptr);
+                               DocumentPtr doc,
+                               const FileSearchPath& searchPath = FileSearchPath(),
+                               const XmlReadOptions* readOptions = nullptr);
 
 /// Load all MaterialX files within the given library folders into a document,
 /// using the given search path to locate the folders on the file system.
 MX_FORMAT_API StringSet loadLibraries(const FilePathVec& libraryFolders,
-                        const FileSearchPath& searchPath,
-                        DocumentPtr doc,
-                        const StringSet& excludeFiles = StringSet(),
-                        const XmlReadOptions* readOptions = nullptr);
+                                      const FileSearchPath& searchPath,
+                                      DocumentPtr doc,
+                                      const StringSet& excludeFiles = StringSet(),
+                                      const XmlReadOptions* readOptions = nullptr);
 
 /// Flatten all filenames in the given document, applying string resolvers at the
 /// scope of each element and removing all fileprefix attributes.

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -20,7 +20,8 @@ namespace MaterialX
 
 const string MTLX_EXTENSION = "mtlx";
 
-namespace {
+namespace
+{
 
 const string XINCLUDE_TAG = "xi:include";
 const string XINCLUDE_NAMESPACE = "xmlns:xi";
@@ -114,8 +115,7 @@ void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions
 
                     // Write relative include paths in Posix format, and absolute
                     // include paths in native format.
-                    FilePath::Format includeFormat = includePath.isAbsolute() ?
-                        FilePath::FormatNative : FilePath::FormatPosix;
+                    FilePath::Format includeFormat = includePath.isAbsolute() ? FilePath::FormatNative : FilePath::FormatPosix;
                     includeAttr.set_value(includePath.asString(includeFormat).c_str());
 
                     writtenSourceFiles.insert(sourceUri);

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -59,7 +59,7 @@ class MX_FORMAT_API XmlWriteOptions
     /// If true, elements with source file markings will be written as
     /// XIncludes rather than explicit data.  Defaults to true.
     bool writeXIncludeEnable;
-    
+
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;


### PR DESCRIPTION
This changelist applies Clang formatting to the C++ source in MaterialXFormat, providing improvements in coding style consistency.