### PR TITLE
Add V-flip option for geometry loaders

### DIFF
--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -79,7 +79,7 @@ void GeometryHandler::computeBounds()
     }
 }
 
-bool GeometryHandler::loadGeometry(const FilePath& filePath, bool uvVerticalFlip )
+bool GeometryHandler::loadGeometry(const FilePath& filePath, bool texcoordVerticalFlip)
 {
     // Early return if already loaded
     if (hasGeometry(filePath))
@@ -96,7 +96,7 @@ bool GeometryHandler::loadGeometry(const FilePath& filePath, bool uvVerticalFlip
     GeometryLoaderMap::iterator last = --range.first;
     for (auto it = first; it != last; --it)
     {
-        loaded = it->second->load(filePath, _meshes, uvVerticalFlip);
+        loaded = it->second->load(filePath, _meshes, texcoordVerticalFlip);
         if (loaded)
         {
             break;

--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -79,7 +79,7 @@ void GeometryHandler::computeBounds()
     }
 }
 
-bool GeometryHandler::loadGeometry(const FilePath& filePath)
+bool GeometryHandler::loadGeometry(const FilePath& filePath, bool uvVerticalFlip )
 {
     // Early return if already loaded
     if (hasGeometry(filePath))
@@ -96,7 +96,7 @@ bool GeometryHandler::loadGeometry(const FilePath& filePath)
     GeometryLoaderMap::iterator last = --range.first;
     for (auto it = first; it != last; --it)
     {
-        loaded = it->second->load(filePath, _meshes);
+        loaded = it->second->load(filePath, _meshes, uvVerticalFlip);
         if (loaded)
         {
             break;

--- a/source/MaterialXRender/GeometryHandler.h
+++ b/source/MaterialXRender/GeometryHandler.h
@@ -42,9 +42,9 @@ class MX_RENDER_API GeometryLoader
     /// Load geometry from disk. Must be implemented by derived classes.
     /// @param filePath Path to file to load
     /// @param meshList List of meshes to update
-    /// @param uvVerticalFlip Flip texture coordinates in V when loading
+    /// @param texcoordVerticalFlip Flip texture coordinates in V when loading
     /// @return True if load was successful
-    virtual bool load(const FilePath& filePath, MeshList& meshList, bool uvVerticalFlip = false) = 0;
+    virtual bool load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip = false) = 0;
 
   protected:
     // List of supported string extensions
@@ -92,8 +92,8 @@ class MX_RENDER_API GeometryHandler
 
     /// Load geometry from a given location
     /// @param filePath Path to geometry
-    /// @param uvVerticalFlip Flip texture coordinates in V. Default is to not flip.
-    bool loadGeometry(const FilePath& filePath, bool uvVerticalFlip = false);
+    /// @param texcoordVerticalFlip Flip texture coordinates in V. Default is to not flip.
+    bool loadGeometry(const FilePath& filePath, bool texcoordVerticalFlip = false);
 
     /// Get list of meshes
     const MeshList& getMeshes() const

--- a/source/MaterialXRender/GeometryHandler.h
+++ b/source/MaterialXRender/GeometryHandler.h
@@ -42,8 +42,9 @@ class MX_RENDER_API GeometryLoader
     /// Load geometry from disk. Must be implemented by derived classes.
     /// @param filePath Path to file to load
     /// @param meshList List of meshes to update
+    /// @param uvVerticalFlip Flip texture coordinates in V when loading
     /// @return True if load was successful
-    virtual bool load(const FilePath& filePath, MeshList& meshList) = 0;
+    virtual bool load(const FilePath& filePath, MeshList& meshList, bool uvVerticalFlip = false) = 0;
 
   protected:
     // List of supported string extensions
@@ -90,7 +91,9 @@ class MX_RENDER_API GeometryHandler
     void getGeometry(MeshList& meshes, const string& location);
 
     /// Load geometry from a given location
-    bool loadGeometry(const FilePath& filePath);
+    /// @param filePath Path to geometry
+    /// @param uvVerticalFlip Flip texture coordinates in V. Default is to not flip.
+    bool loadGeometry(const FilePath& filePath, bool uvVerticalFlip = false);
 
     /// Get list of meshes
     const MeshList& getMeshes() const

--- a/source/MaterialXRender/TinyObjLoader.cpp
+++ b/source/MaterialXRender/TinyObjLoader.cpp
@@ -46,7 +46,7 @@ using VertexIndexMap = std::unordered_map<VertexVector, uint32_t, VertexVector::
 // TinyObjLoader methods
 //
 
-bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
+bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList, bool uvVerticalFlip)
 {
     tinyobj::attrib_t attrib;
     vector<tinyobj::shape_t> shapes;
@@ -114,6 +114,10 @@ bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
                 if (indexObj.texcoord_index >= 0 && k < MeshStream::STRIDE_2D)
                 {
                     texcoord[k] = attrib.texcoords[indexObj.texcoord_index * MeshStream::STRIDE_2D + k];
+                }
+                if (uvVerticalFlip && k == 1)
+                {
+                    texcoord[k] = 1.0f - texcoord[k];
                 }
             }
 

--- a/source/MaterialXRender/TinyObjLoader.cpp
+++ b/source/MaterialXRender/TinyObjLoader.cpp
@@ -46,7 +46,7 @@ using VertexIndexMap = std::unordered_map<VertexVector, uint32_t, VertexVector::
 // TinyObjLoader methods
 //
 
-bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList, bool uvVerticalFlip)
+bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip)
 {
     tinyobj::attrib_t attrib;
     vector<tinyobj::shape_t> shapes;
@@ -115,7 +115,7 @@ bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList, bool uvVe
                 {
                     texcoord[k] = attrib.texcoords[indexObj.texcoord_index * MeshStream::STRIDE_2D + k];
                 }
-                if (uvVerticalFlip && k == 1)
+                if (texcoordVerticalFlip && k == 1)
                 {
                     texcoord[k] = 1.0f - texcoord[k];
                 }

--- a/source/MaterialXRender/TinyObjLoader.h
+++ b/source/MaterialXRender/TinyObjLoader.h
@@ -31,7 +31,7 @@ class MX_RENDER_API TinyObjLoader : public GeometryLoader
     static TinyObjLoaderPtr create() { return std::make_shared<TinyObjLoader>(); }
 
     /// Load geometry from disk
-    bool load(const FilePath& filePath, MeshList& meshList) override;
+    bool load(const FilePath& filePath, MeshList& meshList, bool uvVerticalFlip = false) override;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXRender/TinyObjLoader.h
+++ b/source/MaterialXRender/TinyObjLoader.h
@@ -31,7 +31,7 @@ class MX_RENDER_API TinyObjLoader : public GeometryLoader
     static TinyObjLoaderPtr create() { return std::make_shared<TinyObjLoader>(); }
 
     /// Load geometry from disk
-    bool load(const FilePath& filePath, MeshList& meshList, bool uvVerticalFlip = false) override;
+    bool load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip = false) override;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -499,9 +499,9 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
                 {
                     // For test sphere and plane geometry perform a V-flip of texture coordinates.
                     const std::string baseName = geomPath.getBaseName();
-                    bool uvVerticalFlip = baseName == "sphere.obj" || baseName == "plane.obj";
+                    bool texcoordVerticalFlip = baseName == "sphere.obj" || baseName == "plane.obj";
                     geomHandler->clearGeometry();
-                    geomHandler->loadGeometry(geomPath, uvVerticalFlip);
+                    geomHandler->loadGeometry(geomPath, texcoordVerticalFlip);
                     for (mx::MeshPtr mesh : geomHandler->getMeshes())
                     {
                         addAdditionalTestStreams(mesh);

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -476,37 +476,37 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
             bool validated = false;
             try
             {
-				// Set geometry
+                // Set geometry
                 mx::GeometryHandlerPtr geomHandler = _renderer->getGeometryHandler();
-				mx::FilePath geomPath;
-				if (!testOptions.shadedGeometry.isEmpty())
-				{
-					if (!testOptions.shadedGeometry.isAbsolute())
-					{
-						geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Geometry") / testOptions.shadedGeometry;
-					}
-					else
-					{
-						geomPath = testOptions.shadedGeometry;
-					}
-				}
-				else
-				{
-					geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Geometry/sphere.obj");
-				}
+                mx::FilePath geomPath;
+                if (!testOptions.shadedGeometry.isEmpty())
+                {
+                    if (!testOptions.shadedGeometry.isAbsolute())
+                    {
+                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Geometry") / testOptions.shadedGeometry;
+                    }
+                    else
+                    {
+                        geomPath = testOptions.shadedGeometry;
+                    }
+                }
+                else
+                {
+                    geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Geometry/sphere.obj");
+                }
 
                 if (!geomHandler->hasGeometry(geomPath))
-				{
+                {
                     // For test sphere and plane geometry perform a V-flip of texture coordinates.
                     const std::string baseName = geomPath.getBaseName();
                     bool uvVerticalFlip = baseName == "sphere.obj" || baseName == "plane.obj";
-					geomHandler->clearGeometry();
-					geomHandler->loadGeometry(geomPath,uvVerticalFlip);
-					for (mx::MeshPtr mesh : geomHandler->getMeshes())
-					{
-						addAdditionalTestStreams(mesh);
-					}
-				}
+                    geomHandler->clearGeometry();
+                    geomHandler->loadGeometry(geomPath, uvVerticalFlip);
+                    for (mx::MeshPtr mesh : geomHandler->getMeshes())
+                    {
+                        addAdditionalTestStreams(mesh);
+                    }
+                }
 
                 bool isShader = mx::elementRequiresShading(element);
                 _renderer->setLightHandler(isShader ? _lightHandler : nullptr);

--- a/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
@@ -18,7 +18,7 @@ class PyGeometryLoader : public mx::GeometryLoader
     {
     }
 
-    bool load(const mx::FilePath& filePath, mx::MeshList& meshList, bool uvVerticalFlip = false) override
+    bool load(const mx::FilePath& filePath, mx::MeshList& meshList, bool texcoordVerticalFlip = false) override
     {
         PYBIND11_OVERLOAD_PURE(
             bool,
@@ -26,7 +26,7 @@ class PyGeometryLoader : public mx::GeometryLoader
             load,
             filePath,
             meshList,
-            uvVerticalFlip
+            texcoordVerticalFlip
         );
     }
 };

--- a/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
@@ -18,14 +18,15 @@ class PyGeometryLoader : public mx::GeometryLoader
     {
     }
 
-    bool load(const mx::FilePath& filePath, mx::MeshList& meshList) override
+    bool load(const mx::FilePath& filePath, mx::MeshList& meshList, bool uvVerticalFlip = false) override
     {
         PYBIND11_OVERLOAD_PURE(
             bool,
             mx::GeometryLoader,
             load,
             filePath,
-            meshList
+            meshList,
+            uvVerticalFlip
         );
     }
 };


### PR DESCRIPTION
### Add V-flip option for geometry loaders
- Allows for customization on load allowing for tangent space to be computed on load
- Used for GLSL render unit testing when the specified geometry is the "stock" sphere or plane.
- Turn off texture flip as a consequence of flipping texture coordinates.
- Also simplified testing logic to either use the geometry file if specified or default to the stock sphere otherwise.
