### PR TITLE
Add support for rough nodedef matches

### DIFF
--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -625,19 +625,18 @@ ConstNodeDefPtr InterfaceElement::getDeclaration(const string&) const
     return NodeDefPtr();
 }
 
-bool InterfaceElement::isTypeCompatible(ConstInterfaceElementPtr declaration) const
+bool InterfaceElement::hasExactInputMatch(ConstInterfaceElementPtr declaration, string* message) const
 {
-    if (getType() != declaration->getType())
+    for (InputPtr input : getActiveInputs())
     {
-        return false;
-    }
-    for (ValueElementPtr value : getActiveValueElements())
-    {
-        ValueElementPtr declarationValue = declaration->getActiveValueElement(value->getName());
-        if (!declarationValue ||
-            declarationValue->getCategory() != value->getCategory() ||
-            declarationValue->getType() != value->getType())
+        InputPtr declarationInput = declaration->getActiveInput(input->getName());
+        if (!declarationInput ||
+            declarationInput->getType() != input->getType())
         {
+            if (message)
+            {
+                *message += "Input '" + input->getName() + "' doesn't match declaration";
+            }
             return false;
         }
     }

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -639,14 +639,13 @@ class MX_CORE_API InterfaceElement : public TypedElement
     ///    no declaration was found.
     virtual ConstNodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const;
 
-    /// Return true if this interface instance is type compatible with the given
-    /// interface declaration.  This may be used to test, for example, whether a
-    /// Node is an instantiation of a given NodeDef.
-    ///
-    /// If the type string of the instance differs from that of the declaration,
-    /// then false is returned.  If the instance possesses an Input with no Input
-    /// of matching type in the declaration, then false is returned.
-    bool isTypeCompatible(ConstInterfaceElementPtr declaration) const;
+    /// Return true if this instance has an exact input match with the given
+    /// declaration, where each input of this the instance corresponds to a
+    /// declaration input of the same name and type.
+    /// 
+    /// If an exact input match is not found, and the optional message argument
+    /// is provided, then an error message will be appended to the given string.
+    bool hasExactInputMatch(ConstInterfaceElementPtr declaration, string* message = nullptr) const;
 
     /// @}
 

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -96,9 +96,13 @@ class MX_CORE_API Node : public InterfaceElement
     /// by the given target name.
     /// @param target An optional target name, which will be used to filter
     ///    the nodedefs that are considered.
+    /// @param allowRoughMatch If specified, then a rough match will be allowed
+    ///    when an exact match is not found.  An exact match requires that each
+    ///    node input corresponds to a nodedef input of the same name and type.
     /// @return A NodeDef for this node, or an empty shared pointer if none
     ///    was found.
-    NodeDefPtr getNodeDef(const string& target = EMPTY_STRING) const;
+    NodeDefPtr getNodeDef(const string& target = EMPTY_STRING,
+                          bool allowRoughMatch = false) const;
 
     /// @}
     /// @name Implementation References

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -444,11 +444,17 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
     GenContext& context,
     ElementPtr& root)
 {
-    NodeDefPtr nodeDef = node->getNodeDef();
+    NodeDefPtr nodeDef = node->getNodeDef(EMPTY_STRING, true);
+    string message;
     if (!nodeDef)
     {
         throw ExceptionShaderGenError("Could not find a nodedef for shader node '" + node->getName() +
                                       "' with category '" + node->getCategory() + "'");
+    }
+    if (!node->hasExactInputMatch(nodeDef, &message))
+    {
+        std::cerr << "Nodedef " << nodeDef->getName() << " is not an exact match for shader node '" << node->getName() <<
+                     " (" << message << ")" << std::endl;
     }
 
     ShaderGraphPtr graph = std::make_shared<ShaderGraph>(parent, name, node->getDocument(), context.getReservedWords());

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -227,18 +227,8 @@ bool isTransparentSurface(ElementPtr element, const string& target)
 
         // Handle graph definitions.
         NodeDefPtr nodeDef = node->getNodeDef();
-        if (!nodeDef)
-        {
-            throw ExceptionShaderGenError("Could not find a nodedef for shader node '" + node->getName() +
-                                          "' with category '" + node->getCategory() + "'");
-        }
-        InterfaceElementPtr impl = nodeDef->getImplementation(target);
-        if (!impl)
-        {
-            throw ExceptionShaderGenError("Could not find a matching implementation for node '" + nodeDef->getNodeString() +
-                                          "' matching target '" + target + "'");
-        }
-        if (impl->isA<NodeGraph>())
+        InterfaceElementPtr impl = nodeDef ? nodeDef->getImplementation(target) : nullptr;
+        if (impl && impl->isA<NodeGraph>())
         {
             NodeGraphPtr graph = impl->asA<NodeGraph>();
 

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -93,7 +93,8 @@ void bindPyInterface(py::module& mod)
         .def("getDefaultVersion", &mx::InterfaceElement::getDefaultVersion)
         .def("getDeclaration", &mx::InterfaceElement::getDeclaration,
             py::arg("target") = mx::EMPTY_STRING)
-        .def("isTypeCompatible", &mx::InterfaceElement::isTypeCompatible)
+        .def("hasExactInputMatch", &mx::InterfaceElement::hasExactInputMatch,
+            py::arg("declaration"), py::arg("message") = nullptr)
         BIND_INTERFACE_TYPE_INSTANCE(integer, int)
         BIND_INTERFACE_TYPE_INSTANCE(boolean, bool)
         BIND_INTERFACE_TYPE_INSTANCE(float, float)

--- a/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
@@ -20,7 +20,7 @@ void bindPyNode(py::module& mod)
         .def("setConnectedNodeName", &mx::Node::setConnectedNodeName)
         .def("getConnectedNodeName", &mx::Node::getConnectedNodeName)
         .def("getNodeDef", &mx::Node::getNodeDef,
-            py::arg("target") = mx::EMPTY_STRING)
+            py::arg("target") = mx::EMPTY_STRING, py::arg("allowRoughMatch") = false)
         .def("getImplementation", &mx::Node::getImplementation,
             py::arg("target") = mx::EMPTY_STRING)
         .def("getDownstreamPorts", &mx::Node::getDownstreamPorts)


### PR DESCRIPTION
This changelist adds support for rough nodedef matches, where a node contains additional inputs not found in its nodedef declaration.  This matching approach has been applied to shader nodes in code generation, allowing a roughly-matching shader node to render with warnings, rather than completely failing to render.