### PR TITLE
Improvements to Windows build testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
           architecture: x64
           python: 3.9
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
-          test_validate: ON
+          test_shaders: ON
 
     steps:
     - name: Sync Repository
@@ -131,11 +131,25 @@ jobs:
           echo "CXX=clang++" >> $GITHUB_ENV
         fi
 
+    - name: Install Dependencies (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        git clone -b 2021.05.12 https://github.com/Microsoft/vcpkg
+        vcpkg/bootstrap-vcpkg.bat
+        echo $PWD/build/installed/bin | Out-File -FilePath $env:GITHUB_PATH -Append
+        echo $PWD/vcpkg/installed/x64-windows/bin | Out-File -FilePath $env:GITHUB_PATH -Append
+        echo $PWD/vcpkg/installed/x64-windows/tools | Out-File -FilePath $env:GITHUB_PATH -Append
+
     - name: Install Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.architecture }}
+
+    - name: Install OpenImageIO
+      if: matrix.install_oiio == 'ON' && runner.os == 'Windows'
+      run: |
+        vcpkg/vcpkg install openimageio --triplet=x64-windows
 
     - name: Create Build Directory
       run: mkdir build
@@ -157,11 +171,6 @@ jobs:
         echo "MESA_GLSL_VERSION_OVERRIDE=400" >> $GITHUB_ENV
         echo "GALLIUM_DRIVER=softpipe" >> $GITHUB_ENV
 
-    - name: Set Runtime Path (Windows)
-      if: runner.os == 'Windows'
-      run: echo "$PWD" | Out-File -FilePath $env:GITHUB_PATH -Append
-      working-directory: build/installed/bin
-
     - name: CMake Unit Tests
       run: ctest -VV --output-on-failure --build-config Release
       working-directory: build
@@ -178,6 +187,14 @@ jobs:
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx --path .. --target mdl
       working-directory: python
 
+    - name: Shader Validation Tests
+      if: matrix.test_shaders == 'ON' && runner.os == 'Windows'
+      run: |
+        vcpkg/vcpkg install glslang --triplet=x64-windows
+        glslangValidator.exe -v
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target essl --validator glslangValidator.exe
+
     - name: Render Tests
       if: matrix.test_render == 'ON'
       run: |
@@ -186,20 +203,6 @@ jobs:
         python python/Scripts/translateshader.py resources/Materials/Examples/StandardSurface/standard_surface_carpaint.mtlx build/render/usd_preview_surface_carpaint.mtlx UsdPreviewSurface --hdr --path .
         build/installed/bin/MaterialXView --material build/render/brass_average_baked.mtlx --mesh resources/Geometry/sphere.obj --screenWidth 128 --screenHeight 128 --cameraZoom 1.4 --captureFilename build/render/Viewer_BrassAverage.png
         build/installed/bin/MaterialXView --material build/render/usd_preview_surface_carpaint.mtlx --mesh resources/Geometry/sphere.obj --screenWidth 128 --screenHeight 128 --cameraZoom 1.4 --captureFilename build/render/Viewer_CarpaintTranslated.png
-
-    - name: Shader Validation Tests
-      if: matrix.test_validate == 'ON' && runner.os == 'Windows'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg
-        cd vcpkg
-        bootstrap-vcpkg.bat
-        vcpkg integrate install
-        vcpkg install glslang:x64-windows
-        cd ..
-        vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe -v
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target glsl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target essl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target glsl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
 
     - name: Upload Installed Package
       uses: actions/upload-artifact@v2

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -12,7 +12,7 @@ import MaterialX.PyMaterialXGenOsl as mx_gen_osl
 import MaterialX.PyMaterialXGenMdl as mx_gen_mdl
 
 def validateCode(sourceCodeFile, codevalidator, codevalidatorArgs):
-    if codevalidator and os.path.isfile(codevalidator):
+    if codevalidator:
         cmd = codevalidator + ' ' + sourceCodeFile 
         if codevalidatorArgs:
             cmd += ' ' + codevalidatorArgs


### PR DESCRIPTION
- Create a separate step for vcpkg installation on Windows.
- Add an optional step for OpenImageIO installation on Windows.
- Simplify runtime path handling on Windows.