### PR TITLE
Clarify usage of alpha and roughness

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -10,7 +10,7 @@ float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamp
     return max(effectiveMaxMipLevel - 0.5 * log2(float(envSamples) * pdf * distortion), 0.0);
 }
 
-vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution, FresnelData fd)
+vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
 {
     // Generate tangent frame.
     vec3 Y = normalize(cross(N, X));
@@ -22,7 +22,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distrib
 
     // Compute derived properties.
     float NdotV = clamp(V.z, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(roughness);
+    float avgAlpha = mx_average_alpha(alpha);
     
     // Integrate outgoing radiance using filtered importance sampling.
     // http://cgg.mff.cuni.cz/~jaroslav/papers/2008-egsr-fis/2008-egsr-fis-final-embedded.pdf
@@ -33,7 +33,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distrib
         vec2 Xi = mx_spherical_fibonacci(i, envRadianceSamples);
 
         // Compute the half vector and incoming light direction.
-        vec3 H = mx_ggx_importance_sample_NDF(Xi, roughness);
+        vec3 H = mx_ggx_importance_sample_NDF(Xi, alpha);
         vec3 L = -reflect(V, H);
         
         // Compute dot products for this sample.
@@ -44,7 +44,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distrib
 
         // Sample the environment light from the given direction.
         vec3 Lw = tangentToWorld * L;
-        float pdf = mx_ggx_PDF(H, LdotH, roughness);
+        float pdf = mx_ggx_PDF(H, LdotH, alpha);
         float lod = mx_latlong_compute_lod(Lw, pdf, float($envRadianceMips - 1), envRadianceSamples);
         vec3 sampleColor = mx_latlong_map_lookup(Lw, $envMatrix, lod, $envRadiance);
 
@@ -52,7 +52,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distrib
         vec3 F = mx_compute_fresnel(VdotH, fd);
 
         // Compute the geometric term.
-        float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
+        float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
         // Add the radiance contribution of this sample.
         // From https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -1,24 +1,24 @@
 #include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
-float mx_latlong_compute_lod(float roughness)
+float mx_latlong_compute_lod(float alpha)
 {
-    // Select a mip level based on input roughness.
-    float lodBias = roughness < 0.25 ? sqrt(roughness) : 0.5*roughness + 0.375;
+    // Select a mip level based on input alpha.
+    float lodBias = alpha < 0.25 ? sqrt(alpha) : 0.5*alpha + 0.375;
     return lodBias * float($envRadianceMips);
 }
 
-vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution, FresnelData fd)
+vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
 {
     N = mx_forward_facing_normal(N, V);
     vec3 L = reflect(-V, N);
 
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    float avgRoughness = mx_average_roughness(roughness);
+    float avgAlpha = mx_average_alpha(alpha);
     vec3 F = mx_compute_fresnel(NdotV, fd);
-    float G = mx_ggx_smith_G2(NdotV, NdotV, avgRoughness);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_compute_lod(avgRoughness), $envRadiance);
+    float G = mx_ggx_smith_G2(NdotV, NdotV, avgAlpha);
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+    vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_compute_lod(avgAlpha), $envRadiance);
 
     return Li * F * G * comp;
 }

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
@@ -46,12 +46,6 @@ vec3 mx_fresnel_schlick(float cosTheta, vec3 F0, vec3 F90, float exponent)
     return mix(F0, F90, pow(x, exponent));
 }
 
-// Compute the average of an anisotropic roughness pair
-float mx_average_roughness(vec2 roughness)
-{
-    return sqrt(roughness.x * roughness.y);
-}
-
 // Enforce that the given normal is forward-facing from the specified view direction.
 vec3 mx_forward_facing_normal(vec3 N, vec3 V)
 {

--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -18,8 +18,8 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd;
@@ -29,10 +29,10 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
         fd = mx_init_fresnel_conductor(ior_n, ior_k);
 
     vec3 F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(Ht, safeRoughness);
-    float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
+    float D = mx_ggx_NDF(Ht, safeAlpha);
+    float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
 
     // Note: NdotL is cancelled out
     bsdf.response = D * F * G * comp * occlusion * weight / (4.0 * NdotV);
@@ -59,11 +59,11 @@ void mx_conductor_bsdf_indirect(vec3 V, float weight, vec3 ior_n, vec3 ior_k, ve
 
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
 
-    vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);
+    vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
 
     bsdf.response = Li * comp * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -16,8 +16,8 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd;
@@ -30,12 +30,12 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
          fd = mx_init_fresnel_dielectric(ior);
     }
     vec3  F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(Ht, safeRoughness);
-    float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
+    float D = mx_ggx_NDF(Ht, safeAlpha);
+    float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
     float F0 = mx_ior_to_f0(ior);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
     bsdf.throughput = 1.0 - dirAlbedo * weight;
 
     // Note: NdotL is cancelled out
@@ -67,11 +67,11 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
 
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
     float F0 = mx_ior_to_f0(ior);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
     bsdf.throughput = 1.0 - dirAlbedo * weight;
 
     bsdf.response = (scatter_mode == 2) ? tint * weight * bsdf.throughput : vec3(0.0);
@@ -96,13 +96,13 @@ void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
 
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
     float F0 = mx_ior_to_f0(ior);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, F0, 1.0) * comp;
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
     bsdf.throughput = 1.0 - dirAlbedo * weight;
 
-    vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);
+    vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
     bsdf.response = Li * tint * comp * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -16,17 +16,17 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
     float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3  F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(Ht, safeRoughness);
-    float G = mx_ggx_smith_G2(NdotL, NdotV, avgRoughness);
+    float D = mx_ggx_NDF(Ht, safeAlpha);
+    float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 
@@ -54,10 +54,10 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 
@@ -77,13 +77,13 @@ void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec
     FresnelData fd = mx_init_fresnel_schlick(color0, color90, exponent);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
-    vec2 safeRoughness = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgRoughness = mx_average_roughness(safeRoughness);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
+    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 
-    vec3 Li = mx_environment_radiance(N, V, X, safeRoughness, distribution, fd);
+    vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
     bsdf.response = Li * comp * weight;
 }

--- a/libraries/pbrlib/genosl/lib/mx_microfacet.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet.osl
@@ -23,54 +23,6 @@ float mx_pow5(float x)
     return mx_square(mx_square(x)) * x;
 }
 
-float mx_fract(float x)
-{
-    return x - floor(x);
-}
-
-float mx_average_roughness(vector2 roughness)
-{
-    return sqrt(roughness.x * roughness.y);
-}
-
-// https://www.graphics.rwth-aachen.de/publication/2/jgt.pdf
-float mx_golden_ratio_sequence(int i)
-{
-    float GOLDEN_RATIO = 1.6180339887498948;
-    return mx_fract((float(i) + 1.0) * GOLDEN_RATIO);
-}
-
-// https://people.irisa.fr/Ricardo.Marques/articles/2013/SF_CGF.pdf
-vector2 mx_spherical_fibonacci(int i, int numSamples)
-{
-    return vector2((float(i) + 0.5) / float(numSamples), mx_golden_ratio_sequence(i));
-}
-
-// Convert a real-valued index of refraction to normal-incidence reflectivity.
-float mx_ior_to_f0(float ior)
-{
-    return mx_square((ior - 1.0) / (ior + 1.0));
-}
-
-// https://seblagarde.wordpress.com/2013/04/29/memo-on-fresnel-equations/
-float mx_fresnel_dielectric(float cosTheta, float ior)
-{
-    if (cosTheta < 0.0 || ior == 0.0)
-        return 1.0;
-
-    float g =  ior*ior + cosTheta*cosTheta - 1.0;
-    // Check for total internal reflection
-    if (g < 0.0)
-        return 1.0;
-
-    g = sqrt(g);
-    float gmc = g - cosTheta;
-    float gpc = g + cosTheta;
-    float x = gmc / gpc;
-    float y = (gpc * cosTheta - 1.0) / (gmc * cosTheta + 1.0);
-    return 0.5 * x * x * (1.0 + y * y);
-}
-
 color mx_fresnel_conductor(float cosTheta, vector n, vector k)
 {
    float c2 = cosTheta*cosTheta;

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
@@ -1,35 +1,24 @@
 #include "pbrlib/genosl/lib/mx_microfacet.osl"
 
-// https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf
-// Appendix B.2 Equation 15
-vector mx_ggx_importance_sample_NDF(vector2 Xi, vector X, vector Y, vector N, float alphaX, float alphaY)
+// Compute the average of an anisotropic alpha pair.
+float mx_average_alpha(vector2 alpha)
 {
-    float phi = 2.0 * M_PI * Xi.x;
-    float tanTheta = sqrt(Xi.y / (1.0 - Xi.y));
-    vector H = X * (tanTheta * alphaX * cos(phi)) +
-               Y * (tanTheta * alphaY * sin(phi)) +
-               N;
-    return normalize(H);
+    return sqrt(alpha.x * alpha.y);
 }
 
-// Height-correlated Smith masking-shadowing
-// http://jcgt.org/published/0003/02/03/paper.pdf
-// Equations 72 and 99
-float mx_ggx_smith_G2(float NdotL, float NdotV, float alpha)
+// Convert a real-valued index of refraction to normal-incidence reflectivity.
+float mx_ior_to_f0(float ior)
 {
-    float alpha2 = mx_square(alpha);
-    float lambdaL = sqrt(alpha2 + (1.0 - alpha2) * mx_square(NdotL));
-    float lambdaV = sqrt(alpha2 + (1.0 - alpha2) * mx_square(NdotV));
-    return 2.0 / (lambdaL / NdotL + lambdaV / NdotV);
+    return mx_square((ior - 1.0) / (ior + 1.0));
 }
 
 // Rational quadratic fit to Monte Carlo data for GGX directional albedo.
-color mx_ggx_dir_albedo(float NdotV, float roughness, color F0, color F90)
+color mx_ggx_dir_albedo(float NdotV, float alpha, color F0, color F90)
 {
     float x = NdotV;
-    float y = roughness;
-    float x2 = mx_square(NdotV);
-    float y2 = mx_square(roughness);
+    float y = alpha;
+    float x2 = mx_square(x);
+    float y2 = mx_square(y);
     vector4 r = vector4(0.10031, 0.93450, 1.0, 1.0) +
                 vector4(-0.63301, -2.32352, -1.76427, 0.22797) * x +
                 vector4(9.74995, 2.22823, 8.26501, 15.93688) * y +
@@ -45,28 +34,28 @@ color mx_ggx_dir_albedo(float NdotV, float roughness, color F0, color F90)
     return F0 * AB.x + F90 * AB.y;
 }
 
-float mx_ggx_dir_albedo(float NdotV, float roughness, float F0, float F90)
+float mx_ggx_dir_albedo(float NdotV, float alpha, float F0, float F90)
 {
-    color result = mx_ggx_dir_albedo(NdotV, roughness, color(F0), color(F90));
+    color result = mx_ggx_dir_albedo(NdotV, alpha, color(F0), color(F90));
     return result[0];
 }
 
-float mx_ggx_dir_albedo(float NdotV, float roughness, float ior)
+float mx_ggx_dir_albedo(float NdotV, float alpha, float ior)
 {
-    color result = mx_ggx_dir_albedo(NdotV, roughness, color(mx_ior_to_f0(ior)), color(1.0));
+    color result = mx_ggx_dir_albedo(NdotV, alpha, color(mx_ior_to_f0(ior)), color(1.0));
     return result[0];
 }
 
 // https://blog.selfshadow.com/publications/turquin/ms_comp_final.pdf
 // Equations 14 and 16
-color mx_ggx_energy_compensation(float NdotV, float roughness, color Fss)
+color mx_ggx_energy_compensation(float NdotV, float alpha, color Fss)
 {
-    float Ess = mx_ggx_dir_albedo(NdotV, roughness, 1.0, 1.0);
+    float Ess = mx_ggx_dir_albedo(NdotV, alpha, 1.0, 1.0);
     return 1.0 + Fss * (1.0 - Ess) / Ess;
 }
 
-float mx_ggx_energy_compensation(float NdotV, float roughness, float Fss)
+float mx_ggx_energy_compensation(float NdotV, float alpha, float Fss)
 {
-    color result = mx_ggx_energy_compensation(NdotV, roughness, color(Fss));
+    color result = mx_ggx_energy_compensation(NdotV, alpha, color(Fss));
     return result[0];
 }

--- a/libraries/pbrlib/genosl/mx_conductor_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_conductor_bsdf.osl
@@ -23,9 +23,10 @@ void mx_conductor_bsdf(float weight, color ior_n, color ior_k, vector2 roughness
     // This should normally be done inside the closure
     // but since vanilla OSL doesen't support this we
     // add it here in shader code instead.
-    float avgRoughness = mx_average_roughness(roughness);
-    color comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
+    vector2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
+    color comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
 
     // Set ior to 0.0 to disable the internal dielectric fresnel
-    bsdf.response = F * comp * weight * microfacet(distribution, N, U, roughness.x, roughness.y, 0.0, false);
+    bsdf.response = F * comp * weight * microfacet(distribution, N, U, safeAlpha.x, safeAlpha.y, 0.0, false);
 }

--- a/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
@@ -17,20 +17,21 @@ void mx_dielectric_bsdf(float weight, color tint, float ior, vector2 roughness, 
     // This should normally be done inside the closure
     // but since vanilla OSL doesen't support this we
     // add it here in shader code instead.
-    float avgRoughness = mx_average_roughness(roughness);
-    float comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
+    vector2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
+    float comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
 
     if (scatter_mode == "R")
     {
-        bsdf.response = tint * weight * comp * microfacet(distribution, N, U, roughness.x, roughness.y, ior, 0);
+        bsdf.response = tint * weight * comp * microfacet(distribution, N, U, safeAlpha.x, safeAlpha.y, ior, 0);
 
         // Calculate throughput from directional albedo.
-        float dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, ior) * comp;
+        float dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, ior) * comp;
         bsdf.throughput = 1.0 - dirAlbedo * weight;
     }
     else
     {
-        bsdf.response = tint * weight * comp * microfacet(distribution, N, U, roughness.x, roughness.y, ior, 2);
+        bsdf.response = tint * weight * comp * microfacet(distribution, N, U, safeAlpha.x, safeAlpha.y, ior, 2);
         bsdf.throughput = color(1.0);
     }
 }

--- a/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
@@ -14,20 +14,21 @@ void mx_generalized_schlick_bsdf(float weight, color color0, color color90, floa
 
     float NdotV = fabs(dot(N,-I));
     color F = mx_fresnel_schlick(NdotV, color0, color90, exponent);
-    float avgRoughness = mx_average_roughness(roughness);
+    vector2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
 
     // Calculate compensation for multiple scattering.
     // This should normally be done inside the closure
     // but since vanilla OSL doesen't support this we
     // add it here in shader code instead.
-    color comp = mx_ggx_energy_compensation(NdotV, avgRoughness, F);
+    color comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
 
     // Calculate directional albedo since we need
     // to attenuate the base layer according to this.
-    color dirAlbedo = mx_ggx_dir_albedo(NdotV, avgRoughness, color0, color90) * comp;
+    color dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, color(1.0 / 3.0));
     bsdf.throughput = color(1.0 - avgDirAlbedo * weight);
 
     // Set ior to 0.0 to disable the internal dielectric fresnel
-    bsdf.response = F * comp * weight * microfacet(distribution, N, U, roughness.x, roughness.y, 0.0, 0);
+    bsdf.response = F * comp * weight * microfacet(distribution, N, U, safeAlpha.x, safeAlpha.y, 0.0, 0);
 }


### PR DESCRIPTION
This changelist clarifies the usage of the terms alpha and roughness in the PBR libraries for GLSL and OSL, using the term 'alpha' to mean the square of artist-facing roughness in the context of specular BSDFs.

In the future, we should consider modifying the interfaces of specular BSDF nodes such as <dielectric_bsdf> and <conductor_bsdf> to follow this convention as well, since their "roughness" inputs actually represent alpha.

Additional changes:
- Align handling of input alpha between GLSL and OSL.
- Remove unused helper functions in the PBR library for OSL.