### PR TITLE
Improved OSL render testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,9 @@ set(MATERIALX_INSTALL_LIB_PATH "lib" CACHE STRING "Install lib path (e.g. 'libs'
 set(MATERIALX_INSTALL_STDLIB_PATH "libraries" CACHE STRING "Install path for mtlx std libs (e.g. 'libraries').")
 
 # Helpers for OSL validation
-set(MATERIALX_TESTOSLC_EXECUTABLE "" CACHE FILEPATH "Full path to the oslc binary.")
-set(MATERIALX_TESTRENDER_EXECUTABLE "" CACHE FILEPATH "Full path to the testrender binary.")
-set(MATERIALX_OSL_INCLUDE_PATH "" CACHE PATH "Full path to osl include paths. e.g. location of stdosl.h")
+set(MATERIALX_OSL_BINARY_OSLC "" CACHE FILEPATH "Full path to the OSL compiler binary.")
+set(MATERIALX_OSL_BINARY_TESTRENDER "" CACHE FILEPATH "Full path to the OSL test render binary.")
+set(MATERIALX_OSL_INCLUDE_PATH "" CACHE PATH "Full path to OSL shader includes (e.g. 'stdosl.h').")
 
 # Helpers for MDL validation
 if (MATERIALX_BUILD_GEN_MDL)
@@ -117,8 +117,8 @@ mark_as_advanced(MATERIALX_PYTHON_EXECUTABLE)
 mark_as_advanced(MATERIALX_PYTHON_OCIO_DIR)
 mark_as_advanced(MATERIALX_PYTHON_PYBIND11_DIR)
 mark_as_advanced(MATERIALX_OIIO_DIR)
-mark_as_advanced(MATERIALX_TESTOSLC_EXECUTABLE)
-mark_as_advanced(MATERIALX_TESTRENDER_EXECUTABLE)
+mark_as_advanced(MATERIALX_OSL_BINARY_OSLC)
+mark_as_advanced(MATERIALX_OSL_BINARY_TESTRENDER)
 mark_as_advanced(MATERIALX_OSL_INCLUDE_PATH)
 mark_as_advanced(MATERIALX_INSTALL_INCLUDE_PATH)
 mark_as_advanced(MATERIALX_INSTALL_LIB_PATH)
@@ -134,8 +134,8 @@ if (MATERIALX_BUILD_GEN_MDL)
 endif()
 
 # Add global definitions
-add_definitions(-DMATERIALX_TESTOSLC_EXECUTABLE=\"${MATERIALX_TESTOSLC_EXECUTABLE}\")
-add_definitions(-DMATERIALX_TESTRENDER_EXECUTABLE=\"${MATERIALX_TESTRENDER_EXECUTABLE}\")
+add_definitions(-DMATERIALX_OSL_BINARY_OSLC=\"${MATERIALX_OSL_BINARY_OSLC}\")
+add_definitions(-DMATERIALX_OSL_BINARY_TESTRENDER=\"${MATERIALX_OSL_BINARY_TESTRENDER}\")
 add_definitions(-DMATERIALX_OSL_INCLUDE_PATH=\"${MATERIALX_OSL_INCLUDE_PATH}\")
 if(MATERIALX_BUILD_OIIO)
     add_definitions(-DMATERIALX_BUILD_OIIO)

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -87,11 +87,11 @@
     <!-- Transforms UVs of loaded geometry -->
     <input name="transformUVs" type="matrix44" value="1.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -0.235f, 1.0f, 0.0f, 1.0f" />
 
-    <!-- External testing: extra comma separated list of library paths -->
-    <input name="externalLibraryPaths" type="string" value="" />
+    <!-- List of extra library paths for generator and render tests -->
+    <input name="extraLibraryPaths" type="string" value="" />
 
-    <!-- External testing: extra comma separated list of test root paths -->
-    <input name="externalTestPaths" type="string" value="" />
+    <!-- List of document paths for render tests -->
+    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/Examples/UsdPreviewSurface,resources/Materials/TestSuite" />
 
     <!-- Wedge rendering options -->
     <input name="wedgeFiles" type="string" value="wedge_conductor.mtlx,wedge_conductor.mtlx" />

--- a/source/MaterialXGenShader/Shader.h
+++ b/source/MaterialXGenShader/Shader.h
@@ -94,10 +94,13 @@ class MX_GENSHADER_API Shader
     /// Return true if this shader matches the given classification.
     bool hasClassification(unsigned int c) const { return _graph->hasClassification(c); }
 
-    /// Return the final shader source code for a given shader stage
+    /// Set the shader source code for a given shader stage.
+    const void setSourceCode(const string& code, const string& stage = Stage::PIXEL) { getStage(stage).setSourceCode(code); }
+
+    /// Return the shader source code for a given shader stage.
     const string& getSourceCode(const string& stage = Stage::PIXEL) const { return getStage(stage).getSourceCode(); }
 
-  protected: 
+  protected:
     /// Create a new stage in the shader.
     ShaderStagePtr createStage(const string& name, ConstSyntaxPtr syntax);
 

--- a/source/MaterialXGenShader/ShaderStage.h
+++ b/source/MaterialXGenShader/ShaderStage.h
@@ -140,6 +140,9 @@ public:
     /// Return the stage function name.
     const string& getFunctionName() const { return _functionName; }
 
+    /// Set the stage source code.
+    void setSourceCode(const string& code) { _code = code; }
+
     /// Return the stage source code.
     const string& getSourceCode() const { return _code; }
 

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -83,7 +83,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     string shaderPath = shaderFilePath.asString();
 
     // Set output image name.
-    string outputFileName = shaderPath + "_osl.exr";
+    string outputFileName = shaderPath + "_osl.png";
     _oslOutputFileName = outputFileName;
 
     // Use a known error file name to check
@@ -217,7 +217,7 @@ void OslRenderer::shadeOSL(const FilePath& dirPath, const string& shaderName, co
     string shaderPath = shaderFilePath.asString();
 
     // Set output image name.
-    string outputFileName = shaderPath + ".testshade.exr";
+    string outputFileName = shaderPath + ".testshade.png";
     _oslOutputFileName = outputFileName;
 
     // Use a known error file name to check

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -5,17 +5,15 @@
 
 #include <MaterialXRenderOsl/OslRenderer.h>
 
-#include <MaterialXFormat/File.h>
-
-#include <MaterialXFormat/Util.h>
-
 #include <MaterialXGenOsl/OslShaderGenerator.h>
+
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/Util.h>
 
 #include <fstream>
 
 MATERIALX_NAMESPACE_BEGIN
 
-// Statics
 string OslRenderer::OSL_CLOSURE_COLOR_STRING("closure color");
 
 //
@@ -85,8 +83,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     string shaderPath = shaderFilePath.asString();
 
     // Set output image name.
-    string outputFileName = shaderPath + "_osl.png";
-    // Cache the output file name
+    string outputFileName = shaderPath + "_osl.exr";
     _oslOutputFileName = outputFileName;
 
     // Use a known error file name to check
@@ -95,11 +92,10 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
 
     // Read in scene template and replace the applicable tokens to have a valid ShaderGroup.
     // Write to local file to use as input for rendering.
-    //
     std::ifstream sceneTemplateStream(_oslTestRenderSceneTemplateFile);
     string sceneTemplateString;
     sceneTemplateString.assign(std::istreambuf_iterator<char>(sceneTemplateStream),
-        std::istreambuf_iterator<char>());
+                               std::istreambuf_iterator<char>());
 
     // Get final output to use in the shader
     const string CLOSURE_PASSTHROUGH_SHADER_STRING("closure_passthrough");
@@ -141,7 +137,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     if ((sceneString == sceneTemplateString) || sceneTemplateString.empty())
     {
         throw ExceptionRenderError("Scene template file: " + _oslTestRenderSceneTemplateFile.asString() +
-                                         " does not include proper tokens for rendering");
+                                   " does not include proper tokens for rendering");
     }
 
     // Write scene file
@@ -159,7 +155,6 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     osoPaths += PATH_LIST_SEPARATOR + dirPath.asString();
 
     // Build and run render command
-    //
     string command(_oslTestRenderExecutable);
     command += " " + sceneFileName;
     command += " " + outputFileName;
@@ -170,35 +165,41 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     }
     command += " > " + errorFile + redirectString;
 
-    int returnValue = std::system(command.c_str());
-
-    std::ifstream errorStream(errorFile);
-    StringVec result;
-    string line;
-    const string pngWarning("libpng warning: iCCP: known incorrect sRGB profile");
-    unsigned int errCount = 0;
-    while (std::getline(errorStream, line))
+    // Repeat the render command to allow for sporadic errors.
+    int returnValue = 0;
+    for (int i = 0; i < 3; i++)
     {
-        if (line.find(pngWarning) != std::string::npos)
-        {
-            continue;
-        }
-        if (errCount++ > 10)
+        returnValue = std::system(command.c_str());
+        if (!returnValue)
         {
             break;
         }
-        result.push_back(line);
     }
-    if (!result.empty())
+
+    // Report errors on a non-zero return value.
+    if (returnValue)
     {
+        std::ifstream errorStream(errorFile);
+        StringVec result;
+        string line;
+        unsigned int errCount = 0;
+        while (std::getline(errorStream, line))
+        {
+            if (errCount++ > 10)
+            {
+                break;
+            }
+            result.push_back(line);
+        }
+
         StringVec errors;
-        errors.push_back("Command string: " + command);
-        errors.push_back("Command return code: " + std::to_string(returnValue));
-        errors.push_back("Shader failed to render:");
+        errors.push_back("Errors reported in renderOSL:");
         for (size_t i = 0; i < result.size(); i++)
         {
             errors.push_back(result[i]);
         }
+        errors.push_back("Command string: " + command);
+        errors.push_back("Command return code: " + std::to_string(returnValue));
         throw ExceptionRenderError("OSL rendering error", errors);
     }
 }
@@ -216,8 +217,7 @@ void OslRenderer::shadeOSL(const FilePath& dirPath, const string& shaderName, co
     string shaderPath = shaderFilePath.asString();
 
     // Set output image name.
-    string outputFileName = shaderPath + ".testshade.png";
-    // Cache the output file name
+    string outputFileName = shaderPath + ".testshade.exr";
     _oslOutputFileName = outputFileName;
 
     // Use a known error file name to check
@@ -255,13 +255,13 @@ void OslRenderer::shadeOSL(const FilePath& dirPath, const string& shaderName, co
     if (!results.empty())
     {
         StringVec errors;
-        errors.push_back("Command string: " + command);
-        errors.push_back("Command return code: " + std::to_string(returnValue));
-        errors.push_back("Shader failed to render:");
+        errors.push_back("Errors reported in shadeOSL:");
         for (const auto& resultLine : results)
         {
             errors.push_back(resultLine);
         }
+        errors.push_back("Command string: " + command);
+        errors.push_back("Command return code: " + std::to_string(returnValue));
         throw ExceptionRenderError("OSL rendering error", errors);
     }
 }

--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -5,8 +5,6 @@ list(APPEND materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/Catch/catch.hpp")
 assign_source_group("Source Files" ${materialx_source})
 assign_source_group("Header Files" ${materialx_headers})
 
-set(MATERIALX_TEST_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
 # Discover all tests and allow them to be run in parallel (ctest -j20):
 function(add_tests _sources)
   foreach(src_file ${_sources})

--- a/source/MaterialXTest/Main.cpp
+++ b/source/MaterialXTest/Main.cpp
@@ -4,7 +4,11 @@
 //
 
 #define CATCH_CONFIG_RUNNER
+
 #include <MaterialXTest/Catch/catch.hpp>
+#include <MaterialXFormat/File.h>
+
+namespace mx = MaterialX;
 
 int main(int argc, char* const argv[])
 {
@@ -24,6 +28,16 @@ int main(int argc, char* const argv[])
         session.configData().outputFilename = "";
     }
 #endif
+
+    mx::FilePath resourcesPath = mx::FilePath::getCurrentPath() / "resources";
+    if (!resourcesPath.exists())
+    {
+        resourcesPath = mx::FilePath::getModulePath().getParentPath() / "resources";
+        if (resourcesPath.exists())
+        {
+            resourcesPath.getParentPath().setCurrentPath();
+        }
+    }
 
     int returnCode = session.applyCommandLine(argc, argv);
     if (returnCode != 0)

--- a/source/MaterialXTest/Main.cpp
+++ b/source/MaterialXTest/Main.cpp
@@ -29,6 +29,8 @@ int main(int argc, char* const argv[])
     }
 #endif
 
+    // If the current path has no valid resources folder, as can occur when launching the
+    // test suite from an IDE, then align the current path with the module path.
     mx::FilePath resourcesPath = mx::FilePath::getCurrentPath() / "resources";
     if (!resourcesPath.exists())
     {

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -124,19 +124,16 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
 
 static void generateGlslCode(bool generateLayout = false)
 {
-    const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    const mx::FilePath testRootPath3 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/UsdPreviewSurface");
     mx::FilePathVec testRootPaths;
-    testRootPaths.push_back(testRootPath);
-    testRootPaths.push_back(testRootPath2);
-    testRootPaths.push_back(testRootPath3);
+    testRootPaths.push_back("resources/Materials/TestSuite");
+    testRootPaths.push_back("resources/Materials/Examples/StandardSurface");
+    testRootPaths.push_back("resources/Materials/Examples/UsdPreviewSurface");
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     bool writeShadersToDisk = false;
 
     const mx::GenOptions genOptions;
-    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
 
     const mx::FilePath logPath(generateLayout ? "genglsl_glsl420_layout_generate_test.txt" : "genglsl_glsl400_generate_test.txt");
 

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -236,13 +236,10 @@ void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& so
 
 TEST_CASE("GenShader: MDL Shader Generation", "[genmdl]")
 {
-    const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    const mx::FilePath testRootPath3 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/UsdPreviewSurface");
     mx::FilePathVec testRootPaths;
-    testRootPaths.push_back(testRootPath);
-    testRootPaths.push_back(testRootPath2);
-    testRootPaths.push_back(testRootPath3);
+    testRootPaths.push_back("resources/Materials/TestSuite");
+    testRootPaths.push_back("resources/Materials/Examples/StandardSurface");
+    testRootPaths.push_back("resources/Materials/Examples/UsdPreviewSurface");
 
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
     mx::FileSearchPath srcSearchPath(libSearchPath.asString());
@@ -258,6 +255,6 @@ TEST_CASE("GenShader: MDL Shader Generation", "[genmdl]")
 
     mx::GenOptions genOptions;
     genOptions.targetColorSpaceOverride = "lin_rec709";
-    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
 }

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -189,13 +189,11 @@ TEST_CASE("GenShader: OSL Metadata", "[genosl]")
 
 static void generateOslCode()
 {
-    const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    const mx::FilePath testRootPath3 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/UsdPreviewSurface");
     mx::FilePathVec testRootPaths;
-    testRootPaths.push_back(testRootPath);
-    testRootPaths.push_back(testRootPath2);
-    testRootPaths.push_back(testRootPath3);
+    testRootPaths.push_back("resources/Materials/TestSuite");
+    testRootPaths.push_back("resources/Materials/Examples/StandardSurface");
+    testRootPaths.push_back("resources/Materials/Examples/UsdPreviewSurface");
+
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
     mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     srcSearchPath.append(libSearchPath / mx::FilePath("stdlib/osl"));
@@ -207,7 +205,7 @@ static void generateOslCode()
     tester.addSkipLibraryFiles();
 
     const mx::GenOptions genOptions;
-    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
 }
 

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -178,10 +178,10 @@ TEST_CASE("GenShader: Transparency Regression Check", "[genshader]")
         "Materials/Examples/StandardSurface/standard_surface_default.mtlx", 
         "Materials/Examples/StandardSurface/standard_surface_glass.mtlx",
         "Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx",
-        "Materials/TestStuie/pbrlib/surfaceshader/transparency_nodedef_test.mtlx",
-        "Materials/TestStuie/pbrlib/surfaceshader/transparency_test.mtlx",
+        "Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx",
+        "Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx",
     };
-    std::vector<bool> transparencyTest = { false, true, true, true };
+    std::vector<bool> transparencyTest = { false, true, true, true, true };
     for (size_t i=0; i<testFiles.size(); i++)
     {
         const mx::FilePath& testFile = resourcePath / testFiles[i];

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -904,8 +904,8 @@ void TestSuiteOptions::print(std::ostream& output) const
     output << "\tSpecular Environment Method: " << specularEnvironmentMethod << std::endl;
     output << "\tRadiance IBL File Path " << radianceIBLPath.asString() << std::endl;
     output << "\tIrradiance IBL File Path: " << irradianceIBLPath.asString() << std::endl;
-    output << "\tExternal library paths: " << externalLibraryPaths.asString() << std::endl;
-    output << "\tExternal test root paths: " << externalTestPaths.asString() << std::endl;
+    output << "\tExtra library paths: " << extraLibraryPaths.asString() << std::endl;
+    output << "\tRender test paths: " << renderTestPaths.asString() << std::endl;
 }
 
 bool TestSuiteOptions::readOptions(const std::string& optionFile)
@@ -937,8 +937,8 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     const std::string TRANSFORM_UVS_STRING("transformUVs");
     const std::string SPHERE_OBJ("sphere.obj");
     const std::string SHADERBALL_OBJ("shaderball.obj");
-    const std::string EXTERNAL_LIBRARY_PATHS("externalLibraryPaths");
-    const std::string EXTERNAL_TEST_PATHS("externalTestPaths");
+    const std::string EXTRA_LIBRARY_PATHS("extraLibraryPaths");
+    const std::string RENDER_TEST_PATHS("renderTestPaths");
     const std::string WEDGE_FILES("wedgeFiles");
     const std::string WEDGE_PARAMETERS("wedgeParameters");
     const std::string WEDGE_RANGE_MIN("wedgeRangeMin");
@@ -1059,20 +1059,20 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     {
                         transformUVs = val->asA<mx::Matrix44>();
                     }
-                    else if (name == EXTERNAL_LIBRARY_PATHS)
+                    else if (name == EXTRA_LIBRARY_PATHS)
                     {
                         mx::StringVec list = mx::splitString(p->getValueString(), ",");
                         for (const auto& l : list)
                         {
-                            externalLibraryPaths.append(mx::FilePath(l));
+                            extraLibraryPaths.append(mx::FilePath(l));
                         }
                     }
-                    else if (name == EXTERNAL_TEST_PATHS)
+                    else if (name == RENDER_TEST_PATHS)
                     {
                         mx::StringVec list = mx::splitString(p->getValueString(), ",");
                         for (const auto& l : list)
                         {
-                            externalTestPaths.append(mx::FilePath(l));
+                            renderTestPaths.append(mx::FilePath(l));
                         }
                     }
                     else if (name == WEDGE_FILES)

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -134,11 +134,11 @@ class TestSuiteOptions
     // Transforms UVs of loaded geometry
     mx::Matrix44 transformUVs;
 
-    // Additional library paths
-    mx::FileSearchPath externalLibraryPaths;
+    // Extra library paths
+    mx::FileSearchPath extraLibraryPaths;
 
-    // Additional testPaths paths
-    mx::FileSearchPath externalTestPaths;
+    // Render test paths
+    mx::FileSearchPath renderTestPaths;
 
     // Wedge parameters
     mx::StringVec wedgeFiles;

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -62,9 +62,9 @@ void ShaderRenderTester::loadDependentLibraries(GenShaderUtil::TestSuiteOptions 
 
     const mx::FilePathVec libraries = { "targets", "adsk", "stdlib", "pbrlib", "bxdf", "lights" };
     mx::loadLibraries(libraries, searchPath, dependLib);
-    for (size_t i = 0; i < options.externalLibraryPaths.size(); i++)
+    for (size_t i = 0; i < options.extraLibraryPaths.size(); i++)
     {
-        const mx::FilePath& libraryPath = options.externalLibraryPaths[i];
+        const mx::FilePath& libraryPath = options.extraLibraryPaths[i];
         for (const mx::FilePath& libraryFile : libraryPath.getFilesInDirectory("mtlx"))
         {
             std::cout << "Extra library path: " << (libraryPath / libraryFile).asString() << std::endl;
@@ -89,7 +89,7 @@ void ShaderRenderTester::addSkipFiles()
     _skipFiles.insert("material_element_to_surface_material.mtlx");
 }
 
-bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx::FilePath optionsFilePath)
+bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
 {
 #ifdef LOG_TO_FILE
     std::ofstream logfile(_shaderGenerator->getTarget() + "_render_log.txt");
@@ -134,24 +134,11 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
     mx::ScopedTimer ioTimer(&profileTimes.ioTime);
     mx::FilePathVec dirs;
-    if (options.externalTestPaths.size() == 0)
+    for (const auto& root : options.renderTestPaths)
     {
-        for (const auto& testRoot : testRootPaths)
-        {
-            mx::FilePathVec testRootDirs = testRoot.getSubDirectories();
-            dirs.insert(std::end(dirs), std::begin(testRootDirs), std::end(testRootDirs));
-        }
+        mx::FilePathVec testRootDirs = root.getSubDirectories();
+        dirs.insert(std::end(dirs), std::begin(testRootDirs), std::end(testRootDirs));
     }
-    else
-    {
-        // Use test roots from options file
-        for (size_t i = 0; i < options.externalTestPaths.size(); i++)
-        {
-            std::cout << "Test root: " << options.externalTestPaths[i].asString() << std::endl;
-            dirs.push_back(options.externalTestPaths[i]);
-        }
-    }
-
     ioTimer.endTimer();
 
     // Add files to skip
@@ -266,7 +253,6 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
             ioTimer.endTimer();
 
             validateTimer.startTimer();
-            std::cout << "- Validating rendering for: " << filename.asString() << std::endl;
             log << "MTLX Filename: " << filename.asString() << std::endl;
 
             // Validate the test document

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -92,7 +92,7 @@ class ShaderRenderTester
     ShaderRenderTester(mx::ShaderGeneratorPtr shaderGenerator);
     virtual ~ShaderRenderTester();
 
-    bool validate(const mx::FilePathVec& testRootPaths, const mx::FilePath optionsFilePath);
+    bool validate(const mx::FilePath optionsFilePath);
 
     void setEmitColorTransforms(bool val)
     {

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -405,6 +405,8 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
                                           const std::string& outputPath,
                                           mx::ImageVec* imageVec)
 {
+    std::cout << "Validating GLSL rendering for: " << doc->getSourceUri() << std::endl;
+
     mx::ScopedTimer totalGLSLTime(&profileTimes.languageTimes.totalTime);
 
     const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
@@ -722,15 +724,7 @@ TEST_CASE("Render: GLSL TestSuite", "[renderglsl]")
 {
     GlslShaderRenderTester renderTester(mx::GlslShaderGenerator::create());
 
-    const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    const mx::FilePath testRootPath3 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/UsdPreviewSurface");
-    mx::FilePathVec testRootPaths;
-    testRootPaths.push_back(testRootPath);
-    testRootPaths.push_back(testRootPath2);
-    testRootPaths.push_back(testRootPath3);
+    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
 
-    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
-
-    renderTester.validate(testRootPaths, optionsFilePath);
+    renderTester.validate(optionsFilePath);
 }

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -170,12 +170,12 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     context.getOptions().fileTextureVerticalFlip = true;
     context.getOptions().addUpstreamDependencies = false;
 
-    bool runCompileTest = !std::string(MATERIALX_TESTOSLC_EXECUTABLE).empty();
+    bool runCompileTest = !std::string(MATERIALX_OSL_BINARY_OSLC).empty();
     mx::OslRendererPtr oslRenderer = nullptr;
     if (runCompileTest)
     {
         oslRenderer = mx::OslRenderer::create();
-        oslRenderer->setOslCompilerExecutable(MATERIALX_TESTOSLC_EXECUTABLE);
+        oslRenderer->setOslCompilerExecutable(MATERIALX_OSL_BINARY_OSLC);
         oslRenderer->setOslIncludePath(MATERIALX_OSL_INCLUDE_PATH);
     }
 

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -69,9 +69,9 @@ void OslShaderRenderTester::createRenderer(std::ostream& log)
     // Set up additional utilities required to run OSL testing including
     // oslc and testrender paths and OSL include path
     //
-    const std::string oslcExecutable(MATERIALX_TESTOSLC_EXECUTABLE);
+    const std::string oslcExecutable(MATERIALX_OSL_BINARY_OSLC);
     _renderer->setOslCompilerExecutable(oslcExecutable);
-    const std::string testRenderExecutable(MATERIALX_TESTRENDER_EXECUTABLE);
+    const std::string testRenderExecutable(MATERIALX_OSL_BINARY_TESTRENDER);
     _renderer->setOslTestRenderExecutable(testRenderExecutable);
     _renderer->setOslIncludePath(mx::FilePath(MATERIALX_OSL_INCLUDE_PATH));
 
@@ -123,10 +123,12 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
                                          std::ostream& log,
                                          const GenShaderUtil::TestSuiteOptions& testOptions,
                                          RenderUtil::RenderProfileTimes& profileTimes,
-                                         const mx::FileSearchPath& imageSearchPath,
+                                         const mx::FileSearchPath&,
                                          const std::string& outputPath,
                                          mx::ImageVec* imageVec)
 {
+    std::cout << "Validating OSL rendering for: " << doc->getSourceUri() << std::endl;
+
     mx::ScopedTimer totalOSLTime(&profileTimes.languageTimes.totalTime);
 
     const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
@@ -174,6 +176,14 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
                 return false;
             }
             CHECK(shader->getSourceCode().length() > 0);
+
+            // Convert relative paths to absolute, using hardcoded logic for now.
+            mx::StringMap resourceStringMap =
+            {
+                {"\"../../../Images", "\"resources/Images"},
+                {"\"textures/", "\"resources/Materials/TestSuite/libraries/metal/textures"}
+            };
+            shader->setSourceCode(mx::replaceSubstrings(shader->getSourceCode(), resourceStringMap));
 
             std::string shaderPath;
             mx::FilePath outputFilePath = outputPath;
@@ -226,48 +236,13 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
                     const mx::ShaderStage& stage = shader->getStage(mx::Stage::PIXEL);
 
-                    // Look for textures and build parameter override string for each image
-                    // files if a relative path maps to an absolute path
-                    const mx::VariableBlock& uniforms = stage.getUniformBlock(mx::OSL::UNIFORMS);
-
-                    mx::StringVec overrides;
-                    mx::StringVec envOverrides;
-                    mx::StringMap separatorMapper;
-                    separatorMapper["\\\\"] = "/";
-                    separatorMapper["\\"] = "/";
-                    for (size_t i = 0; i<uniforms.size(); ++i)
-                    {
-                        const mx::ShaderPort* uniform = uniforms[i];
-
-                        // Bind input images
-                        if (uniform->getType() != MaterialX::Type::FILENAME)
-                        {
-                            continue;
-                        }
-                        if (uniform->getValue())
-                        {
-                            const std::string& uniformName = uniform->getName();
-                            mx::FilePath filename;
-                            mx::FilePath origFilename(uniform->getValue()->getValueString());
-                            if (!origFilename.isAbsolute())
-                            {
-                                filename = imageSearchPath.find(origFilename);
-                                if (filename != origFilename)
-                                {
-                                    std::string overrideString("string " + uniformName + " \"" + filename.asString() + "\";\n");
-                                    overrideString = mx::replaceSubstrings(overrideString, separatorMapper);
-                                    overrides.push_back(overrideString);
-                                }
-                            }
-                        }
-                    }
                     // Bind IBL image name overrides.
+                    mx::StringVec envOverrides;
                     std::string envmap_filename("string envmap_filename \"");
                     envmap_filename += testOptions.radianceIBLPath;
                     envmap_filename += "\";\n";                    
                     envOverrides.push_back(envmap_filename);
 
-                    _renderer->setShaderParameterOverrides(overrides);
                     _renderer->setEnvShaderParameterOverrides(envOverrides);
 
                     const mx::VariableBlock& outputs = stage.getOutputBlock(mx::OSL::OUTPUTS);
@@ -337,8 +312,8 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
 TEST_CASE("Render: OSL TestSuite", "[renderosl]")
 {
-    if (std::string(MATERIALX_TESTOSLC_EXECUTABLE).empty() &&
-        std::string(MATERIALX_TESTRENDER_EXECUTABLE).empty())
+    if (std::string(MATERIALX_OSL_BINARY_OSLC).empty() &&
+        std::string(MATERIALX_OSL_BINARY_TESTRENDER).empty())
     {
         INFO("Skipping the OSL test suite as its executable locations haven't been set.");
         return;
@@ -346,15 +321,7 @@ TEST_CASE("Render: OSL TestSuite", "[renderosl]")
 
     OslShaderRenderTester renderTester(mx::OslShaderGenerator::create());
 
-    const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    const mx::FilePath testRootPath3 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/UsdPreviewSurface");
-    mx::FilePathVec testRootPaths;
-    testRootPaths.push_back(testRootPath);
-    testRootPaths.push_back(testRootPath2);
-    testRootPaths.push_back(testRootPath3);
+    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
 
-    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
-
-    renderTester.validate(testRootPaths, optionsFilePath);
+    renderTester.validate(optionsFilePath);
 }


### PR DESCRIPTION
- Clarify the names of OSL test options, giving them a consistent MATERIALX_OSL prefix.
- Move the list of render test paths from code to data, adding a "renderTestPaths" option to options.mtlx.
- Manually convert relative paths in OSL render tests, working around an issue in testrender on Windows.
- Add support for launching MaterialXTest directly from Visual Studio.
- Fix typos in the transparency regression check for MaterialXGenShader.