### PR TITLE
Fix shader compilation in albedo table generation

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -522,7 +522,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     // Add lighting support
     bool lighting = requiresLighting(graph);
     
-    // define Albedo table type
+    // Define directional albedo approach
     if (lighting || context.getOptions().hwWriteAlbedoTable)
     {
         emitLine("#define DIRECTIONAL_ALBEDO_METHOD " + std::to_string(int(context.getOptions().hwDirectionalAlbedoMethod)), stage, false);

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -519,7 +519,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     emitInclude("stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_math.glsl", context, stage);
     emitLineBreak(stage);
 
-    // Add lighting support
+    // Determine whether lighting is required
     bool lighting = requiresLighting(graph);
     
     // Define directional albedo approach
@@ -529,7 +529,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
         emitLineBreak(stage);
     }
     
-    // Add Lighting function
+    // Add lighting support
     if (lighting)
     {
         if (context.getOptions().hwMaxActiveLightSources > 0)

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -521,6 +521,15 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
 
     // Add lighting support
     bool lighting = requiresLighting(graph);
+    
+    // define Albedo table type
+    if (lighting || context.getOptions().hwWriteAlbedoTable)
+    {
+        emitLine("#define DIRECTIONAL_ALBEDO_METHOD " + std::to_string(int(context.getOptions().hwDirectionalAlbedoMethod)), stage, false);
+        emitLineBreak(stage);
+    }
+    
+    // Add Lighting function
     if (lighting)
     {
         if (context.getOptions().hwMaxActiveLightSources > 0)
@@ -528,8 +537,6 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
             const unsigned int maxLights = std::max(1u, context.getOptions().hwMaxActiveLightSources);
             emitLine("#define " + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + " " + std::to_string(maxLights), stage, false);
         }
-        emitLine("#define DIRECTIONAL_ALBEDO_METHOD " + std::to_string(int(context.getOptions().hwDirectionalAlbedoMethod)), stage, false);
-        emitLineBreak(stage);
         emitSpecularEnvironment(context, stage);
 
         if (context.getOptions().hwMaxActiveLightSources > 0)


### PR DESCRIPTION
The albedo table shader fails to compile because DIRECTIONAL_ALBEDO_METHOD is not defined.
DIRECTIONAL_ALBEDO_METHOD get’s defined if and only if a lighting nodes are found (see GlslShaderGenerator::requiresLighting)

Minor update to this to also check for hwWriteAlbedoTable in the Context.