### PR TITLE
Optimizations to GLSL shading

### DIFF
--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -16,8 +16,11 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
 
     float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-    float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
+
+    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgRoughness = mx_average_roughness(safeRoughness);
+    vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd;
     if (bsdf.thickness > 0.0)
@@ -26,10 +29,7 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
         fd = mx_init_fresnel_conductor(ior_n, ior_k);
 
     vec3 F = mx_compute_fresnel(VdotH, fd);
-
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
-    float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
+    float D = mx_ggx_NDF(Ht, safeRoughness);
     float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -14,11 +14,11 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
 
     float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-    float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
     vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgRoughness = mx_average_roughness(safeRoughness);
+    vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd;
     if (bsdf.thickness > 0.0)
@@ -30,7 +30,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
          fd = mx_init_fresnel_dielectric(ior);
     }
     vec3  F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
+    float D = mx_ggx_NDF(Ht, safeRoughness);
     float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
 
     float F0 = mx_ior_to_f0(ior);

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -14,15 +14,15 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
 
     float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-    float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
     vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgRoughness = mx_average_roughness(safeRoughness);
+    vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3  F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(X, Y, H, NdotH, safeRoughness.x, safeRoughness.y);
+    float D = mx_ggx_NDF(Ht, safeRoughness);
     float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);


### PR DESCRIPTION
- Move filtered importance sampling from world space to tangent space.
- Move NDF and PDF computations from world space to tangent space.
- Pass alpha arguments as vec2, allowing additional SIMD optimizations to be stated explicitly.