### PR TITLE
Deterministic codegen

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -315,7 +315,7 @@ void ShaderGraph::addColorTransformNode(ShaderOutput* output, const ColorSpaceTr
         ShaderNode* colorTransformNode = colorTransformNodePtr.get();
         ShaderOutput* colorTransformNodeOutput = colorTransformNode->getOutput(0);
 
-        ShaderInputSet inputs = output->getConnections();
+        ShaderInputVec inputs = output->getConnections();
         for (ShaderInput* input : inputs)
         {
             input->breakConnection();

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -385,10 +385,9 @@ void ShaderGraph::addUnitTransformNode(ShaderOutput* output, const UnitTransform
         ShaderNode* unitTransformNode = unitTransformNodePtr.get();
         ShaderOutput* unitTransformNodeOutput = unitTransformNode->getOutput(0);
 
-        ShaderInputSet inputs = output->getConnections();
+        ShaderInputVec inputs = output->getConnections();
         for (ShaderInput* input : inputs)
         {
-            string inname = input->getFullName();
             input->breakConnection();
             input->makeConnection(unitTransformNodeOutput);
         }
@@ -1076,9 +1075,9 @@ void ShaderGraph::bypass(GenContext& context, ShaderNode* node, size_t inputInde
     if (upstream)
     {
         // Re-route the upstream output to the downstream inputs.
-        // Iterate a copy of the connection set since the
-        // original set will change when breaking connections.
-        ShaderInputSet downstreamConnections = output->getConnections();
+        // Iterate a copy of the connection vector since the
+        // original vector will change when breaking connections.
+        ShaderInputVec downstreamConnections = output->getConnections();
         for (ShaderInput* downstream : downstreamConnections)
         {
             output->breakConnection(downstream);
@@ -1089,9 +1088,9 @@ void ShaderGraph::bypass(GenContext& context, ShaderNode* node, size_t inputInde
     {
         // No node connected upstream to re-route,
         // so push the input's value and element path downstream instead.
-        // Iterate a copy of the connection set since the
-        // original set will change when breaking connections.
-        ShaderInputSet downstreamConnections = output->getConnections();
+        // Iterate a copy of the connection vector since the
+        // original vector will change when breaking connections.
+        ShaderInputVec downstreamConnections = output->getConnections();
         for (ShaderInput* downstream : downstreamConnections)
         {
             output->breakConnection(downstream);
@@ -1129,10 +1128,8 @@ void ShaderGraph::topologicalSort()
     // Calculate in-degrees for all nodes, and enqueue those with degree 0.
     std::unordered_map<ShaderNode*, int> inDegree(_nodeMap.size());
     std::deque<ShaderNode*> nodeQueue;
-    for (const auto& it : _nodeMap)
+    for (ShaderNode* node : _nodeOrder)
     {
-        ShaderNode* node = it.second.get();
-
         int connectionCount = 0;
         for (const ShaderInput* input : node->getInputs())
         {
@@ -1162,15 +1159,16 @@ void ShaderGraph::topologicalSort()
 
         // Find connected nodes and decrease their in-degree,
         // adding node to the queue if in-degrees becomes 0.
-        for (const auto& output : node->getOutputs())
+        for (const ShaderOutput* output : node->getOutputs())
         {
-            for (const auto& input : output->getConnections())
+            for (const ShaderInput* input : output->getConnections())
             {
-                if (input->getNode() != this)
+                ShaderNode* downstreamNode = const_cast<ShaderNode*>(input->getNode());
+                if (downstreamNode != this)
                 {
-                    if (--inDegree[input->getNode()] <= 0)
+                    if (--inDegree[downstreamNode] <= 0)
                     {
-                        nodeQueue.push_back(input->getNode());
+                        nodeQueue.push_back(downstreamNode);
                     }
                 }
             }

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -45,16 +45,32 @@ ShaderInput::ShaderInput(ShaderNode* node, const TypeDesc* type, const string& n
 
 void ShaderInput::makeConnection(ShaderOutput* src)
 {
-    breakConnection();
-    _connection = src;
-    src->_connections.insert(this);
+    // Make sure this is a new connection.
+    if (src != _connection)
+    {
+        // Break the old connection.
+        breakConnection();
+        if (src)
+        {
+            // Make the new connection.
+            _connection = src;
+            src->_connections.push_back(this);
+        }
+    }
 }
 
 void ShaderInput::breakConnection()
 {
     if (_connection)
     {
-        _connection->_connections.erase(this);
+        // Find and erase this input from the connected output's connection vector.
+        ShaderInputVec& connected = _connection->_connections;
+        ShaderInputVec::iterator it = std::find(connected.begin(), connected.end(), this);
+        if (it != connected.end())
+        {
+            connected.erase(it);
+        }
+        // Clear the connection.
         _connection = nullptr;
     }
 }
@@ -85,7 +101,7 @@ void ShaderOutput::makeConnection(ShaderInput* dst)
 
 void ShaderOutput::breakConnection(ShaderInput* dst)
 {
-    if (!_connections.count(dst))
+    if (std::find(_connections.begin(), _connections.end(), dst) == _connections.end())
     {
         throw ExceptionShaderGenError(
             "Cannot break non-existent connection from output: " + getFullName()
@@ -96,8 +112,8 @@ void ShaderOutput::breakConnection(ShaderInput* dst)
 
 void ShaderOutput::breakConnections()
 {
-    ShaderInputSet inputSet(_connections);
-    for (ShaderInput* input : inputSet)
+    ShaderInputVec inputVec(_connections);
+    for (ShaderInput* input : inputVec)
     {
         input->breakConnection();
     }

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -34,8 +34,8 @@ using ShaderInputPtr = shared_ptr<class ShaderInput>;
 using ShaderOutputPtr = shared_ptr<class ShaderOutput>;
 /// Shared pointer to a ShaderNode
 using ShaderNodePtr = shared_ptr<class ShaderNode>;
-/// Shared pointer to a ShaderInput
-using ShaderInputSet = std::set<ShaderInput*>;
+/// A vector of ShaderInput pointers
+using ShaderInputVec = vector<ShaderInput*>;
 
 
 /// Metadata to be exported to generated shader.
@@ -296,11 +296,7 @@ class MX_GENSHADER_API ShaderOutput : public ShaderPort
 
     /// Return a set of connections to downstream node inputs,
     /// empty if not connected.
-    ShaderInputSet& getConnections() { return _connections; }
-
-    /// Return a set of connections to downstream node inputs,
-    /// empty if not connected.
-    const ShaderInputSet& getConnections() const { return _connections; }
+    const ShaderInputVec& getConnections() const { return _connections; }
 
     /// Make a connection from this output to the given input
     void makeConnection(ShaderInput* dst);
@@ -312,7 +308,7 @@ class MX_GENSHADER_API ShaderOutput : public ShaderPort
     void breakConnections();
 
   protected:
-    ShaderInputSet _connections;
+    ShaderInputVec _connections;
     friend class ShaderInput;
 };
 


### PR DESCRIPTION
This change list adds some changes to make codegen deterministic, always producing the same code from the same input data.

* Change connection storage on ShaderOutput from set to vector to make connection ordering deterministic.
* Make ShaderGraph topological sort order independent of std::unorder_map implementation.
* Add test for deterministic codegen.
