### PR TITLE
Fix viewer performance for multi-UDIM assets

### DIFF
--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -113,6 +113,22 @@ bool GeometryHandler::loadGeometry(const FilePath& filePath)
     return loaded;
 }
 
+MeshPtr GeometryHandler::findParentMesh(MeshPartitionPtr part)
+{
+    for (MeshPtr mesh : getMeshes())
+    {
+        for (size_t i = 0; i < mesh->getPartitionCount(); i++)
+        {
+            if (mesh->getPartition(i) == part)
+            {
+                return mesh;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
 MeshPtr GeometryHandler::createQuadMesh()
 {
     MeshStreamPtr quadPositions = MeshStream::create(HW::IN_POSITION, MeshStream::POSITION_ATTRIBUTE, 0);

--- a/source/MaterialXRender/GeometryHandler.h
+++ b/source/MaterialXRender/GeometryHandler.h
@@ -99,6 +99,10 @@ class MX_RENDER_API GeometryHandler
         return _meshes;
     }
 
+    /// Return the first mesh in our list containing the given partition.
+    /// If no matching mesh is found, then nullptr is returned.
+    MeshPtr findParentMesh(MeshPartitionPtr part);
+
     /// Return the minimum bounds for all meshes
     const Vector3& getMinimumBounds() const
     {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1844,7 +1844,6 @@ void Viewer::renderFrame()
             _envMaterial->bindViewInformation(envWorld, view, proj);
             _envMaterial->bindImages(_imageHandler, _searchPath, false);
             _envMaterial->drawPartition(envPart);
-            _envMaterial->unbindGeometry();
             glDisable(GL_CULL_FACE);
             glCullFace(GL_BACK);
         }
@@ -1858,7 +1857,6 @@ void Viewer::renderFrame()
     }
 
     // Opaque pass
-    const mx::MeshList& meshList = _geometryHandler->getMeshes();
     for (const auto& assignment : _materialAssignments)
     {
         mx::MeshPartitionPtr geom = assignment.first;
@@ -1874,17 +1872,7 @@ void Viewer::renderFrame()
             glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
         }
         material->bindShader();
-        for (auto mesh : meshList)
-        {
-            for (size_t i = 0; i < mesh->getPartitionCount(); i++)
-            {
-                if (mesh->getPartition(i) == geom)
-                {
-                    material->bindMesh(mesh);
-                    break;
-                }
-            }
-        }
+        material->bindMesh(_geometryHandler->findParentMesh(geom));
         if (material->getProgram()->hasUniform(mx::HW::ALPHA_THRESHOLD))
         {
             material->getProgram()->bindUniform(mx::HW::ALPHA_THRESHOLD, mx::Value::createValue(0.99f));
@@ -1894,7 +1882,6 @@ void Viewer::renderFrame()
         material->bindImages(_imageHandler, _searchPath);
         material->drawPartition(geom);
         material->unbindImages(_imageHandler);
-        material->unbindGeometry();
         if (material->getShader()->getName() == "__WIRE_SHADER__")
         {
             glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
@@ -1917,17 +1904,7 @@ void Viewer::renderFrame()
             }
 
             material->bindShader();
-            for (auto mesh : meshList)
-            {
-                for (size_t i = 0; i < mesh->getPartitionCount(); i++)
-                {
-                    if (mesh->getPartition(i) == geom)
-                    {
-                        material->bindMesh(mesh);
-                        break;
-                    }
-                }
-            }
+            material->bindMesh(_geometryHandler->findParentMesh(geom));
             if (material->getProgram()->hasUniform(mx::HW::ALPHA_THRESHOLD))
             {
                 material->getProgram()->bindUniform(mx::HW::ALPHA_THRESHOLD, mx::Value::createValue(0.001f));
@@ -1937,7 +1914,6 @@ void Viewer::renderFrame()
             material->bindImages(_imageHandler, _searchPath);
             material->drawPartition(geom);
             material->unbindImages(_imageHandler);
-            material->unbindGeometry();
         }
         glDisable(GL_BLEND);
     }
@@ -1953,20 +1929,9 @@ void Viewer::renderFrame()
     {
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
         _wireMaterial->bindShader();
-        for (auto mesh : meshList)
-        {
-            for (size_t i = 0; i < mesh->getPartitionCount(); i++)
-            {
-                if (mesh->getPartition(i) == getSelectedGeometry())
-                {
-                    _wireMaterial->bindMesh(mesh);
-                    break;
-                }
-            }
-        }
+        _wireMaterial->bindMesh(_geometryHandler->findParentMesh(getSelectedGeometry()));
         _wireMaterial->bindViewInformation(world, view, proj);
         _wireMaterial->drawPartition(getSelectedGeometry());
-        _wireMaterial->unbindGeometry();
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     }
 }
@@ -2427,7 +2392,6 @@ void Viewer::updateShadowMap()
             _shadowMaterial->drawPartition(geom);
         }
     }
-    _shadowMaterial->unbindGeometry();
     _shadowMap = framebuffer->getColorImage();
 
     // Apply Gaussian blurring.
@@ -2520,5 +2484,4 @@ void Viewer::renderScreenSpaceQuad(MaterialPtr material)
     
     material->bindMesh(_quadMesh);
     material->drawPartition(_quadMesh->getPartition(0));
-    material->unbindGeometry();
 }

--- a/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
@@ -46,6 +46,7 @@ void bindPyGeometryHandler(py::module& mod)
         .def("getGeometry", &mx::GeometryHandler::getGeometry)
         .def("loadGeometry", &mx::GeometryHandler::loadGeometry)
         .def("getMeshes", &mx::GeometryHandler::getMeshes)
+        .def("findParentMesh", &mx::GeometryHandler::findParentMesh)
         .def("getMinimumBounds", &mx::GeometryHandler::getMinimumBounds)
         .def("getMaximumBounds", &mx::GeometryHandler::getMaximumBounds);
 }


### PR DESCRIPTION
This changelist fixes a regression in the performance of the MaterialX viewer for multi-UDIM assets, which was caused by unbinding geometries between the rendering of each mesh partition.

Additionally, it adds the helper method GeometryHandler::findParentMesh, which is used to clarify mesh and shader binding logic in Viewer::renderFrame.