### PR TITLE
Improved handling for empty materials

### DIFF
--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -80,7 +80,7 @@ vector<NodePtr> getShaderNodes(NodePtr materialNode, const string& nodeType, con
         if (materialNodeDef)
         {
             InterfaceElementPtr impl = materialNodeDef->getImplementation();
-            if (impl->isA<NodeGraph>())
+            if (impl && impl->isA<NodeGraph>())
             {
                 NodeGraphPtr implGraph = impl->asA<NodeGraph>();
                 for (OutputPtr defOutput : materialNodeDef->getOutputs())

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -212,6 +212,11 @@ bool Node::validate(string* message) const
     bool res = true;
     validateRequire(!getCategory().empty(), res, message, "Node element is missing a category");
     validateRequire(hasType(), res, message, "Node element is missing a type");
+    if (getCategory() == SURFACE_MATERIAL_NODE_STRING ||
+        getCategory() == VOLUME_MATERIAL_NODE_STRING)
+    {
+        validateRequire(!getChildren().empty(), res, message, "Material node is empty");
+    }
     return InterfaceElement::validate(message) && res;
 }
 


### PR DESCRIPTION
- Add a null check to getShaderNodes, handling the case where a material node has no implementation.
- Add a check for empty material nodes in Node::validate.