### PR TITLE
Add reference GLSL implementation for Worley Noise nodes.

### DIFF
--- a/libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl
@@ -1,0 +1,6 @@
+#include "stdlib/genglsl/lib/mx_noise.glsl"
+
+void mx_worleynoise2d_float(vec2 texcoord, float jitter, out float result)
+{
+    result = mx_worley_noise_float(texcoord, jitter, 0);
+}

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl
@@ -1,0 +1,6 @@
+#include "stdlib/genglsl/lib/mx_noise.glsl"
+
+void mx_worleynoise2d_vector2(vec2 texcoord, float jitter, out vec2 result)
+{
+    result = mx_worley_noise_vec2(texcoord, jitter, 0);
+}

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl
@@ -1,0 +1,6 @@
+#include "stdlib/genglsl/lib/mx_noise.glsl"
+
+void mx_worleynoise2d_vector3(vec2 texcoord, float jitter, out vec3 result)
+{
+    result = mx_worley_noise_vec3(texcoord, jitter, 0);
+}

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl
@@ -1,0 +1,6 @@
+#include "stdlib/genglsl/lib/mx_noise.glsl"
+
+void mx_worleynoise3d_float(vec3 position, float jitter, out float result)
+{
+    result = mx_worley_noise_float(position, jitter, 0);
+}

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl
@@ -1,0 +1,6 @@
+#include "stdlib/genglsl/lib/mx_noise.glsl"
+
+void mx_worleynoise3d_vector2(vec3 position, float jitter, out vec2 result)
+{
+    result = mx_worley_noise_vec2(position, jitter, 0);
+}

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl
@@ -1,0 +1,6 @@
+#include "stdlib/genglsl/lib/mx_noise.glsl"
+
+void mx_worleynoise3d_vector3(vec3 position, float jitter, out vec3 result)
+{
+    result = mx_worley_noise_vec3(position, jitter, 0);
+}

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -129,6 +129,16 @@
   <!-- <cellnoise3d> -->
   <implementation name="IM_cellnoise3d_float_genglsl" nodedef="ND_cellnoise3d_float" file="stdlib/genglsl/mx_cellnoise3d_float.glsl" function="mx_cellnoise3d_float" target="genglsl" />
 
+  <!-- <worleynoise2d> -->
+  <implementation name="IM_worleynoise2d_float_genglsl" nodedef="ND_worleynoise2d_float" file="stdlib/genglsl/mx_worleynoise2d_float.glsl" function="mx_worleynoise2d_float" target="genglsl" />
+  <implementation name="IM_worleynoise2d_vector2_genglsl" nodedef="ND_worleynoise2d_vector2" file="stdlib/genglsl/mx_worleynoise2d_vector2.glsl" function="mx_worleynoise2d_vector2" target="genglsl" />
+  <implementation name="IM_worleynoise2d_vector3_genglsl" nodedef="ND_worleynoise2d_vector3" file="stdlib/genglsl/mx_worleynoise2d_vector3.glsl" function="mx_worleynoise2d_vector3" target="genglsl" />
+
+  <!-- <worleynoise3d> -->
+  <implementation name="IM_worleynoise3d_float_genglsl" nodedef="ND_worleynoise3d_float" file="stdlib/genglsl/mx_worleynoise3d_float.glsl" function="mx_worleynoise3d_float" target="genglsl" />
+  <implementation name="IM_worleynoise3d_vector2_genglsl" nodedef="ND_worleynoise3d_vector2" file="stdlib/genglsl/mx_worleynoise3d_vector2.glsl" function="mx_worleynoise3d_vector2" target="genglsl" />
+  <implementation name="IM_worleynoise3d_vector3_genglsl" nodedef="ND_worleynoise3d_vector3" file="stdlib/genglsl/mx_worleynoise3d_vector3.glsl" function="mx_worleynoise3d_vector3" target="genglsl" />
+
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->
   <!-- ======================================================================== -->

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
@@ -52,7 +52,7 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         whiteList =
         {
-            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
+            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "worleynoise", "displacementshader",
             "volumeshader", "IM_constant_", "IM_dot_", "IM_geompropvalue_boolean", "IM_geompropvalue_string",
             "IM_light_genglsl", "IM_point_light_genglsl", "IM_spot_light_genglsl", "IM_directional_light_genglsl",
             "IM_angle", "surfacematerial", "volumematerial", "ND_surfacematerial", "ND_volumematerial", "ND_backface_util", "IM_backface_util_genglsl"

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
@@ -70,8 +70,8 @@ class MdlShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         whiteList =
         {
-            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
-            "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue", "IM_angle", "IM_worleynoise",
+            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "worleynoise", "displacementshader",
+            "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue", "IM_angle",
             "geompropvalue", "surfacematerial", "volumematerial", "IM_absorption_vdf_", "IM_mix_vdf_",
             "IM_anisotropic_vdf_", "IM_measured_edf_", "IM_blackbody_", "IM_conical_edf_", "IM_thin_film_bsdf_",
             "IM_displacement_", "IM_thin_surface_", "IM_volume_", "IM_light_"

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
@@ -59,7 +59,7 @@ class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         whiteList =
         {
-            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
+            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "worleynoise", "displacementshader",
             "volumeshader", "IM_constant_", "IM_dot_", "IM_geompropvalue", "IM_angle", "material", "ND_material",
             "ND_backface_util"
         };


### PR DESCRIPTION
Add reference GLSL implementation for Worley Noise nodes.  This adds the reference implementation to `lib/mx_noise.gls`l and new `.glsl` functions that call into the noise library.  `stdlib_genglsl_impl.mtlx` was modified to call the new functions.
This is the implementation as discussed on the ASWF slack.