### PR TITLE
Improvements to render test parity

### DIFF
--- a/resources/Materials/TestSuite/Utilities/closure_color_scene.xml
+++ b/resources/Materials/TestSuite/Utilities/closure_color_scene.xml
@@ -1,5 +1,6 @@
+<!-- Template for a lit scene in testrender -->
 <World>
-  <Camera eye="0, 0, 4"  dir="0,0,-1"  fov="70" />
+   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.3" />
 
    <!-- Background environment map. -->
    <ShaderGroup>
@@ -15,7 +16,7 @@
       color Cin %background_color%;
       shader constant_color layer1;
    </ShaderGroup>
-   <Quad corner="-400,-400,-800" edge_x="800,0,0" edge_y="0,800,0" />
+   <Quad corner="-400, -400, -800" edge_x="800, 0, 0" edge_y="0, 800, 0" />
 
    <!-- Shader graph for routing to output layer:
    input_shader_parameter_overrides : are parameter overrides for the input shader
@@ -30,5 +31,6 @@
       shader %output_shader_type% outputShader;
       connect inputShader.%input_shader_output% outputShader.%output_shader_input%;
    </ShaderGroup>
-   <Sphere center="0,0,0" radius="1.0" />
+
+   <Sphere center="0, 0, 0" radius="1" />
 </World>

--- a/resources/Materials/TestSuite/Utilities/constant_color_scene.xml
+++ b/resources/Materials/TestSuite/Utilities/constant_color_scene.xml
@@ -1,6 +1,6 @@
-<!-- Template for taking an input color shader and rendering without lighting -->
+<!-- Template for an unlit scene in testrender -->
 <World>
-   <Camera eye="0, 0, 4"  dir="0,0,-1"  fov="70" />
+   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.3" />
 
    <!-- Background clear
    %background_color% : is the background color
@@ -25,6 +25,6 @@
       shader %output_shader_type% outputShader;
       connect inputShader.%input_shader_output% outputShader.%output_shader_input%;
    </ShaderGroup>
-   <Sphere center="0,0,0" radius="1.0" />
 
+   <Sphere center="0, 0, 0" radius="1" />
 </World>

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -62,7 +62,7 @@
     <input name="shadedGeometry" type="string" value="sphere.obj" />
 
     <!-- Amount to scale geometry. -->
-    <input name="geometryScale" type="float" value="40.0" />
+    <input name="geometryScale" type="float" value="1.0" />
 
     <!-- Enable direct lighting. Default is true. -->
     <input name="enableDirectLighting" type="boolean" value="false" />

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -34,11 +34,11 @@ GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height, Im
 GlslRenderer::GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
     ShaderRenderer(width, height, baseType),
     _initialized(false),
-    _eye(0.0f, 0.0f, 4.0f),
+    _eye(0.0f, 0.0f, 3.0f),
     _center(0.0f, 0.0f, 0.0f),
     _up(0.0f, 1.0f, 0.0f),
     _objectScale(1.0f),
-    _clearColor(0.4f, 0.4f, 0.4f, 1.0f)
+    _clearColor(0.3f, 0.3f, 0.32f, 1.0f)
 {
     _program = GlslProgram::create();
 
@@ -162,16 +162,7 @@ void GlslRenderer::updateViewInformation()
 
 void GlslRenderer::updateWorldInformation()
 {
-    float aspectRatio = float(_width) / float(_height);
-    float geometryRatio = _height < _width ?  aspectRatio : (1.0f / aspectRatio);
-    Vector3 boxMin = _geometryHandler->getMinimumBounds();
-    Vector3 boxMax = _geometryHandler->getMaximumBounds();
-    Vector3 sphereCenter = (boxMax + boxMin) / 2.0;
-    float sphereRadius = (sphereCenter - boxMin).getMagnitude() * geometryRatio;
-    float meshFit = 2.0f / sphereRadius;
-    Vector3 modelTranslation = sphereCenter * -1.0f;
-    _camera->setWorldMatrix(Matrix44::createTranslation(modelTranslation) *
-                            Matrix44::createScale(Vector3(_objectScale * meshFit)));
+     _camera->setWorldMatrix(Matrix44::createScale(Vector3(_objectScale)));
 }
 
 void GlslRenderer::render()

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -113,7 +113,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     const string INPUT_SHADER_PARAMETER_OVERRIDES("%input_shader_parameter_overrides%");
     const string INPUT_SHADER_OUTPUT_STRING("%input_shader_output%");
     const string BACKGROUND_COLOR_STRING("%background_color%");
-    const string backgroundColor("0.4 0.4 0.4"); // TODO: Make this a user input
+    const string backgroundColor("0.3 0.3 0.32"); // TODO: Make this a user input
 
     StringMap replacementMap;
     replacementMap[OUTPUT_SHADER_TYPE_STRING] = outputShader;
@@ -158,16 +158,17 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     string command(_oslTestRenderExecutable);
     command += " " + sceneFileName;
     command += " " + outputFileName;
-    command += " -r " + std::to_string(_width) + " " + std::to_string(_height) + " --path " + osoPaths;
+    command += " -r " + std::to_string(_width) + " " + std::to_string(_height);
+    command += " --path " + osoPaths;
     if (isColorClosure)
     {
-        command += " -aa 4 "; // Images are very noisy without anti-aliasing
+        command += " -aa 6"; // Increase rays per pixel for lit surfaces
     }
     command += " > " + errorFile + redirectString;
 
     // Repeat the render command to allow for sporadic errors.
     int returnValue = 0;
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 5; i++)
     {
         returnValue = std::system(command.c_str());
         if (!returnValue)

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -97,7 +97,7 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
     std::string docValidLogFilename = _shaderGenerator->getTarget() + "_render_doc_validation_log.txt";
     std::ofstream docValidLogFile(docValidLogFilename);
     std::ostream& docValidLog(docValidLogFile);
-    std::ofstream profilingLogfile(_shaderGenerator->getTarget() + "__render_profiling_log.txt");
+    std::ofstream profilingLogfile(_shaderGenerator->getTarget() + "_render_profiling_log.txt");
     std::ostream& profilingLog(profilingLogfile);
 #else
     std::ostream& log(std::cout);

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -101,6 +101,7 @@ void GlslShaderRenderTester::registerLights(mx::DocumentPtr document,
     REQUIRE(envIrradiance);
     _lightHandler->setEnvRadianceMap(envRadiance);
     _lightHandler->setEnvIrradianceMap(envIrradiance);
+    _lightHandler->setEnvSamples(256);
 }
 
 //

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -167,6 +167,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     mx::ShaderGeneratorPtr generator = mx::OslShaderGenerator::create();
     mx::GenContext context(generator);
     context.registerSourceCodeSearchPath(librariesPath);
+    context.registerSourceCodeSearchPath(librariesPath / mx::FilePath("stdlib/genosl/include"));
     context.getOptions().fileTextureVerticalFlip = true;
     context.getOptions().addUpstreamDependencies = false;
 
@@ -237,7 +238,16 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
                 }
             }
         }
-        catch (mx::Exception & e)
+        catch (mx::ExceptionRenderError& e)
+        {
+            logFile << "Error compiling OSL reference for '" << nodeName << "' : " << std::endl;
+            logFile << e.what() << std::endl;
+            for (const std::string& error : e.errorLog())
+            {
+                logFile << error << std::endl;
+            }
+        }
+        catch (mx::Exception& e)
         {
             logFile << "Error generating OSL reference for '" << nodeName << "' : " << std::endl;
             logFile << e.what() << std::endl;


### PR DESCRIPTION
This changelist implements a number of improvements to the parity of render tests between GLSL and OSL, including the following:

- Render with a unit sphere in both GLSL and OSL, adjusting the zoom in OSL to compensate for framing differences.
- Increase the environment map sample count in GLSL.
- Increase the rays per pixel for lit surfaces in OSL.
- Increase the tolerance for error messages in testrender.