### PR TITLE
Add Python 3.9 to build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,10 +89,10 @@ jobs:
           python: 3.8
           cmake_config: -G "Visual Studio 16 2019" -A "x64"
 
-        - name: Windows_VS2022_x64_Python37
+        - name: Windows_VS2022_x64_Python39
           os: windows-2022
           architecture: x64
-          python: 3.8
+          python: 3.9
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
           test_validate: ON
 


### PR DESCRIPTION
This changelist adds Python 3.9 to the build matrix in GitHub Actions, leveraging support for this version of Python in PyBind11 2.7.1.