### PR TITLE
Update for Vulkan compliance in GLSL codegen

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,6 +199,7 @@ jobs:
         vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe -v
         python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target glsl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe
         python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target essl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target glsl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
 
     - name: Upload Installed Package
       uses: actions/upload-artifact@v2

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -440,9 +440,9 @@ vec2 mx_latlong_projection(vec3 dir)
     return vec2(longitude, latitude);
 }
 
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D tex_sampler)
+vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D envSampler)
 {
     vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
     vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(tex_sampler, uv, lod).rgb;
+    return textureLod(envSampler, uv, lod).rgb;
 }

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -440,9 +440,9 @@ vec2 mx_latlong_projection(vec3 dir)
     return vec2(longitude, latitude);
 }
 
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
+vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D tex_sampler)
 {
     vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
     vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(sampler, uv, lod).rgb;
+    return textureLod(tex_sampler, uv, lod).rgb;
 }

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -15,7 +15,7 @@ def validateCode(sourceCodeFile, codevalidator, codevalidatorArgs):
     if codevalidator and os.path.isfile(codevalidator):
         cmd = codevalidator + ' ' + sourceCodeFile 
         if codevalidatorArgs:
-            cmd + ' ' + codevalidatorArgs
+            cmd += ' ' + codevalidatorArgs
         print('----- Run: '+ cmd)
         try:
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
@@ -35,6 +35,7 @@ def main():
     parser.add_argument('--outputPath', dest='outputPath', help='File path to output shaders to. If not specified, is the location of the input document is used.')
     parser.add_argument('--validator', dest='validator', nargs='?', const=' ', type=str, help='Name of executable to perform source code validation.')
     parser.add_argument('--validatorArgs', dest='validatorArgs', nargs='?', const=' ', type=str, help='Optional arguments for code validator.')
+    parser.add_argument('--vulkanGlsl', dest='vulkanCompliantGlsl', default=False, type=bool, help='Set to True to generate Vulkan-compliant GLSL when using the genglsl target.')
     parser.add_argument(dest='inputFilename', help='Filename of the input document.')
     opts = parser.parse_args()
 
@@ -77,8 +78,15 @@ def main():
         shadergen = mx_gen_glsl.EsslShaderGenerator.create()
     else:
         shadergen = mx_gen_glsl.GlslShaderGenerator.create()
+            
     context = mx_gen_shader.GenContext(shadergen)
     context.registerSourceCodeSearchPath(searchPath)
+
+    # If we're generating Vulkan-compliant GLSL then set the binding context
+    if opts.vulkanCompliantGlsl:
+        bindingContext = mx_gen_glsl.GlslResourceBindingContext.create(0,0)
+        context.pushUserData('udbinding', bindingContext)
+
     genoptions = context.getOptions() 
     genoptions.shaderInterfaceType = int(mx_gen_shader.ShaderInterfaceType.SHADER_INTERFACE_COMPLETE)
 

--- a/source/PyMaterialX/PyMaterialXGenShader/PyGenContext.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyGenContext.cpp
@@ -19,7 +19,8 @@ void bindPyGenContext(py::module& mod)
         .def("getOptions", static_cast<mx::GenOptions& (mx::GenContext::*)()>(&mx::GenContext::getOptions), py::return_value_policy::reference)
         .def("registerSourceCodeSearchPath", static_cast<void (mx::GenContext::*)(const mx::FilePath&)>(&mx::GenContext::registerSourceCodeSearchPath))
         .def("registerSourceCodeSearchPath", static_cast<void (mx::GenContext::*)(const mx::FileSearchPath&)>(&mx::GenContext::registerSourceCodeSearchPath))
-        .def("resolveSourceFile", &mx::GenContext::resolveSourceFile);
+        .def("resolveSourceFile", &mx::GenContext::resolveSourceFile)
+        .def("pushUserData", &mx::GenContext::pushUserData);
 }
 
 void bindPyGenUserData(py::module& mod)


### PR DESCRIPTION
- Fix usage of keyword "sampler" in code
- Update `generateShader` script to support Vulkan code and uniform layout code generation.
- Add test to CI using `glslValidaitor` with Vulkan option.

