### PR TITLE
Improvements to build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,14 +31,14 @@ jobs:
           compiler_version: "10"
           python: 3.7
 
-        - name: Linux_GCC_11_Python37
+        - name: Linux_GCC_11_Python39
           os: ubuntu-20.04
           compiler: gcc
           compiler_version: "11"
-          python: 3.7
+          python: 3.9
           test_render: ON
 
-        - name: Linux_Clang_9_Python36
+        - name: Linux_Clang_9_Python27
           os: ubuntu-18.04
           compiler: clang
           compiler_version: "9"
@@ -51,11 +51,11 @@ jobs:
           compiler_version: "11"
           python: 3.7
 
-        - name: Linux_Clang_12_Python38
+        - name: Linux_Clang_12_Python39
           os: ubuntu-20.04
           compiler: clang
           compiler_version: "12"
-          python: 3.8
+          python: 3.9
           test_render: ON
 
         - name: MacOS_Xcode_10_Python27
@@ -68,14 +68,14 @@ jobs:
         - name: MacOS_Xcode_12_Python37
           os: macos-11
           compiler: xcode
-          compiler_version: "12.5.1"
+          compiler_version: "12.4"
           python: 3.7
 
-        - name: MacOS_Xcode_13_Python38
+        - name: MacOS_Xcode_13_Python39
           os: macos-11
           compiler: xcode
-          compiler_version: "13.0"
-          python: 3.8
+          compiler_version: "13.1"
+          python: 3.9
 
         - name: Windows_VS2019_Win32_Python27
           os: windows-2019
@@ -134,8 +134,8 @@ jobs:
     - name: Install Dependencies (Windows)
       if: runner.os == 'Windows'
       run: |
-        git clone -b 2021.05.12 https://github.com/Microsoft/vcpkg
-        vcpkg/bootstrap-vcpkg.bat
+        git clone https://github.com/Microsoft/vcpkg -b 2021.05.12 -c advice.detachedHead=false
+        vcpkg/bootstrap-vcpkg.bat -disableMetrics
         echo $PWD/build/installed/bin | Out-File -FilePath $env:GITHUB_PATH -Append
         echo $PWD/vcpkg/installed/x64-windows/bin | Out-File -FilePath $env:GITHUB_PATH -Append
         echo $PWD/vcpkg/installed/x64-windows/tools | Out-File -FilePath $env:GITHUB_PATH -Append

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following packages contain pre-built binaries for the latest release, includ
 
 - [Microsoft Windows (Visual Studio 2019, Python 3.8)](https://github.com/materialx/MaterialX/releases/latest/download/MaterialX_Windows_VS2019_x64_Python38.zip)
 - [MacOS (Xcode 12, Python 3.7)](https://github.com/materialx/MaterialX/releases/latest/download/MaterialX_MacOS_Xcode_12_Python37.zip)
-- [Linux (GCC 11, Python 3.7)](https://github.com/materialx/MaterialX/releases/latest/download/MaterialX_Linux_GCC_11_Python37.zip)
+- [Linux (GCC 10, Python 3.7)](https://github.com/materialx/MaterialX/releases/latest/download/MaterialX_Linux_GCC_10_Python37.zip)
 
 ### Additional Resources
 


### PR DESCRIPTION
- Add Python 3.9 builds for all platforms.
- Update compiler versions on MacOS.
- Suppress warnings in Windows setup.