### PR TITLE
Give access to class derived from SurfaceNodeGLSL

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.h
@@ -26,7 +26,7 @@ class MX_GENGLSL_API SurfaceNodeGlsl : public GlslImplementation
 
     virtual void emitLightLoop(const ShaderNode& node, GenContext& context, ShaderStage& stage, const string& outColor) const;
 
-  private:
+  protected:
     /// Closure contexts for calling closure functions.
     mutable ClosureContext _callReflection;
     mutable ClosureContext _callTransmission;


### PR DESCRIPTION
One such class is the SurfaceNodeMaya as used by MayaUSD.