### PR TITLE
Fix up html generator for rendering tests

### DIFF
--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -69,18 +69,18 @@ def main(args=None):
             if curFile.endswith(args.sourcelang + ".png"):
                 sourceFiles.append(curFile)
                 sourceCount += 1
-            else:
-                sourceFiles.append("")
-            if curFile.endswith(args.destlang + ".png"):
-                destFiles.append(curFile)
-                destCount += 1
-            else:
-                destFiles.append("")
+                # Allow for just one language to be shown if source and dest are the same.
+                # Otherwise add in equivalent name with dest language replacement 
+                if args.sourcelang != args.destlang:
+                    destFile = curFile.replace(args.sourcelang, args.destlang)
+                    destFiles.append(destFile)
+                else:
+                    destFiles.append("")
 
-        if sourceCount > 0 or destCount > 0:
+        if sourceFiles:
             fh.write("<p>" + subdir + ":</p>\n")
             fh.write("<table>\n")
-            for sourceFile, destFile in zip_longest(sourceFiles, destFiles):
+            for sourceFile, destFile in zip(sourceFiles, destFiles):
                 fullsourcePath = os.path.join(subdir, sourceFile) if sourceFile else None
                 fulldestPath = os.path.join(subdir, destFile) if destFile else None
                 if sourceFile and destFile and DIFF_ENABLED and args.CREATE_DIFF:


### PR DESCRIPTION
Fix:
- Adding to source destination lists incorrectly, producing source on one row and destination on another.
- Cleaned up to use source to determine destination file name by replacing language to avoid name mismatches per row. If exists as source file, then append destination file. e.g. if `foo.glsl.png` found then  `foo.osl.png` is added. The second file is not checked until generation time.
- Fix to allow only one language to be shown (again) if both destination and source languages are the same.
- 