### PR TITLE
OSL image structure support

### DIFF
--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -1,8 +1,8 @@
 #include "$fileTransformUv"
 
-void mx_image_color3(string file, string layer, color default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output color out)
+void mx_image_color3(textureresource file, string layer, color default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output color out)
 {
-    if (file == "" ||
+    if (file.filename == "" ||
         (uaddressmode == "constant" && (texcoord.x<0.0 || texcoord.x>1.0)) ||
         (vaddressmode == "constant" && (texcoord.y<0.0 || texcoord.y>1.0)))
     {
@@ -12,5 +12,6 @@ void mx_image_color3(string file, string layer, color default_value, vector2 tex
 
     color missingColor = default_value;
     vector2 st = mx_transform_uv(texcoord);
-    out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
+    out = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode $extraTextureLookupArguments);
 }
+

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -1,8 +1,8 @@
 #include "$fileTransformUv"
 
-void mx_image_color4(string file, string layer, color4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output color4 out)
+void mx_image_color4(textureresource file, string layer, color4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output color4 out)
 {
-    if (file == "" ||
+    if (file.filename == "" ||
         (uaddressmode == "constant" && (texcoord.x<0.0 || texcoord.x>1.0)) ||
         (vaddressmode == "constant" && (texcoord.y<0.0 || texcoord.y>1.0)))
     {
@@ -14,8 +14,8 @@ void mx_image_color4(string file, string layer, color4 default_value, vector2 te
     float missingAlpha = default_value.a;
     vector2 st = mx_transform_uv(texcoord);
     float alpha;
-    color rgb = texture(file, st.x, st.y, "alpha", alpha, "subimage", layer,
-                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode);
+    color rgb = texture(file.filename, st.x, st.y, "alpha", alpha, "subimage", layer,
+                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode $extraTextureLookupArguments );
 
     out = color4(rgb, alpha);
 }

--- a/libraries/stdlib/genosl/mx_image_float.osl
+++ b/libraries/stdlib/genosl/mx_image_float.osl
@@ -1,8 +1,8 @@
 #include "$fileTransformUv"
 
-void mx_image_float(string file, string layer, float default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output float out)
+void mx_image_float(textureresource file, string layer, float default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output float out)
 {
-    if (file == "" ||
+    if (file.filename == "" ||
         (uaddressmode == "constant" && (texcoord.x<0.0 || texcoord.x>1.0)) ||
         (vaddressmode == "constant" && (texcoord.y<0.0 || texcoord.y>1.0)))
     {
@@ -12,6 +12,6 @@ void mx_image_float(string file, string layer, float default_value, vector2 texc
 
     color missingColor = color(default_value);
     vector2 st = mx_transform_uv(texcoord);
-    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
+    color rgb = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
     out = rgb[0];
 }

--- a/libraries/stdlib/genosl/mx_image_vector2.osl
+++ b/libraries/stdlib/genosl/mx_image_vector2.osl
@@ -1,8 +1,8 @@
 #include "$fileTransformUv"
 
-void mx_image_vector2(string file, string layer, vector2 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector2 out)
+void mx_image_vector2(textureresource file, string layer, vector2 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector2 out)
 {
-    if (file == "" ||
+    if (file.filename == "" ||
         (uaddressmode == "constant" && (texcoord.x<0.0 || texcoord.x>1.0)) ||
         (vaddressmode == "constant" && (texcoord.y<0.0 || texcoord.y>1.0)))
     {
@@ -12,7 +12,7 @@ void mx_image_vector2(string file, string layer, vector2 default_value, vector2 
 
     color missingColor = color(default_value.x, default_value.y, 0.0);
     vector2 st = mx_transform_uv(texcoord);
-    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
+    color rgb = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
     out.x = rgb[0];
     out.y = rgb[1];
 }

--- a/libraries/stdlib/genosl/mx_image_vector3.osl
+++ b/libraries/stdlib/genosl/mx_image_vector3.osl
@@ -1,8 +1,8 @@
 #include "$fileTransformUv"
 
-void mx_image_vector3(string file, string layer, vector default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector out)
+void mx_image_vector3(textureresource file, string layer, vector default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector out)
 {
-    if (file == "" ||
+    if (file.filename == "" ||
         (uaddressmode == "constant" && (texcoord.x<0.0 || texcoord.x>1.0)) ||
         (vaddressmode == "constant" && (texcoord.y<0.0 || texcoord.y>1.0)))
     {
@@ -12,5 +12,5 @@ void mx_image_vector3(string file, string layer, vector default_value, vector2 t
 
     color missingColor = default_value;
     vector2 st = mx_transform_uv(texcoord);
-    out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
+    out = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
 }

--- a/libraries/stdlib/genosl/mx_image_vector4.osl
+++ b/libraries/stdlib/genosl/mx_image_vector4.osl
@@ -1,8 +1,8 @@
 #include "$fileTransformUv"
 
-void mx_image_vector4(string file, string layer, vector4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector4 out)
+void mx_image_vector4(textureresource file, string layer, vector4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector4 out)
 {
-    if (file == "" ||
+    if (file.filename == "" ||
         (uaddressmode == "constant" && (texcoord.x<0.0 || texcoord.x>1.0)) ||
         (vaddressmode == "constant" && (texcoord.y<0.0 || texcoord.y>1.0)))
     {
@@ -14,7 +14,7 @@ void mx_image_vector4(string file, string layer, vector4 default_value, vector2 
     float missingAlpha = default_value.w;
     vector2 st = mx_transform_uv(texcoord);
     float alpha;
-    color rgb = texture(file, st.x, st.y, "alpha", alpha, "subimage", layer,
+    color rgb = texture(file.filename, st.x, st.y, "alpha", alpha, "subimage", layer,
                         "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode);
 
     out = vector4(rgb[0], rgb[1], rgb[2], alpha);

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -27,6 +27,7 @@ namespace MaterialX
 {
 
 const string OslShaderGenerator::TARGET = "genosl";
+const string OslShaderGenerator::T_FILE_EXTRA_ARGUMENTS = "$extraTextureLookupArguments";
 
 //
 // OslShaderGenerator methods
@@ -181,6 +182,9 @@ OslShaderGenerator::OslShaderGenerator() :
 
     // <!-- <surface> -->
     registerImplementation("IM_surface_" + OslShaderGenerator::TARGET, SurfaceNodeOsl::create);
+
+    // Extra arguments for texture lookups.
+    _tokenSubstitutions[T_FILE_EXTRA_ARGUMENTS] = EMPTY_STRING;
 }
 
 ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, GenContext& context) const
@@ -483,6 +487,7 @@ void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
         Type::VECTOR2, // Custom struct types doesn't support metadata declarations.
         Type::VECTOR4, //
         Type::COLOR4,  //
+        Type::FILENAME, //
         Type::BSDF     //
     };
 
@@ -491,9 +496,7 @@ void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
         const ShaderPort* input = inputs[i];
 
         const string& type = _syntax->getTypeName(input->getType());
-        const string value = (input->getValue() ?
-            _syntax->getValue(input->getType(), *input->getValue(), true) :
-            _syntax->getDefaultValue(input->getType(), true));
+        string value = _syntax->getValue((ShaderPort*)input, true);
 
         emitLineBegin(stage);
 

--- a/source/MaterialXGenOsl/OslShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslShaderGenerator.h
@@ -49,6 +49,8 @@ class MX_GENOSL_API OslShaderGenerator : public ShaderGenerator
     void registerShaderMetadata(const DocumentPtr& doc, GenContext& context) const override;
 
 protected:
+    // Extra file arguments for texture lookup call
+    static const string T_FILE_EXTRA_ARGUMENTS;
 
     /// Create and initialize a new OSL shader for shader generation.
     virtual ShaderPtr createShader(const string& name, ElementPtr element, GenContext& context) const;

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -265,7 +265,7 @@ class OSLFilenameTypeSyntax : public AggregateTypeSyntax
         const string prefix = uniform ? "{" : getName() + "(";
         const string suffix = uniform ? "}" : ")";
         const string filename = port->getValue() ? port->getValue()->getValueString() : EMPTY_STRING;
-        return prefix + "\"" + filename + "\", \"" + port->getColorspace() + "\"" + suffix;
+        return prefix + "\"" + filename + "\", \"" + port->getColorSpace() + "\"" + suffix;
     }
 
     string getValue(const Value& value, bool uniform) const override

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -246,6 +246,49 @@ class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
     }
 };
 
+class OSLFilenameTypeSyntax : public AggregateTypeSyntax
+{
+  public:
+    OSLFilenameTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
+                     const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
+                     const StringVec& members = EMPTY_MEMBERS) :
+        AggregateTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition, members)
+    {}
+    
+    string getValue(const ShaderPort* port, bool uniform) const override
+    {
+        if (!port)
+        {
+            return EMPTY_STRING;
+        }
+
+        const string prefix = uniform ? "{" : getName() + "(";
+        const string suffix = uniform ? "}" : ")";
+        const string filename = port->getValue() ? port->getValue()->getValueString() : EMPTY_STRING;
+        return prefix + "\"" + filename + "\", \"" + port->getColorspace() + "\"" + suffix;
+    }
+
+    string getValue(const Value& value, bool uniform) const override
+    {
+        const string prefix = uniform ? "{" : getName() + "(";
+        const string suffix = uniform ? "}" : ")";
+        return prefix + "\"" + value.getValueString() + "\", \"\"" + suffix;
+    }
+
+    string getValue(const StringVec& values, bool uniform) const override
+    {
+        if (values.size() != 2)
+        {
+            throw ExceptionShaderGenError("Incorrect number of values given to construct a value");
+        }
+
+        const string prefix = uniform ? "{" : getName() + "(";
+        const string suffix = uniform ? "}" : ")";
+        return prefix + "\"" + values[0] + "\", \"" + values[1] + "\"" + suffix;
+    }
+};
+
+
 } // anonymous namespace
 
 const string OslSyntax::OUTPUT_QUALIFIER = "output";
@@ -274,7 +317,7 @@ OslSyntax::OslSyntax()
         "emission", "background", "diffuse", "oren_nayer", "translucent", "phong", "ward", "microfacet",
         "reflection", "transparent", "debug", "holdout", "subsurface", 
         // TODO: Add all OSL standard library functions names
-        "mix", "rotate"
+        "mix", "rotate", "textureresource"
     });
 
     //
@@ -407,10 +450,12 @@ OslSyntax::OslSyntax()
     registerTypeSyntax
     (
         Type::FILENAME,
-        std::make_shared<StringTypeSyntax>(
-            "string",
-            "\"\"",
-            "\"\"")
+        std::make_shared<OSLFilenameTypeSyntax>(
+            "textureresource ",
+            "textureresource (\"\", \"\")",
+            "(\"\", \"\")",
+            EMPTY_STRING,
+            "struct textureresource { string filename; string colorspace; };")
     );
 
     registerTypeSyntax

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -76,7 +76,8 @@ class MX_GENSHADER_API GenOptions
         hwAmbientOcclusion(false),
         hwMaxActiveLightSources(3),
         hwNormalizeUdimTexCoords(false),
-        hwWriteAlbedoTable(false)
+        hwWriteAlbedoTable(false),
+        emitColorTransforms(true)
     {
     }
     virtual ~GenOptions() { }
@@ -149,6 +150,11 @@ class MX_GENSHADER_API GenOptions
     /// Enables the writing of a directional albedo table.
     /// Defaults to false.
     bool hwWriteAlbedoTable;
+
+    /// Enable emitting colorspace transform code if a color management 
+    /// system is defined.
+    /// Defaults to true.
+    bool emitColorTransforms;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -382,7 +382,8 @@ void ShaderGenerator::registerShaderMetadata(const DocumentPtr& doc, GenContext&
         ShaderMetadata(ValueElement::UI_STEP_ATTRIBUTE, nullptr),
         ShaderMetadata(ValueElement::UI_ADVANCED_ATTRIBUTE, Type::BOOLEAN),
         ShaderMetadata(ValueElement::DOC_ATTRIBUTE, Type::STRING),
-        ShaderMetadata(ValueElement::UNIT_ATTRIBUTE, Type::STRING)
+        ShaderMetadata(ValueElement::UNIT_ATTRIBUTE, Type::STRING),
+        ShaderMetadata(ValueElement::COLOR_SPACE_ATTRIBUTE, Type::STRING)
     };
     for (auto data : defaultMetadata)
     {

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -356,7 +356,7 @@ void ShaderGraph::addUnitTransformNode(ShaderInput* input, const UnitTransform& 
         shaderInput->setValue(input->getValue());
         shaderInput->setPath(input->getPath());
         shaderInput->setUnit(input->getUnit());
-        shaderInput->setColorspace(input->getColorspace());
+        shaderInput->setColorSpace(input->getColorSpace());
 
         if (input->isBindInput())
         {
@@ -519,8 +519,8 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
             const string& nodeColorspace = nodeInput->getColorSpace();
             if (!nodeColorspace.empty())
             {
-                inputSocket->setColorspace(nodeColorspace);
-                input->setColorspace(nodeColorspace);
+                inputSocket->setColorSpace(nodeColorspace);
+                input->setColorSpace(nodeColorspace);
             }
         }
 
@@ -566,7 +566,7 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
         const string& inputName = nodeInput->getName();
         const string path = nodePath + NAME_PATH_SEPARATOR + inputName;
         const string& unit = nodeInput->getUnit();
-        const string& colorspace = nodeInput->getColorSpace();
+        const string& colorSpace = nodeInput->getColorSpace();
         ShaderInput* input = newNode->getInput(inputName);
         if (input)
         {
@@ -578,9 +578,9 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
             {
                 input->setUnit(unit);
             }
-            if (input->getColorspace().empty() && !colorspace.empty())
+            if (input->getColorSpace().empty() && !colorSpace.empty())
             {
-                input->setColorspace(colorspace);
+                input->setColorSpace(colorSpace);
             }
         }
         ShaderGraphInputSocket* inputSocket = graph->getInputSocket(inputName);
@@ -594,9 +594,9 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
             {
                 inputSocket->setUnit(unit);
             }
-            if (inputSocket->getColorspace().empty() && !colorspace.empty())
+            if (inputSocket->getColorSpace().empty() && !colorSpace.empty())
             {
-                inputSocket->setColorspace(colorspace);
+                inputSocket->setColorSpace(colorSpace);
             }
         }
     }
@@ -660,10 +660,10 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
         {
             outputSocket->setUnit(outputUnit);
         }
-        const string& outputColorspace = output->getColorSpace();
-        if (!outputColorspace.empty())
+        const string& outputColorSpace = output->getColorSpace();
+        if (!outputColorSpace.empty())
         {
-            outputSocket->setColorspace(outputColorspace);
+            outputSocket->setColorSpace(outputColorSpace);
         }
 
         // Start traversal from this output
@@ -744,11 +744,11 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
                         inputSocket->setUnit(unit);
                         input->setUnit(unit);
                     }
-                    const string& colorspace = nodePort->getColorSpace();
-                    if (!colorspace.empty())
+                    const string& colorSpace = nodePort->getColorSpace();
+                    if (!colorSpace.empty())
                     {
-                        inputSocket->setColorspace(colorspace);
-                        input->setColorspace(colorspace);
+                        inputSocket->setColorSpace(colorSpace);
+                        input->setColorSpace(colorSpace);
                     }
                 }
 
@@ -861,11 +861,11 @@ ShaderNode* ShaderGraph::createNode(const Node& node, GenContext& context)
             ShaderOutput* shaderOutput = newNode->getOutput();
             if (shaderOutput)
             {
-                string cs = populateColorTransformMap(colorManagementSystem, shaderOutput, input, targetColorSpace, false);
+                string colorSpace = populateColorTransformMap(colorManagementSystem, shaderOutput, input, targetColorSpace, false);
                 ShaderInput* shaderInput = newNode->getInput(input->getName());
-                if (shaderInput && !cs.empty())
+                if (shaderInput && !colorSpace.empty())
                 {
-                    shaderInput->setColorspace(cs);
+                    shaderInput->setColorSpace(colorSpace);
                 }
                 populateUnitTransformMap(unitSystem, shaderOutput, input, targetDistanceUnit, false);
             }
@@ -980,7 +980,7 @@ void ShaderGraph::finalize(GenContext& context)
                             inputSocket->setPath(input->getPath());
                             inputSocket->setValue(input->getValue());
                             inputSocket->setUnit(input->getUnit());
-                            inputSocket->setColorspace(input->getColorspace());
+                            inputSocket->setColorSpace(input->getColorSpace());
                             if (input->isUniform())
                             {
                                 inputSocket->setUniform();
@@ -1133,10 +1133,10 @@ void ShaderGraph::bypass(GenContext& context, ShaderNode* node, size_t inputInde
             {
                 downstream->setUnit(inputUnit);
             }
-            const string& inputColorspace = input->getColorspace();
-            if (!inputColorspace.empty())
+            const string& inputColorSpace = input->getColorSpace();
+            if (!inputColorSpace.empty())
             {
-                downstream->setColorspace(inputColorspace);
+                downstream->setColorSpace(inputColorSpace);
             }
 
             // Swizzle the input value. Once done clear the channel to indicate
@@ -1339,7 +1339,7 @@ string ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorMana
             if (sourceColorSpace != targetColorSpace)
             {
                 // Cache colorspace on shader port
-                shaderPort->setColorspace(sourceColorSpace);
+                shaderPort->setColorSpace(sourceColorSpace);
                 if (colorManagementSystem)
                 { 
                     ColorSpaceTransform transform(sourceColorSpace, targetColorSpace, shaderPort->getType());

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -178,7 +178,7 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
 
     /// Populates the input or output color transform map if the provided input/parameter
     /// has a color space attribute and has a type of color3 or color4.
-    void populateColorTransformMap(ColorManagementSystemPtr colorManagementSystem, ShaderPort* shaderPort, ValueElementPtr element, const string& targetColorSpace, bool asInput);
+    string populateColorTransformMap(ColorManagementSystemPtr colorManagementSystem, ShaderPort* shaderPort, ValueElementPtr element, const string& targetColorSpace, bool asInput);
 
     /// Populates the appropriate unit transform map if the provided input/parameter or output
     /// has a unit attribute and is of the supported type

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -173,10 +173,10 @@ class MX_GENSHADER_API ShaderPort : public std::enable_shared_from_this<ShaderPo
     ValuePtr getValue() const { return _value; }
 
     /// Set a source color space for the value on this port.
-    void setColorspace(const string& colorspace) { _colorspace = colorspace; }
+    void setColorSpace(const string& colorspace) { _colorspace = colorspace; }
 
     /// Return the source color space for the value on this port.
-    const string& getColorspace() const { return _colorspace; }
+    const string& getColorSpace() const { return _colorspace; }
 
     /// Set a unit type for the value on this port.
     void setUnit(const string& unit) { _unit = unit; }

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -172,6 +172,12 @@ class MX_GENSHADER_API ShaderPort : public std::enable_shared_from_this<ShaderPo
     /// Return the value set on this port.
     ValuePtr getValue() const { return _value; }
 
+    /// Set a source color space for the value on this port.
+    void setColorspace(const string& colorspace) { _colorspace = colorspace; }
+
+    /// Return the source color space for the value on this port.
+    const string& getColorspace() const { return _colorspace; }
+
     /// Set a unit type for the value on this port.
     void setUnit(const string& unit) { _unit = unit; }
 
@@ -245,6 +251,7 @@ class MX_GENSHADER_API ShaderPort : public std::enable_shared_from_this<ShaderPo
     string _variable;
     ValuePtr _value;
     string _unit;
+    string _colorspace;
     string _geomprop;
     ShaderMetadataVecPtr _metadata;
     uint32_t _flags;

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -96,6 +96,12 @@ const TypeDesc* Syntax::getTypeDescription(const TypeSyntaxPtr& typeSyntax) cons
     return nullptr;
 }
 
+string Syntax::getValue(const ShaderPort* port, bool uniform) const
+{
+    const TypeSyntax& syntax = getTypeSyntax(port->getType());
+    return syntax.getValue(port, uniform);
+}
+
 string Syntax::getValue(const TypeDesc* type, const Value& value, bool uniform) const
 {
     const TypeSyntax& syntax = getTypeSyntax(type);
@@ -343,6 +349,14 @@ TypeSyntax::TypeSyntax(const string& name, const string& defaultValue, const str
 {
 }
 
+ string TypeSyntax::getValue(const ShaderPort* port, bool uniform) const
+ {
+     if (!port || !port->getValue())
+     {
+         return getDefaultValue(uniform);
+     }
+     return getValue(*port->getValue(), uniform);
+ }
 
 ScalarTypeSyntax::ScalarTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
                                    const string& typeAlias, const string& typeDefinition) :

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -237,7 +237,7 @@ class MX_GENSHADER_API TypeSyntax
     /// can be swizzled.
     const StringVec& getMembers() const { return _members; }
 
-    /// Returns the value formatted acoording to the this type syntax
+    /// Returns a value formatted according to this type syntax.
     /// The value is constructed from the given shader port object.
     virtual string getValue(const ShaderPort* port, bool uniform) const;
 

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -21,6 +21,7 @@ namespace MaterialX
 class Syntax;
 class TypeSyntax;
 class TypeDesc;
+class ShaderPort;
 
 /// Shared pointer to a Syntax
 using SyntaxPtr = shared_ptr<Syntax>;
@@ -101,6 +102,9 @@ class MX_GENSHADER_API Syntax
 
     /// Returns the value string for a given type and value object
     virtual string getValue(const TypeDesc* type, const Value& value, bool uniform = false) const;
+
+    /// Returns the value string for a given shader port object
+    virtual string getValue(const ShaderPort* port, bool uniform = false) const;
 
     /// Get syntax for a swizzled variable
     virtual string getSwizzledVariable(const string& srcName, const TypeDesc* srcType, const string& channels, const TypeDesc* dstType) const;
@@ -232,6 +236,10 @@ class MX_GENSHADER_API TypeSyntax
     /// Returns the syntax for accessing type members if the type 
     /// can be swizzled.
     const StringVec& getMembers() const { return _members; }
+
+    /// Returns the value formatted acoording to the this type syntax
+    /// The value is constructed from the given shader port object.
+    virtual string getValue(const ShaderPort* port, bool uniform) const;
 
     /// Returns a value formatted according to this type syntax.
     /// The value is constructed from the given value object.

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -948,7 +948,7 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                     Input* input = inputIt->second.get();
                     input->path = v->getPath();
                     input->unit = v->getUnit();
-                    input->colorspace = v->getColorspace();
+                    input->colorspace = v->getColorSpace();
                     input->value = v->getValue();
                     if (input->gltype == glType)
                     {
@@ -963,7 +963,7 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                             + "\". Semantic: \"" + v->getSemantic()
                             + "\". Value: \"" + (v->getValue() ? v->getValue()->getValueString() : "<none>")
                             + "\". Unit: \"" + (!v->getUnit().empty() ? v->getUnit() : "<none>")
-                            + "\". Colorspace: \"" + (!v->getColorspace().empty() ? v->getColorspace() : "<none>")
+                            + "\". Colorspace: \"" + (!v->getColorSpace().empty() ? v->getColorSpace() : "<none>")
                             + "\". GLType: " + std::to_string(mapTypeToOpenGLType(v->getType()))
                         );
                         uniformTypeMismatchFound = true;
@@ -989,7 +989,7 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                         input->value = v->getValue();
                         input->path = v->getPath();
                         input->unit = v->getUnit();
-                        input->colorspace = v->getColorspace();
+                        input->colorspace = v->getColorSpace();
                     }
                     else
                     {
@@ -1000,7 +1000,7 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                             + "\". Semantic: \"" + v->getSemantic()
                             + "\". Value: \"" + (v->getValue() ? v->getValue()->getValueString() : "<none>")
                             + "\". Unit: \"" + (!v->getUnit().empty() ? v->getUnit() : "<none>")
-                            + "\". Colorspace: \"" + (!v->getColorspace().empty() ? v->getColorspace() : "<none>")
+                            + "\". Colorspace: \"" + (!v->getColorSpace().empty() ? v->getColorSpace() : "<none>")
                             + "\". GLType: " + std::to_string(mapTypeToOpenGLType(v->getType()))
                         );
                         uniformTypeMismatchFound = true;

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -947,6 +947,8 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                 {
                     Input* input = inputIt->second.get();
                     input->path = v->getPath();
+                    input->unit = v->getUnit();
+                    input->colorspace = v->getColorspace();
                     input->value = v->getValue();
                     if (input->gltype == glType)
                     {
@@ -960,6 +962,8 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                             + "\". Type: \"" + v->getType()->getName()
                             + "\". Semantic: \"" + v->getSemantic()
                             + "\". Value: \"" + (v->getValue() ? v->getValue()->getValueString() : "<none>")
+                            + "\". Unit: \"" + (!v->getUnit().empty() ? v->getUnit() : "<none>")
+                            + "\". Colorspace: \"" + (!v->getColorspace().empty() ? v->getColorspace() : "<none>")
                             + "\". GLType: " + std::to_string(mapTypeToOpenGLType(v->getType()))
                         );
                         uniformTypeMismatchFound = true;
@@ -985,6 +989,7 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                         input->value = v->getValue();
                         input->path = v->getPath();
                         input->unit = v->getUnit();
+                        input->colorspace = v->getColorspace();
                     }
                     else
                     {
@@ -995,6 +1000,7 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                             + "\". Semantic: \"" + v->getSemantic()
                             + "\". Value: \"" + (v->getValue() ? v->getValue()->getValueString() : "<none>")
                             + "\". Unit: \"" + (!v->getUnit().empty() ? v->getUnit() : "<none>")
+                            + "\". Colorspace: \"" + (!v->getColorspace().empty() ? v->getColorspace() : "<none>")
                             + "\". GLType: " + std::to_string(mapTypeToOpenGLType(v->getType()))
                         );
                         uniformTypeMismatchFound = true;
@@ -1182,6 +1188,7 @@ void GlslProgram::printUniforms(std::ostream& outputStream)
         string type = input.second->typeString;
         string value = input.second->value ? input.second->value->getValueString() : EMPTY_STRING;
         string unit = input.second->unit;
+        string colorspace = input.second->colorspace;
         bool isConstant = input.second->isConstant;
         outputStream << "Program Uniform: \"" << input.first
             << "\". Location:" << location
@@ -1194,6 +1201,8 @@ void GlslProgram::printUniforms(std::ostream& outputStream)
             outputStream << ". Value: " << value;
             if (!unit.empty())
                 outputStream << ". Unit: " << unit;
+            if (!colorspace.empty())
+                outputStream << ". Colorspace: " << colorspace;
         }
         outputStream << ". Is constant: " << isConstant;
         if (!input.second->path.empty())

--- a/source/MaterialXRenderGlsl/GlslProgram.h
+++ b/source/MaterialXRenderGlsl/GlslProgram.h
@@ -102,6 +102,8 @@ class MX_RENDERGLSL_API GlslProgram
         string path;
         /// Unit
         string unit;
+        /// Colorspace 
+        string colorspace;
 
         /// Program input constructor
         Input(int inputLocation, int inputType, int inputSize, string inputPath)

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -175,7 +175,7 @@ TEST_CASE("GenShader: OSL Metadata", "[genosl]")
     context.registerSourceCodeSearchPath(searchPath);
 
     // Metadata to export must be registered in the context before shader generation starts.
-    // Custom generators can override this mehtod to customize which metadata gets registered.
+    // Custom generators can override this method to customize which metadata gets registered.
     generator->registerShaderMetadata(doc, context);
 
     // Generate the shader and write to file for inspection.

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -14,7 +14,8 @@ namespace RenderUtil
 {
 
 ShaderRenderTester::ShaderRenderTester(mx::ShaderGeneratorPtr shaderGenerator) :
-    _shaderGenerator(shaderGenerator)
+    _shaderGenerator(shaderGenerator),
+    _emitColorTransforms(true)
 {
 }
 
@@ -193,6 +194,9 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
     // Set target unit space
     context.getOptions().targetDistanceUnit = "meter";
+
+    // Set whether to emit colorspace transforms
+    context.getOptions().emitColorTransforms = _emitColorTransforms;
 
     // Register shader metadata defined in the libraries.
     _shaderGenerator->registerShaderMetadata(dependLib, context);

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -94,6 +94,11 @@ class ShaderRenderTester
 
     bool validate(const mx::FilePathVec& testRootPaths, const mx::FilePath optionsFilePath);
 
+    void setEmitColorTransforms(bool val)
+    {
+        _emitColorTransforms = val;
+    }
+
   protected:
     // Check if testing should be performed based in input options
 #if defined(MATERIALX_TEST_RENDER)
@@ -174,6 +179,11 @@ class ShaderRenderTester
 
     // Files to skip
     mx::StringSet _skipFiles;
+
+    // Color management information
+    mx::ColorManagementSystemPtr _colorManagementSystem;
+    mx::FilePath _colorManagementConfigFile;
+    bool _emitColorTransforms;
 };
 
 } // namespace RenderUtil

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1599,6 +1599,7 @@ void Viewer::loadStandardLibraries()
     initContext(_genContextEssl);
 #if MATERIALX_BUILD_GEN_OSL
     initContext(_genContextOsl);
+    _genContextOsl.getOptions().emitColorTransforms = false;
 #endif
 #if MATERIALX_BUILD_GEN_MDL
     initContext(_genContextMdl);

--- a/source/PyMaterialX/PyMaterialXGenShader/PyGenOptions.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyGenOptions.cpp
@@ -31,5 +31,8 @@ void bindPyGenOptions(py::module& mod)
         .def_readwrite("hwTransparency", &mx::GenOptions::hwTransparency)
         .def_readwrite("hwSpecularEnvironmentMethod", &mx::GenOptions::hwSpecularEnvironmentMethod)
         .def_readwrite("hwMaxActiveLightSources", &mx::GenOptions::hwMaxActiveLightSources)
+        .def_readwrite("hwNormalizeUdimTexCoords", &mx::GenOptions::hwNormalizeUdimTexCoords)
+        .def_readwrite("hwWriteAlbedoTable", &mx::GenOptions::hwWriteAlbedoTable)
+        .def_readwrite("emitColorTransforms", &mx::GenOptions::emitColorTransforms)
         .def(py::init<>());
 }

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShaderPort.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShaderPort.cpp
@@ -30,6 +30,8 @@ void bindPyShaderPort(py::module& mod)
         .def("getPath", &mx::ShaderPort::getPath)
         .def("setUnit", &mx::ShaderPort::setUnit)
         .def("getUnit", &mx::ShaderPort::getUnit)
+        .def("setColorSpace", &mx::ShaderPort::setColorSpace)
+        .def("getColorSpace", &mx::ShaderPort::getColorSpace)
         .def("isUniform", &mx::ShaderPort::isUniform)
         .def("isEmitted", &mx::ShaderPort::isEmitted);
 }


### PR DESCRIPTION
Update [#1297](https://github.com/autodesk-forks/MaterialX/issues/1297)

- Modify code generation to query and pass on colorspace information to top level uniforms. 
- Change OSL filename syntax to be a structure. Current members include `filename` and `colorspace` but more can be added (such as for udim information which is currently additional arguments)
- Update OSL color3 / color4 image implementations to accept structure as input. Use string tokens to output arguments to texture() calls.
- Modify Syntax / TypeSytnax interface to accept string value extraction based on ShaderPort (which has typed inputs/outputs).
- Modify OSL shader code generation to emit structure as input argument.
- Modify GLSL introspection to query for colorspace information. Only used for reflection currently.
- Add new GenOption options to indicate whether to emit transforms if a color transform is found. Default is set to true. 

**Results**
Sample MTLX file (found in `/resources/Materials/TestSuite/stdlib/color_management`).
[filename_cm_test.mtlx.txt](https://github.com/autodesk-forks/MaterialX/files/7678873/filename_cm_test.mtlx.txt)
Sample OSL generated using new structure
[shaderref1.osl.txt](https://github.com/autodesk-forks/MaterialX/files/7678846/shaderref1.osl.txt)
Sample OSL
 generate using new structure and passing colorspace
[shaderref1_arnold.osl.txt](https://github.com/autodesk-forks/MaterialX/files/7678860/shaderref1_arnold.osl.txt)
![shaderref1_osl](https://user-images.githubusercontent.com/49369885/145282100-99cf970b-621e-4e01-b8b3-4e2ef12a8500.png)


