### PR TITLE
Fix MDL sheen BSDF

### DIFF
--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib.mdl
@@ -305,7 +305,10 @@ export material mx_sheen_bsdf(
             base: mxp_base.surface.scattering,
             normal: mxp_normal
         )
-    )
+    ),
+    // we need to carry volume properties along for SSS
+    ior:    mxp_base.ior,
+    volume: mxp_base.volume
 );
 
 export material mx_thin_film_bsdf(


### PR DESCRIPTION
Similar to the other BSDFs, `mx_sheen_bsdf` in the MDL generator also needs to pass the volume properties to the next layer. If this is missing, SSS and attenuation do not work if a sheen layer is present in the material.