### PR TITLE
Update writelooks.py for 1.38.3

### DIFF
--- a/python/Scripts/writelooks.py
+++ b/python/Scripts/writelooks.py
@@ -78,12 +78,8 @@ def main():
     # PropertySet
     #
     propset = doc.addPropertySet("standard")
-    p = propset.addProperty("displacementbound_sphere")
-    p.setTarget("rmanris")
-    p.setValue(0.05)
-    p = propset.addProperty("trace_maxdiffusedepth")
-    p.setTarget("rmanris")
-    p.setValue(3.0)
+    p = propset.setPropertyValue("displacementbound_sphere", 0.05)
+    p = propset.setPropertyValue("trace_maxdiffusedepth", 3.0)
 
     #
     # Looks


### PR DESCRIPTION
This changelist updates Python script 'writelooks.py' for the 1.38.3 API.  Moving forward, we should consider more modern replacements for the Materials/Examples/Syntax folder and its associated Python scripts, but for now we're preserving them and updating this script to the latest API.