### PR TITLE
Improvements to standard libraries

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -38,13 +38,10 @@ float mx_imageworks_sheen_dir_albedo_analytic(float NdotV, float roughness)
 
 float mx_imageworks_sheen_dir_albedo_table_lookup(float NdotV, float roughness)
 {
-#if DIRECTIONAL_ALBEDO_METHOD == 1
-    vec2 res = textureSize($albedoTable, 0);
-    if (res.x > 1)
+    if (textureSize($albedoTable, 0).x > 1)
     {
         return texture($albedoTable, vec2(NdotV, roughness)).b;
     }
-#endif
     return 0.0;
 }
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -100,14 +100,11 @@ vec3 mx_ggx_dir_albedo_analytic(float NdotV, float roughness, vec3 F0, vec3 F90)
 
 vec3 mx_ggx_dir_albedo_table_lookup(float NdotV, float roughness, vec3 F0, vec3 F90)
 {
-#if DIRECTIONAL_ALBEDO_METHOD == 1
-    vec2 res = textureSize($albedoTable, 0);
-    if (res.x > 1)
+    if (textureSize($albedoTable, 0).x > 1)
     {
         vec2 AB = texture($albedoTable, vec2(NdotV, roughness)).rg;
         return F0 * AB.x + F90 * AB.y;
     }
-#endif
     return vec3(0.0);
 }
 

--- a/libraries/stdlib/genglsl/mx_normalmap.glsl
+++ b/libraries/stdlib/genglsl/mx_normalmap.glsl
@@ -1,16 +1,16 @@
 void mx_normalmap(vec3 value, int map_space, float normal_scale, vec3 N, vec3 T,  out vec3 result)
 {
-    // Tangent space
+    // Decode the normal map.
+    value = (value == vec3(0.0f)) ? vec3(0.0, 0.0, 1.0) : value * 2.0 - 1.0;
+
+    // Transform from tangent space if needed.
     if (map_space == 0)
     {
-        vec3 v = value * 2.0 - 1.0;
         vec3 B = normalize(cross(N, T));
-        result = normalize(T * v.x * normal_scale + B * v.y * normal_scale + N * v.z);
+        value.xy *= normal_scale;
+        value = T * value.x + B * value.y + N * value.z;
     }
-    // Object space
-    else
-    {
-        vec3 n = value * 2.0 - 1.0;
-        result = normalize(n);
-    }
+
+    // Normalize the result.
+    result = normalize(value);
 }

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -4115,7 +4115,7 @@
   <nodedef name="ND_heighttonormal_vector3" node="heighttonormal" nodegroup="convolution2d">
     <input name="in" type="float" value="0.0" />
     <input name="scale" type="float" value="1.0" />
-    <output name="out" type="vector3" default="0.0, 1.0, 0.0" />
+    <output name="out" type="vector3" default="0.5, 0.5, 1.0" />
   </nodedef>
 
   <!-- ======================================================================== -->


### PR DESCRIPTION
- Remove unneeded guards in GLSL albedo table lookups.
- Improve robustness of the GLSL implementation of normalmap.
- Fix the default output of heighttonormal.