### PR TITLE
Re-expose virtual callback to emit light functions

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -76,6 +76,9 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     /// Emit specular environment lookup code
     virtual void emitSpecularEnvironment(GenContext& context, ShaderStage& stage) const;
 
+    /// Emit function definitions for lighting code
+    virtual void emitLightFunctionDefinitions(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const;
+
     static void toVec4(const TypeDesc* type, string& variable);
 
     /// Nodes used internally for light sampling.


### PR DESCRIPTION
This callback was removed in PR #747. We restore it so USD can keep
using it in their codegen.