### PR TITLE
Default to analytic albedo in MaterialXView

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -94,7 +94,7 @@ vec3 mx_ggx_dir_albedo_analytic(float NdotV, float roughness, vec3 F0, vec3 F90)
              vec4(-26.51510, 1.43366, -36.16186, 54.86775) * x2 * y +
              vec4(19.98406, 0.29060, 15.85408, 300.10923) * x * y2 +
              vec4(-5.41717, 0.62933, 33.41550, -284.73288) * x2 * y2;
-    vec2 AB = r.xy / r.zw;
+    vec2 AB = clamp(r.xy / r.zw, 0.0, 1.0);
     return F0 * AB.x + F90 * AB.y;
 }
 

--- a/libraries/pbrlib/genglsl/lib/mx_table.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_table.glsl
@@ -4,7 +4,7 @@
 vec3 mx_generate_dir_albedo_table()
 {
     vec2 uv = gl_FragCoord.xy / $albedoTableSize;
-    vec2 ggxDirAlbedo = mx_ggx_dir_albedo_monte_carlo(uv.x, uv.y, vec3(1, 0, 0), vec3(0, 1, 0)).xy;
-    float sheenDirAlbedo = mx_imageworks_sheen_dir_albedo_monte_carlo(uv.x, uv.y);
+    vec2 ggxDirAlbedo = mx_ggx_dir_albedo(uv.x, uv.y, vec3(1, 0, 0), vec3(0, 1, 0)).xy;
+    float sheenDirAlbedo = mx_imageworks_sheen_dir_albedo(uv.x, uv.y);
     return vec3(ggxDirAlbedo, sheenDirAlbedo);
 }

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
@@ -40,6 +40,8 @@ color mx_ggx_dir_albedo(float NdotV, float roughness, color F0, color F90)
                 vector4(19.98406, 0.29060, 15.85408, 300.10923) * x * y2 +
                 vector4(-5.41717, 0.62933, 33.41550, -284.73288) * x2 * y2;
     vector2 AB = vector2(r.x, r.y) / vector2(r.z, r.w);
+    AB.x = clamp(AB.x, 0.0, 1.0);
+    AB.y = clamp(AB.y, 0.0, 1.0);
     return F0 * AB.x + F90 * AB.y;
 }
 

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -67,6 +67,7 @@ ShaderPtr createAlbedoTableShader(GenContext& context,
     // Generate the shader
     GenContext tableContext = context;
     tableContext.getOptions().hwWriteAlbedoTable = true;
+    tableContext.getOptions().hwDirectionalAlbedoMethod = DIRECTIONAL_ALBEDO_MONTE_CARLO;
     ShaderPtr shader = createShader(shaderName, tableContext, output);
 
     return shader;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -272,17 +272,14 @@ Viewer::Viewer(const std::string& materialFilename,
     set_background(ng::Color(screenColor[0], screenColor[1], screenColor[2], 1.0f));
 
     // Set default Glsl generator options.
-    _genContext.getOptions().hwDirectionalAlbedoMethod = mx::DIRECTIONAL_ALBEDO_TABLE;
-    _genContext.getOptions().hwShadowMap = true;
     _genContext.getOptions().targetColorSpaceOverride = "lin_rec709";
     _genContext.getOptions().fileTextureVerticalFlip = true;
+    _genContext.getOptions().hwShadowMap = true;
 
     // Set Essl generator options
     _genContextEssl.getOptions().targetColorSpaceOverride = "lin_rec709";
     _genContextEssl.getOptions().fileTextureVerticalFlip = false;
     _genContextEssl.getOptions().hwMaxActiveLightSources = 1;
-    _genContextEssl.getOptions().hwSpecularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
-    _genContextEssl.getOptions().hwDirectionalAlbedoMethod = mx::DIRECTIONAL_ALBEDO_ANALYTIC;
 
 #if MATERIALX_BUILD_GEN_OSL
     // Set OSL generator options.
@@ -909,6 +906,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
     {
         _genContext.getOptions().hwDirectionalAlbedoMethod = (mx::HwDirectionalAlbedoMethod) index;
         reloadShaders();
+        updateAlbedoTable();
     });
 
     Widget* sampleGroup = new Widget(advancedPopup);
@@ -1822,9 +1820,6 @@ void Viewer::renderFrame()
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     glDisable(GL_CULL_FACE);
     glDisable(GL_FRAMEBUFFER_SRGB);
-
-    // Update shading tables
-    updateAlbedoTable();
 
     // Update lighting state.
     _lightHandler->setLightTransform(mx::Matrix44::createRotationY(_lightRotation / 180.0f * PI));


### PR DESCRIPTION
- Default to using analytic directional albedo in MaterialXView, only generating a directional albedo table when requested by the user.
- Clamp the AB term in analytic directional albedo, providing a small improvement in accuracy (reduces average error from 0.0012 to 0.0011, and improves behavior at parameter boundaries).