### PR TITLE
Add OSL node name metadata 

### DIFF
--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -236,11 +236,18 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     setFunctionName(functionName, stage);
     emitLine(functionName, stage, false);
 
-    // Add any metadata if set on the graph.
     const ShaderMetadataVecPtr& metadata = graph.getMetadata();
-    if (metadata && metadata->size())
+    bool haveShaderMetaData = ( metadata && metadata->size() );
+
+    // Always emit node information
+    emitScopeBegin(stage, Syntax::DOUBLE_SQUARE_BRACKETS);
+    emitLine("string mtlx_category = \"" + element->getCategory() + "\"" + Syntax::COMMA, stage, false);
+    emitLine("string mtlx_name = \"" + element->getName() + "\"" + 
+            (haveShaderMetaData ? Syntax::COMMA : EMPTY_STRING), stage, false);
+
+    // Add any metadata if set on the graph.
+    if (haveShaderMetaData)
     {
-        emitScopeBegin(stage, Syntax::DOUBLE_SQUARE_BRACKETS);
         for (size_t j = 0; j < metadata->size(); ++j)
         {
             const ShaderMetadata& data = metadata->at(j);
@@ -249,9 +256,10 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
             const string dataValue = _syntax->getValue(data.type, *data.value, true);
             emitLine(dataType + " " + data.name + " = " + dataValue + delim, stage, false);
         }
-        emitScopeEnd(stage, false, false);
-        emitLineEnd(stage, false);
     }
+    emitScopeEnd(stage, false, false);
+    emitLineEnd(stage, false);
+
 
     emitScopeBegin(stage, Syntax::PARENTHESES);
 

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -237,7 +237,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     emitLine(functionName, stage, false);
 
     const ShaderMetadataVecPtr& metadata = graph.getMetadata();
-    bool haveShaderMetaData = ( metadata && metadata->size() );
+    bool haveShaderMetaData = metadata && metadata->size();
 
     // Always emit node information
     emitScopeBegin(stage, Syntax::DOUBLE_SQUARE_BRACKETS);
@@ -259,7 +259,6 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     }
     emitScopeEnd(stage, false, false);
     emitLineEnd(stage, false);
-
 
     emitScopeBegin(stage, Syntax::PARENTHESES);
 

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -242,7 +242,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     // Always emit node information
     emitScopeBegin(stage, Syntax::DOUBLE_SQUARE_BRACKETS);
     emitLine("string mtlx_category = \"" + element->getCategory() + "\"" + Syntax::COMMA, stage, false);
-    emitLine("string mtlx_name = \"" + element->getName() + "\"" + 
+    emitLine("string mtlx_name = \"" + element->getQualifiedName(element->getName())+ "\"" + 
             (haveShaderMetaData ? Syntax::COMMA : EMPTY_STRING), stage, false);
 
     // Add any metadata if set on the graph.


### PR DESCRIPTION
Add in metadata at the shader level which outputs the node category and qualified name.
This allows the shader to reference back to a specified definition when emitting <nodedefs>
or the root node otherwise.

e.g. cellnoise:
```
 <nodedef name="ND_cellnoise2d_float" node="cellnoise2d" nodegroup="procedural2d">
    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
    <output name="out" type="float" default="0.0" />
  </nodedef>
  ```
  has this reflected in the metadata for the shader:
  ```
 shader cellnoise2d_float
[[
    string mtlx_category = "cellnoise2d",
    string mtlx_name = "cellnoise2d_float"
]]
  ```