### PR TITLE
Improvements to OSL tangent frame

### DIFF
--- a/libraries/stdlib/genosl/mx_bitangent_vector3.inline
+++ b/libraries/stdlib/genosl/mx_bitangent_vector3.inline
@@ -1,1 +1,1 @@
-transform({{space}}, dPdv)
+transform({{space}}, normalize(dPdv))

--- a/libraries/stdlib/genosl/mx_tangent_vector3.inline
+++ b/libraries/stdlib/genosl/mx_tangent_vector3.inline
@@ -1,1 +1,1 @@
-transform({{space}}, dPdu)
+transform({{space}}, normalize(dPdu))

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -61,22 +61,11 @@
          File path is relative to the "/resources/Geometry/" folder -->
     <input name="shadedGeometry" type="string" value="sphere.obj" />
 
-    <!-- Amount to scale geometry. -->
-    <input name="geometryScale" type="float" value="1.0" />
-
     <!-- Enable direct lighting. Default is true. -->
     <input name="enableDirectLighting" type="boolean" value="false" />
 
     <!-- Enable indirect lighting. Default is true. -->
     <input name="enableIndirectLighting" type="boolean" value="true" />
-
-    <!-- Method for specular environment sampling (only used for HW rendering):
-           0 = Disable environment mapping.
-           1 = Filtered Importance Sampling: Use FIS to sample the IBL texture according to the BRDF in runtime.
-           2 = Prefiltered: Use a radiance IBL texture that has been prefiltered with the BRDF.
-           Default value is 1.
-    -->
-    <input name="specularEnvironmentMethod" type="integer" value="1" />
 
     <!-- Suggested radiance IBL file path -->
     <input name="radianceIBLPath" type="string" value="resources/Lights/san_giuseppe_bridge.hdr" />
@@ -92,6 +81,9 @@
 
     <!-- List of document paths for render tests -->
     <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/Examples/UsdPreviewSurface,resources/Materials/TestSuite" />
+
+    <!-- Enable reference quality rendering. Default is false. -->
+    <input name="enableReferenceQuality" type="boolean" value="false" />
 
     <!-- Wedge rendering options -->
     <input name="wedgeFiles" type="string" value="wedge_conductor.mtlx,wedge_conductor.mtlx" />

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -27,7 +27,9 @@ OslRendererPtr OslRenderer::create(unsigned int width, unsigned int height, Imag
 
 OslRenderer::OslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
     ShaderRenderer(width, height, baseType),
-    _useTestRender(true) // By default use testrender
+    _useTestRender(true),
+    _raysPerPixelLit(1),
+    _raysPerPixelUnlit(1)
 {
 }
 
@@ -160,10 +162,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     command += " " + outputFileName;
     command += " -r " + std::to_string(_width) + " " + std::to_string(_height);
     command += " --path " + osoPaths;
-    if (isColorClosure)
-    {
-        command += " -aa 6"; // Increase rays per pixel for lit surfaces
-    }
+    command += " -aa " + std::to_string(isColorClosure ? _raysPerPixelLit : _raysPerPixelUnlit);
     command += " > " + errorFile + redirectString;
 
     // Repeat the render command to allow for sporadic errors.

--- a/source/MaterialXRenderOsl/OslRenderer.h
+++ b/source/MaterialXRenderOsl/OslRenderer.h
@@ -196,6 +196,18 @@ class MX_RENDEROSL_API OslRenderer : public ShaderRenderer
         _useTestRender = useTestRender;
     }
 
+    /// Set the number of rays per pixel to be used for lit surfaces.
+    void setRaysPerPixelLit(int rays)
+    {
+        _raysPerPixelLit = rays;
+    }
+
+    /// Set the number of rays per pixel to be used for unlit surfaces.
+    void setRaysPerPixelUnlit(int rays)
+    {
+        _raysPerPixelUnlit = rays;
+    }
+
     ///
     /// Compile OSL code stored in a file. Will throw an exception if an error occurs.
     /// @param oslFilePath OSL file path.
@@ -222,35 +234,23 @@ class MX_RENDEROSL_API OslRenderer : public ShaderRenderer
     OslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType);
 
   private:
-    /// Path to "oslc" executable`
     FilePath _oslCompilerExecutable;
-    /// OSL include path
     FileSearchPath _oslIncludePath;
-    /// Output file path. File name does not include an extension
     FilePath _oslOutputFilePath;
-    /// Output image file name
     FilePath _oslOutputFileName;
 
-    /// Path to "testshade" executable
     FilePath _oslTestShadeExecutable;
-    /// Path to "testrender" executable
     FilePath _oslTestRenderExecutable;
-    /// Path to template scene XML file used for "testrender"
     FilePath _oslTestRenderSceneTemplateFile;
-    /// Name of shader. Used for rendering with "testrender"
     string _oslShaderName;
-    /// Set of strings containing parameter override settings for "testrender"
     StringVec _oslShaderParameterOverrides;
-    /// Set of strings containing environment parameter override settings for "testrender"
     StringVec _envOslShaderParameterOverrides;
-    /// Name of output on the shader. Used for rendering with "testshade" and "testrender"
     string _oslShaderOutputName;
-    /// MaterialX type of the output on the shader. Used for rendering with "testshade" and "testrender"
     string _oslShaderOutputType;
-    /// Path for utility shaders (.oso) used when rendering with "testrender"
     FilePath _oslUtilityOSOPath;
-    /// Use "testshade" or "testender" for render validation
     bool _useTestRender;
+    int _raysPerPixelLit;
+    int _raysPerPixelUnlit;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -898,14 +898,13 @@ void TestSuiteOptions::print(std::ostream& output) const
     output << "\tDump uniforms and Attributes  " << dumpUniformsAndAttributes << std::endl;
     output << "\tNon-Shaded Geometry: " << unShadedGeometry.asString() << std::endl;
     output << "\tShaded Geometry: " << shadedGeometry.asString() << std::endl;
-    output << "\tGeometry Scale: " << geometryScale << std::endl;
     output << "\tEnable Direct Lighting: " << enableDirectLighting << std::endl;
     output << "\tEnable Indirect Lighting: " << enableIndirectLighting << std::endl;
-    output << "\tSpecular Environment Method: " << specularEnvironmentMethod << std::endl;
     output << "\tRadiance IBL File Path " << radianceIBLPath.asString() << std::endl;
     output << "\tIrradiance IBL File Path: " << irradianceIBLPath.asString() << std::endl;
     output << "\tExtra library paths: " << extraLibraryPaths.asString() << std::endl;
     output << "\tRender test paths: " << renderTestPaths.asString() << std::endl;
+    output << "\tEnable Reference Quality: " << enableReferenceQuality << std::endl;
 }
 
 bool TestSuiteOptions::readOptions(const std::string& optionFile)
@@ -928,16 +927,15 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     const std::string DUMP_GENERATED_CODE_STRING("dumpGeneratedCode");
     const std::string UNSHADED_GEOMETRY_STRING("unShadedGeometry");
     const std::string SHADED_GEOMETRY_STRING("shadedGeometry");
-    const std::string GEOMETRY_SCALE_STRING("geometryScale");
     const std::string ENABLE_DIRECT_LIGHTING("enableDirectLighting");
     const std::string ENABLE_INDIRECT_LIGHTING("enableIndirectLighting");
-    const std::string SPECULAR_ENVIRONMENT_METHOD("specularEnvironmentMethod");
     const std::string RADIANCE_IBL_PATH_STRING("radianceIBLPath");
     const std::string IRRADIANCE_IBL_PATH_STRING("irradianceIBLPath");
     const std::string SPHERE_OBJ("sphere.obj");
     const std::string SHADERBALL_OBJ("shaderball.obj");
     const std::string EXTRA_LIBRARY_PATHS("extraLibraryPaths");
     const std::string RENDER_TEST_PATHS("renderTestPaths");
+    const std::string ENABLE_REFERENCE_QUALITY("enableReferenceQuality");
     const std::string WEDGE_FILES("wedgeFiles");
     const std::string WEDGE_PARAMETERS("wedgeParameters");
     const std::string WEDGE_RANGE_MIN("wedgeRangeMin");
@@ -951,10 +949,9 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     dumpGeneratedCode = false;
     unShadedGeometry = SPHERE_OBJ;
     shadedGeometry = SHADERBALL_OBJ;
-    geometryScale = 1.0f;
     enableDirectLighting = true;
     enableIndirectLighting = true;
-    specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
+    enableReferenceQuality = false;
 
     MaterialX::DocumentPtr doc = MaterialX::createDocument();
     try
@@ -1030,10 +1027,6 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     {
                         shadedGeometry = p->getValueString();
                     }
-                    else if (name == GEOMETRY_SCALE_STRING)
-                    {
-                        geometryScale = val->asA<float>();
-                    }
                     else if (name == ENABLE_DIRECT_LIGHTING)
                     {
                         enableDirectLighting = val->asA<bool>();
@@ -1041,10 +1034,6 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     else if (name == ENABLE_INDIRECT_LIGHTING)
                     {
                         enableIndirectLighting = val->asA<bool>();
-                    }
-                    else if (name == SPECULAR_ENVIRONMENT_METHOD)
-                    {
-                        specularEnvironmentMethod = (mx::HwSpecularEnvironmentMethod) val->asA<int>();
                     }
                     else if (name == RADIANCE_IBL_PATH_STRING)
                     {
@@ -1069,6 +1058,10 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                         {
                             renderTestPaths.append(mx::FilePath(l));
                         }
+                    }
+                    else if (name == ENABLE_REFERENCE_QUALITY)
+                    {
+                        enableReferenceQuality = val->asA<bool>();
                     }
                     else if (name == WEDGE_FILES)
                     {

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -110,20 +110,11 @@ class TestSuiteOptions
     // Shaded geometry file
     MaterialX::FilePath shadedGeometry;
 
-    // Amount to scale geometry. 
-    float geometryScale;
-
     // Enable direct lighting. Default is true. 
     bool enableDirectLighting;
 
     // Enable indirect lighting. Default is true. 
     bool enableIndirectLighting;
-
-    // Method for specular environment sampling (only used for HW rendering):
-    //   0 : Prefiltered - Use a radiance IBL texture that has been prefiltered with the BRDF.
-    //   1 : Filtered Importance Sampling - Use FIS to sample the IBL texture according to the BRDF in runtime.
-    // Default value is 1.
-    mx::HwSpecularEnvironmentMethod specularEnvironmentMethod;
 
     // Radiance IBL file.
     mx::FilePath radianceIBLPath;
@@ -136,6 +127,9 @@ class TestSuiteOptions
 
     // Render test paths
     mx::FileSearchPath renderTestPaths;
+
+    // Enable reference quality rendering. Default is false.
+    bool enableReferenceQuality;
 
     // Wedge parameters
     mx::StringVec wedgeFiles;

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -99,7 +99,7 @@ void GlslShaderRenderTester::registerLights(mx::DocumentPtr document,
     REQUIRE(envIrradiance);
     _lightHandler->setEnvRadianceMap(envRadiance);
     _lightHandler->setEnvIrradianceMap(envIrradiance);
-    _lightHandler->setEnvSamples(256);
+    _lightHandler->setEnvSamples(1024);
 }
 
 //
@@ -433,7 +433,6 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
                 mx::GenOptions& contextOptions = context.getOptions();
                 contextOptions = options;
                 contextOptions.targetColorSpaceOverride = "lin_rec709";
-                contextOptions.hwSpecularEnvironmentMethod = testOptions.specularEnvironmentMethod;
                 shader = shadergen.generate(shaderName, element, context);
                 generationTimer.endTimer();
             }


### PR DESCRIPTION
- Generate normalized tangent and bitangent vectors in vanilla OSL.
- Generate custom tangent and bitangent vectors for the parametric sphere in testrender, aligning them with Lengyel/Mikkelsen conventions for a polygonal sphere.
- Add a reference quality option for render tests.