### PR TITLE
Port Worley noise GLSL implementation to MDL

### DIFF
--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -131,6 +131,16 @@
   <!-- <cellnoise3d> -->
   <implementation name="IM_cellnoise3d_float_genmdl" nodedef="ND_cellnoise3d_float" sourcecode="mx::stdlib::mx_cellnoise3d_float(mxp_position:{{position}})" target="genmdl" />
 
+  <!-- <worleynoise2d> -->
+  <implementation name="IM_worleynoise2d_float_genmdl" nodedef="ND_worleynoise2d_float" sourcecode="mx::stdlib::mx_worleynoise2d_float(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise2d_vector2_genmdl" nodedef="ND_worleynoise2d_vector2" sourcecode="mx::stdlib::mx_worleynoise2d_vector2(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise2d_vector3_genmdl" nodedef="ND_worleynoise2d_vector3" sourcecode="mx::stdlib::mx_worleynoise2d_vector3(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
+
+  <!-- <worleynoise3d> -->
+  <implementation name="IM_worleynoise3d_float_genmdl" nodedef="ND_worleynoise3d_float" sourcecode="mx::stdlib::mx_worleynoise3d_float(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise3d_vector2_genmdl" nodedef="ND_worleynoise3d_vector2" sourcecode="mx::stdlib::mx_worleynoise3d_vector2(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise3d_vector3_genmdl" nodedef="ND_worleynoise3d_vector3" sourcecode="mx::stdlib::mx_worleynoise3d_vector3(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
+
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -133,13 +133,13 @@
 
   <!-- <worleynoise2d> -->
   <implementation name="IM_worleynoise2d_float_genmdl" nodedef="ND_worleynoise2d_float" sourcecode="mx::stdlib::mx_worleynoise2d_float(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
-  <implementation name="IM_worleynoise2d_vector2_genmdl" nodedef="ND_worleynoise2d_vector2" sourcecode="mx::stdlib::mx_worleynoise2d_vector2(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
-  <implementation name="IM_worleynoise2d_vector3_genmdl" nodedef="ND_worleynoise2d_vector3" sourcecode="mx::stdlib::mx_worleynoise2d_vector3(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise2d_vector2_genmdl" nodedef="ND_worleynoise2d_vector2" sourcecode="mx::stdlib::mx_worleynoise2d_float2(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise2d_vector3_genmdl" nodedef="ND_worleynoise2d_vector3" sourcecode="mx::stdlib::mx_worleynoise2d_float3(mxp_texcoord:{{texcoord}}, mxp_jitter:{{jitter}})" target="genmdl" />
 
   <!-- <worleynoise3d> -->
   <implementation name="IM_worleynoise3d_float_genmdl" nodedef="ND_worleynoise3d_float" sourcecode="mx::stdlib::mx_worleynoise3d_float(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
-  <implementation name="IM_worleynoise3d_vector2_genmdl" nodedef="ND_worleynoise3d_vector2" sourcecode="mx::stdlib::mx_worleynoise3d_vector2(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
-  <implementation name="IM_worleynoise3d_vector3_genmdl" nodedef="ND_worleynoise3d_vector3" sourcecode="mx::stdlib::mx_worleynoise3d_vector3(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise3d_vector2_genmdl" nodedef="ND_worleynoise3d_vector2" sourcecode="mx::stdlib::mx_worleynoise3d_float2(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
+  <implementation name="IM_worleynoise3d_vector3_genmdl" nodedef="ND_worleynoise3d_vector3" sourcecode="mx::stdlib::mx_worleynoise3d_float3(mxp_position:{{position}}, mxp_jitter:{{jitter}})" target="genmdl" />
 
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->

--- a/source/MaterialXGenMdl/mdl/materialx/noise.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/noise.mdl
@@ -370,7 +370,6 @@ export float3 mx_fractal_noise_float3(
     return result;
 }
 
-
 float mx_8bits_to_01(int bits)
 {
     return float(bits) / float(0xff);

--- a/source/MaterialXGenMdl/mdl/materialx/noise.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/noise.mdl
@@ -418,8 +418,6 @@ float mx_worley_distance3(float3 p, int x, int y, int z, int xoff, int yoff, int
 
 export float mx_worley_noise_float(float2 p, float jitter, int metric)
 {
-//    int X, Y;
-//    float2 localpos = float2(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y));
     float ix = math::floor(p.x);
     float iy = math::floor(p.y);
     int X = int(ix);
@@ -442,8 +440,6 @@ export float mx_worley_noise_float(float2 p, float jitter, int metric)
 
 export float2 mx_worley_noise_float2(float2 p, float jitter, int metric)
 {
-//    int X, Y;
-//    float2 localpos = float2(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y));
     float ix = math::floor(p.x);
     float iy = math::floor(p.y);
     int X = int(ix);
@@ -474,8 +470,6 @@ export float2 mx_worley_noise_float2(float2 p, float jitter, int metric)
 
 export float3 mx_worley_noise_float3(float2 p, float jitter, int metric)
 {
-//    int X, Y;
-//    float2 localpos = float2(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y));
     float ix = math::floor(p.x);
     float iy = math::floor(p.y);
     int X = int(ix);
@@ -512,8 +506,6 @@ export float3 mx_worley_noise_float3(float2 p, float jitter, int metric)
 
 export float mx_worley_noise_float(float3 p, float jitter, int metric)
 {
-//    int X, Y, Z;
-//    float3 localpos = float3(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y), mx_floorfrac(p.z, Z));
     float ix = math::floor(p.x);
     float iy = math::floor(p.y);
     float iz = math::floor(p.z);
@@ -541,8 +533,6 @@ export float mx_worley_noise_float(float3 p, float jitter, int metric)
 
 export float2 mx_worley_noise_float2(float3 p, float jitter, int metric)
 {
-//    int X, Y, Z;
-//    float3 localpos = float3(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y), mx_floorfrac(p.z, Z));
     float ix = math::floor(p.x);
     float iy = math::floor(p.y);
     float iz = math::floor(p.z);
@@ -578,8 +568,6 @@ export float2 mx_worley_noise_float2(float3 p, float jitter, int metric)
 
 export float3 mx_worley_noise_float3(float3 p, float jitter, int metric)
 {
-//    int X, Y, Z;
-//    float3 localpos = float3(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y), mx_floorfrac(p.z, Z));
     float ix = math::floor(p.x);
     float iy = math::floor(p.y);
     float iz = math::floor(p.z);

--- a/source/MaterialXGenMdl/mdl/materialx/noise.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/noise.mdl
@@ -369,3 +369,252 @@ export float3 mx_fractal_noise_float3(
     }
     return result;
 }
+
+
+float mx_8bits_to_01(int bits)
+{
+    return float(bits) / float(0xff);
+}
+
+float mx_worley_distance2(float2 p, int x, int y, int xoff, int yoff, float jitter, int metric)
+{
+    int3 hash = mx_hash_int3(x+xoff, y+yoff);
+    float2  off = float2(mx_8bits_to_01(hash.x), mx_8bits_to_01(hash.y));
+
+    off -= 0.5f;
+    off *= jitter;
+    off += 0.5f;
+
+    float2 cellpos = float2(float(x), float(y)) + off;
+    float2 diff = cellpos - p;
+    if (metric == 2)
+        return math::abs(diff.x) + math::abs(diff.y); // Manhattan distance
+    if (metric == 3)
+        return math::max(math::abs(diff.x), math::abs(diff.y)); // Chebyshev distance
+    // Either Euclidian or Distance^2
+    return math::dot(diff, diff);
+}
+
+float mx_worley_distance3(float3 p, int x, int y, int z, int xoff, int yoff, int zoff, float jitter, int metric)
+{
+    int3 hash = mx_hash_int3(x+xoff, y+yoff, z+zoff);
+    float3  off = float3(mx_8bits_to_01(hash.x),
+                         mx_8bits_to_01(hash.y),
+                         mx_8bits_to_01(hash.z));
+
+    off -= 0.5f;
+    off *= jitter;
+    off += 0.5f;
+
+    float3 cellpos = float3(float(x), float(y), float(z)) + off;
+    float3 diff = cellpos - p;
+    if (metric == 2)
+        return math::abs(diff.x) + math::abs(diff.y) + math::abs(diff.z); // Manhattan distance
+    if (metric == 3)
+        return math::max(math::max(math::abs(diff.x), math::abs(diff.y)), math::abs(diff.z)); // Chebyshev distance
+    // Either Euclidian or Distance^2
+    return math::dot(diff, diff);
+}
+
+export float mx_worley_noise_float(float2 p, float jitter, int metric)
+{
+//    int X, Y;
+//    float2 localpos = float2(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y));
+    float ix = math::floor(p.x);
+    float iy = math::floor(p.y);
+    int X = int(ix);
+    int Y = int(iy);
+    float2 localpos = float2(p.x-ix, p.y-iy);
+
+    float sqdist = 1e6f;        // Some big number for jitter > 1 (not all GPUs may be IEEE)
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            float dist = mx_worley_distance2(localpos, x, y, X, Y, jitter, metric);
+            sqdist = math::min(sqdist, dist);
+        }
+    }
+    if (metric == 0)
+        sqdist = math::sqrt(sqdist);
+    return sqdist;
+}
+
+export float2 mx_worley_noise_float2(float2 p, float jitter, int metric)
+{
+//    int X, Y;
+//    float2 localpos = float2(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y));
+    float ix = math::floor(p.x);
+    float iy = math::floor(p.y);
+    int X = int(ix);
+    int Y = int(iy);
+    float2 localpos = float2(p.x-ix, p.y-iy);
+
+    float2 sqdist = float2(1e6f, 1e6f);
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            float dist = mx_worley_distance2(localpos, x, y, X, Y, jitter, metric);
+            if (dist < sqdist.x)
+            {
+                sqdist.y = sqdist.x;
+                sqdist.x = dist;
+            }
+            else if (dist < sqdist.y)
+            {
+                sqdist.y = dist;
+            }
+        }
+    }
+    if (metric == 0)
+        sqdist = math::sqrt(sqdist);
+    return sqdist;
+}
+
+export float3 mx_worley_noise_float3(float2 p, float jitter, int metric)
+{
+//    int X, Y;
+//    float2 localpos = float2(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y));
+    float ix = math::floor(p.x);
+    float iy = math::floor(p.y);
+    int X = int(ix);
+    int Y = int(iy);
+    float2 localpos = float2(p.x-ix, p.y-iy);
+
+    float3 sqdist = float3(1e6f, 1e6f, 1e6f);
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            float dist = mx_worley_distance2(localpos, x, y, X, Y, jitter, metric);
+            if (dist < sqdist.x)
+            {
+                sqdist.z = sqdist.y;
+                sqdist.y = sqdist.x;
+                sqdist.x = dist;
+            }
+            else if (dist < sqdist.y)
+            {
+                sqdist.z = sqdist.y;
+                sqdist.y = dist;
+            }
+            else if (dist < sqdist.z)
+            {
+                sqdist.z = dist;
+            }
+        }
+    }
+    if (metric == 0)
+        sqdist = math::sqrt(sqdist);
+    return sqdist;
+}
+
+export float mx_worley_noise_float(float3 p, float jitter, int metric)
+{
+//    int X, Y, Z;
+//    float3 localpos = float3(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y), mx_floorfrac(p.z, Z));
+    float ix = math::floor(p.x);
+    float iy = math::floor(p.y);
+    float iz = math::floor(p.z);
+    int X = int(ix);
+    int Y = int(iy);
+    int Z = int(iz);
+    float3 localpos = float3(p.x-ix, p.y-iy, p.z-iz);
+
+    float sqdist = 1e6f;
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            for (int z = -1; z <= 1; ++z)
+            {
+                float dist = mx_worley_distance3(localpos, x, y, z, X, Y, Z, jitter, metric);
+                sqdist = math::min(sqdist, dist);
+            }
+        }
+    }
+    if (metric == 0)
+        sqdist = math::sqrt(sqdist);
+    return sqdist;
+}
+
+export float2 mx_worley_noise_float2(float3 p, float jitter, int metric)
+{
+//    int X, Y, Z;
+//    float3 localpos = float3(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y), mx_floorfrac(p.z, Z));
+    float ix = math::floor(p.x);
+    float iy = math::floor(p.y);
+    float iz = math::floor(p.z);
+    int X = int(ix);
+    int Y = int(iy);
+    int Z = int(iz);
+    float3 localpos = float3(p.x-ix, p.y-iy, p.z-iz);
+
+    float2 sqdist = float2(1e6f, 1e6f);
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            for (int z = -1; z <= 1; ++z)
+            {
+                float dist = mx_worley_distance3(localpos, x, y, z, X, Y, Z, jitter, metric);
+                if (dist < sqdist.x)
+                {
+                    sqdist.y = sqdist.x;
+                    sqdist.x = dist;
+                }
+                else if (dist < sqdist.y)
+                {
+                    sqdist.y = dist;
+                }
+            }
+        }
+    }
+    if (metric == 0)
+        sqdist = math::sqrt(sqdist);
+    return sqdist;
+}
+
+export float3 mx_worley_noise_float3(float3 p, float jitter, int metric)
+{
+//    int X, Y, Z;
+//    float3 localpos = float3(mx_floorfrac(p.x, X), mx_floorfrac(p.y, Y), mx_floorfrac(p.z, Z));
+    float ix = math::floor(p.x);
+    float iy = math::floor(p.y);
+    float iz = math::floor(p.z);
+    int X = int(ix);
+    int Y = int(iy);
+    int Z = int(iz);
+    float3 localpos = float3(p.x-ix, p.y-iy, p.z-iz);
+
+    float3 sqdist = float3(1e6f, 1e6f, 1e6f);
+    for (int x = -1; x <= 1; ++x)
+    {
+        for (int y = -1; y <= 1; ++y)
+        {
+            for (int z = -1; z <= 1; ++z)
+            {
+                float dist = mx_worley_distance3(localpos, x, y, z, X, Y, Z, jitter, metric);
+                if (dist < sqdist.x)
+                {
+                    sqdist.z = sqdist.y;
+                    sqdist.y = sqdist.x;
+                    sqdist.x = dist;
+                }
+                else if (dist < sqdist.y)
+                {
+                    sqdist.z = sqdist.y;
+                    sqdist.y = dist;
+                }
+                else if (dist < sqdist.z)
+                {
+                    sqdist.z = dist;
+                }
+            }
+        }
+    }
+    if (metric == 0)
+        sqdist = math::sqrt(sqdist);
+    return sqdist;
+}

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
@@ -4648,3 +4648,51 @@ export float mx_cellnoise3d_float(
 {
     return noise::mx_cell_noise_float(mxp_position);
 }
+
+export float mx_worleynoise2d_float(
+  float2 mxp_texcoord = swizzle::xy( ::state::texture_coordinate(0)),
+  float mxp_jitter = 1.0
+)
+{
+    return noise::mx_worley_noise_float(mxp_texcoord, mxp_jitter, 0);
+}
+
+export float2 mx_worleynoise2d_float2(
+  float2 mxp_texcoord = swizzle::xy( ::state::texture_coordinate(0)),
+  float mxp_jitter = 1.0
+)
+{
+    return noise::mx_worley_noise_float2(mxp_texcoord, mxp_jitter, 0);
+}
+
+export float3 mx_worleynoise2d_float3(
+  float2 mxp_texcoord = swizzle::xy( ::state::texture_coordinate(0)),
+  float mxp_jitter = 1.0
+)
+{
+    return noise::mx_worley_noise_float3(mxp_texcoord, mxp_jitter, 0);
+}
+
+export float mx_worleynoise3d_float(
+  float3 mxp_position = state::transform_point(state::coordinate_internal, state::coordinate_object, state::position()),
+  float mxp_jitter = 1.0
+)
+{
+    return noise::mx_worley_noise_float(mxp_position, mxp_jitter, 0);
+}
+
+export float2 mx_worleynoise3d_float2(
+  float3 mxp_position = state::transform_point(state::coordinate_internal, state::coordinate_object, state::position()),
+  float mxp_jitter = 1.0
+)
+{
+    return noise::mx_worley_noise_float2(mxp_position, mxp_jitter, 0);
+}
+
+export float3 mx_worleynoise3d_float3(
+  float3 mxp_position = state::transform_point(state::coordinate_internal, state::coordinate_object, state::position()),
+  float mxp_jitter = 1.0
+)
+{
+    return noise::mx_worley_noise_float3(mxp_position, mxp_jitter, 0);
+}


### PR DESCRIPTION
Straight forward port from GLSL to MDL shader code.

Some render comparisons:

![worley1_glsl](https://user-images.githubusercontent.com/5731522/148638887-997a75c4-f749-469b-b70e-5d6364e1d784.png)
![worley1_mdl](https://user-images.githubusercontent.com/5731522/148638888-ca36a7ce-6a00-4495-a9a5-a714f852f45b.png)

![worley2_glsl](https://user-images.githubusercontent.com/5731522/148638905-b6ca4986-9bfd-44ac-8262-bb7041af8d09.png)
![worley2_mdl](https://user-images.githubusercontent.com/5731522/148638908-b660ccb4-4eb4-4016-aa6b-947fee9e03d7.png)

