### PR TITLE
Improvements to document versioning

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -385,20 +385,22 @@ vector<InterfaceElementPtr> Document::getMatchingImplementations(const string& n
 bool Document::validate(string* message) const
 {
     bool res = true;
-    validateRequire(hasVersionString(), res, message, "Missing version string");
+    std::pair<int, int> expectedVersion(MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION);
+    validateRequire(getVersionIntegers() >= expectedVersion, res, message, "Unsupported document version");
+    validateRequire(getVersionIntegers() <= expectedVersion, res, message, "Future document version");
     return GraphElement::validate(message) && res;
 }
 
 void Document::upgradeVersion()
 {
-    std::pair<int, int> versions = getVersionIntegers();
-    int majorVersion = versions.first;
-    int minorVersion = versions.second;
-    if (majorVersion == MATERIALX_MAJOR_VERSION &&
-        minorVersion == MATERIALX_MINOR_VERSION)
+    std::pair<int, int> documentVersion = getVersionIntegers();
+    std::pair<int, int> expectedVersion(MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION);
+    if (documentVersion >= expectedVersion)
     {
         return;
     }
+    int majorVersion = documentVersion.first;
+    int minorVersion = documentVersion.second;
 
     // Upgrade from v1.22 to v1.23
     if (majorVersion == 1 && minorVersion == 22)
@@ -1394,7 +1396,11 @@ void Document::upgradeVersion()
         minorVersion = 38;
     }
 
-    setVersionIntegers(majorVersion, minorVersion);
+    std::pair<int, int> upgradedVersion(majorVersion, minorVersion);
+    if (upgradedVersion == expectedVersion)
+    {
+        setVersionIntegers(majorVersion, minorVersion);
+    }
 }
 
 void Document::invalidateCache()

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -219,7 +219,10 @@ void documentFromXml(DocumentPtr doc,
         elementFromXml(xmlRoot, doc, readOptions);
     }
 
-    doc->upgradeVersion();
+    if (!readOptions || readOptions->upgradeVersion)
+    {
+        doc->upgradeVersion();
+    }
 }
 
 void validateParseResult(xml_parse_result& result, const FilePath& filename = FilePath())
@@ -265,8 +268,9 @@ unsigned int getParseOptions(const XmlReadOptions* readOptions)
 //
 
 XmlReadOptions::XmlReadOptions() :
-    readXIncludeFunction(readFromXmlFile),
-    readComments(false)
+    readComments(false),
+    upgradeVersion(true),
+    readXIncludeFunction(readFromXmlFile)
 {
 }
 

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -35,13 +35,17 @@ class MX_FORMAT_API XmlReadOptions
     XmlReadOptions();
     ~XmlReadOptions() { }
 
-    /// If provided, this function will be invoked when an XInclude reference
-    /// needs to be read into a document.  Defaults to readFromXmlFile.
-    XmlReadFunction readXIncludeFunction;
-
     /// If true, then XML comments will be read into documents as comment elements.
     /// Defaults to false.
     bool readComments;
+
+    /// If true, then documents from earlier versions of MaterialX will be upgraded
+    /// to the current version.  Defaults to true.
+    bool upgradeVersion;
+
+    /// If provided, this function will be invoked when an XInclude reference
+    /// needs to be read into a document.  Defaults to readFromXmlFile.
+    XmlReadFunction readXIncludeFunction;
 
     /// The vector of parent XIncludes at the scope of the current document.
     /// Defaults to an empty vector.


### PR DESCRIPTION
- Add an upgradeVersion option to XmlReadOptions, allowing clients to disable version upgrading in utilities.
- Add warnings for unsupported and future document versions in validation.