### PR TITLE
Material test suite cleanup

### DIFF
--- a/resources/Materials/TestSuite/pbrlib/bsdf/add_bsdf.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/add_bsdf.mtlx
@@ -5,12 +5,12 @@
       <input name="value" type="float" value="0.5" />
     </constant>
     <clamp name="clamp1" type="float">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+      <input name="in" type="float" nodename="constant1" />
       <input name="low" type="float" value="0.0" />
       <input name="high" type="float" value="1.0" />
     </clamp>
     <invert name="invert1" type="float">
-      <input name="in" type="float" value="0.0" nodename="clamp1" />
+      <input name="in" type="float" nodename="clamp1" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <oren_nayar_diffuse_bsdf name="diffuse_brdf1" type="BSDF">

--- a/resources/Materials/TestSuite/pbrlib/bsdf/vertical_layering.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/vertical_layering.mtlx
@@ -92,68 +92,68 @@
     </nodegraph>
 
     <nodegraph name="vertical_layering_ex5">
-      <thin_film_bsdf name="thin_film_bsdf" type="BSDF" nodedef="ND_thin_film_bsdf" xpos="1902.91" ypos="-214.631">
+      <thin_film_bsdf name="thin_film_bsdf" type="BSDF" nodedef="ND_thin_film_bsdf">
         <input name="thickness" type="float" value="300" uivisible="true" />
       </thin_film_bsdf>
-      <dielectric_bsdf name="dielectric_bsdf" type="BSDF" nodedef="ND_dielectric_bsdf" xpos="305.231" ypos="-139.453">
+      <dielectric_bsdf name="dielectric_bsdf" type="BSDF" nodedef="ND_dielectric_bsdf">
         <input name="ior" type="float" value="3" uivisible="true" />
       </dielectric_bsdf>
-      <surface name="surface" type="surfaceshader" nodedef="ND_surface" xpos="1659.24" ypos="244.948">
+      <surface name="surface" type="surfaceshader" nodedef="ND_surface">
         <input name="bsdf" type="BSDF" value="" uivisible="true" />
         <input name="edf" type="EDF" value="" uivisible="true" />
       </surface>
-      <layer name="layer1" type="BSDF" nodedef="ND_layer_bsdf" xpos="977.162" ypos="107.936">
+      <layer name="layer1" type="BSDF" nodedef="ND_layer_bsdf">
         <input name="top" type="BSDF" value="" uivisible="true" />
         <input name="base" type="BSDF" value="" uivisible="true" />
       </layer>
-      <oren_nayar_diffuse_bsdf name="oren_nayar_diffuse_bsdf1" type="BSDF" nodedef="ND_oren_nayar_diffuse_bsdf" xpos="-166.918" ypos="-95.551">
+      <oren_nayar_diffuse_bsdf name="oren_nayar_diffuse_bsdf1" type="BSDF" nodedef="ND_oren_nayar_diffuse_bsdf">
         <input name="color" type="color3" value="1, 0, 0" uivisible="true" />
       </oren_nayar_diffuse_bsdf>
-      <surface name="surface1" type="surfaceshader" nodedef="ND_surface" xpos="1738.45" ypos="-924.847">
+      <surface name="surface1" type="surfaceshader" nodedef="ND_surface">
         <input name="bsdf" type="BSDF" nodename="layer2" uivisible="true" />
       </surface>
-      <dielectric_bsdf name="dielectric_bsdf1" type="BSDF" nodedef="ND_dielectric_bsdf" xpos="9.7404" ypos="-1071.92">
+      <dielectric_bsdf name="dielectric_bsdf1" type="BSDF" nodedef="ND_dielectric_bsdf">
         <input name="ior" type="float" value="3" uivisible="true" />
       </dielectric_bsdf>
-      <layer name="layer2" type="BSDF" nodedef="ND_layer_bsdf" xpos="1240.65" ypos="-806.687">
+      <layer name="layer2" type="BSDF" nodedef="ND_layer_bsdf">
         <input name="top" type="BSDF" nodename="layer3" uivisible="true" />
         <input name="base" type="BSDF" nodename="mix" uivisible="true" />
       </layer>
-      <layer name="layer3" type="BSDF" nodedef="ND_layer_bsdf" xpos="394.754" ypos="-1186.41">
+      <layer name="layer3" type="BSDF" nodedef="ND_layer_bsdf">
         <input name="top" type="BSDF" nodename="thin_film_bsdf1" uivisible="true" />
         <input name="base" type="BSDF" nodename="dielectric_bsdf1" uivisible="true" />
       </layer>
-      <thin_film_bsdf name="thin_film_bsdf1" type="BSDF" nodedef="ND_thin_film_bsdf" xpos="12.9774" ypos="-1340.7">
+      <thin_film_bsdf name="thin_film_bsdf1" type="BSDF" nodedef="ND_thin_film_bsdf">
         <input name="thickness" type="float" value="300" uivisible="true" />
       </thin_film_bsdf>
-      <mix name="mix" type="BSDF" nodedef="ND_mix_bsdf" xpos="746.49" ypos="-461.463">
+      <mix name="mix" type="BSDF" nodedef="ND_mix_bsdf">
         <input name="fg" type="BSDF" nodename="layer" uivisible="true" />
         <input name="bg" type="BSDF" nodename="dielectric_bsdf" uivisible="true" />
         <input name="mix" type="float" value="0.5" uivisible="true" />
       </mix>
-      <layer name="layer" type="BSDF" nodedef="ND_layer_bsdf" xpos="292.63" ypos="-437.851">
+      <layer name="layer" type="BSDF" nodedef="ND_layer_bsdf">
         <input name="top" type="BSDF" nodename="dielectric_bsdf2" uivisible="true" />
         <input name="base" type="BSDF" nodename="oren_nayar_diffuse_bsdf1" uivisible="true" />
       </layer>
-      <dielectric_bsdf name="dielectric_bsdf2" type="BSDF" nodedef="ND_dielectric_bsdf" xpos="-168.44" ypos="-552.522" />
+      <dielectric_bsdf name="dielectric_bsdf2" type="BSDF" nodedef="ND_dielectric_bsdf" />
       <output name="out" type="surfaceshader" nodename="surface1" />
     </nodegraph>
 
     <nodegraph name="vertical_layering_ex6">
-      <dielectric_bsdf name="dielectric_bsdf2" type="BSDF" nodedef="ND_dielectric_bsdf" xpos="-183.298" ypos="-635.301" />
-      <oren_nayar_diffuse_bsdf name="oren_nayar_diffuse_bsdf1" type="BSDF" nodedef="ND_oren_nayar_diffuse_bsdf" xpos="-166.918" ypos="-95.551">
+      <dielectric_bsdf name="dielectric_bsdf2" type="BSDF" nodedef="ND_dielectric_bsdf" />
+      <oren_nayar_diffuse_bsdf name="oren_nayar_diffuse_bsdf1" type="BSDF" nodedef="ND_oren_nayar_diffuse_bsdf">
         <input name="color" type="color3" value="1, 0, 0" uivisible="true" />
       </oren_nayar_diffuse_bsdf>
-      <layer name="layer" type="BSDF" nodedef="ND_layer_bsdf" xpos="231.077" ypos="-280.784">
+      <layer name="layer" type="BSDF" nodedef="ND_layer_bsdf">
         <input name="top" type="BSDF" nodename="dielectric_bsdf2" uivisible="true" />
         <input name="base" type="BSDF" nodename="oren_nayar_diffuse_bsdf1" uivisible="true" />
       </layer>
-      <mix name="mix" type="BSDF" nodedef="ND_mix_bsdf" xpos="739.807" ypos="-550.212">
+      <mix name="mix" type="BSDF" nodedef="ND_mix_bsdf">
         <input name="fg" type="BSDF" nodename="dielectric_bsdf2" uivisible="true" />
         <input name="bg" type="BSDF" nodename="layer" uivisible="true" />
         <input name="mix" type="float" value="0.5" uivisible="true" />
       </mix>
-      <surface name="surface" type="surfaceshader" nodedef="ND_surface" xpos="1256.95" ypos="-439.06">
+      <surface name="surface" type="surfaceshader" nodedef="ND_surface">
         <input name="bsdf" type="BSDF" nodename="mix" uivisible="true" />
         <input name="edf" type="EDF" value="" uivisible="true" />
       </surface>

--- a/resources/Materials/TestSuite/pbrlib/displacement/displaced_material.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/displacement/displaced_material.mtlx
@@ -8,7 +8,7 @@
     <input name="space" type="string" value="object" />
   </position>
   <multiply name="multiply1" type="vector3">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <input name="in1" type="vector3" nodename="position1" />
     <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
   </multiply>
   <fractal3d name="fractal3d1" type="float">
@@ -16,7 +16,7 @@
     <input name="octaves" type="integer" value="2" />
     <input name="lacunarity" type="float" value="2.0000" />
     <input name="diminish" type="float" value="0.5000" />
-    <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+    <input name="position" type="vector3" nodename="multiply1" />
   </fractal3d>
   <displacement name="disp" type="displacementshader">
     <input name="displacement" type="float" nodename="fractal3d1" />

--- a/resources/Materials/TestSuite/pbrlib/displacement/displacement.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/displacement/displacement.mtlx
@@ -5,7 +5,7 @@
       <input name="space" type="string" value="object" />
     </position>
     <multiply name="multiply1" type="vector3">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
     <fractal3d name="fractal3d1" type="float">
@@ -13,7 +13,7 @@
       <input name="octaves" type="integer" value="2" />
       <input name="lacunarity" type="float" value="2.0000" />
       <input name="diminish" type="float" value="0.5000" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+      <input name="position" type="vector3" nodename="multiply1" />
     </fractal3d>
     <displacement name="disp1" type="displacementshader">
       <input name="displacement" type="float" nodename="fractal3d1" />
@@ -26,7 +26,7 @@
       <input name="space" type="string" value="object" />
     </position>
     <multiply name="multiply1" type="vector3">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
     <fractal3d name="fractal3d1" type="vector3">
@@ -34,7 +34,7 @@
       <input name="octaves" type="integer" value="2" />
       <input name="lacunarity" type="float" value="2.0000" />
       <input name="diminish" type="float" value="0.5000" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+      <input name="position" type="vector3" nodename="multiply1" />
     </fractal3d>
     <displacement name="disp1" type="displacementshader">
       <input name="displacement" type="vector3" nodename="fractal3d1" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/mapped_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/mapped_surfaceshader.mtlx
@@ -1,21 +1,21 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!-- Basic color mapped test -->
-  <nodegraph name="RedRamp" xpos="315" ypos="1129">
-    <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-60">
-      <input name="valuetl" type="color3" uniform="true" value="1, 0, 0" />
-      <input name="valuetr" type="color3" uniform="true" value="0.1, 0, 0" />
-      <input name="valuebl" type="color3" uniform="true" value="1, 0, 0" />
-      <input name="valuebr" type="color3" uniform="true" value="0.1, 0, 0" />
+  <nodegraph name="RedRamp">
+    <ramp4 name="ramp4" type="color3">
+      <input name="valuetl" type="color3" value="1, 0, 0" />
+      <input name="valuetr" type="color3" value="0.1, 0, 0" />
+      <input name="valuebl" type="color3" value="1, 0, 0" />
+      <input name="valuebr" type="color3" value="0.1, 0, 0" />
     </ramp4>
     <output name="out" type="color3" nodename="ramp4" />
   </nodegraph>
-  <nodegraph name="GreenRamp" xpos="315" ypos="1348">
-    <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-60">
-      <input name="valuetl" type="color3" uniform="true" value="0, 1, 0" />
-      <input name="valuetr" type="color3" uniform="true" value="0, 0.1, 0" />
-      <input name="valuebl" type="color3" uniform="true" value="0, 1, 0" />
-      <input name="valuebr" type="color3" uniform="true" value="0, 0.1, 0" />
+  <nodegraph name="GreenRamp">
+    <ramp4 name="ramp4" type="color3">
+      <input name="valuetl" type="color3" value="0, 1, 0" />
+      <input name="valuetr" type="color3" value="0, 0.1, 0" />
+      <input name="valuebl" type="color3" value="0, 1, 0" />
+      <input name="valuebr" type="color3" value="0, 0.1, 0" />
     </ramp4>
     <output name="out" type="color3" nodename="ramp4" />
   </nodegraph>
@@ -27,38 +27,37 @@
     <input name="specular_color" type="color3" nodegraph="GreenRamp" />
     <input name="coat" type="float" value="1" />
   </standard_surface>
-  <surfacematerial name="MappedShaderMaterial" type="material" xpos="925" ypos="1098">
+  <surfacematerial name="MappedShaderMaterial" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="MappedShader" />
     <input name="displacementshader" type="displacementshader" value="" />
   </surfacematerial>
 
   <!-- real world units test -->
-  <nodegraph name="UnitGraph" xpos="336.442" ypos="884.044">
-    <tiledimage name="tiledimage" type="float" xpos="-47" ypos="-72">
-      <input name="file" type="filename" uniform="true" value="resources/Images/grid.png" />
+  <nodegraph name="UnitGraph">
+    <tiledimage name="tiledimage" type="float">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
       <input name="realworldimagesize" type="vector2" value="1, 1" />
       <input name="realworldtilesize" type="vector2" value="100, 50" unit="centimeter" unittype="distance" />
-      <input name="default" type="float" value="0.0" uniform="true" />
       <input name="uvtiling" type="vector2" value="2, 3" />
       <input name="uvoffset" type="vector2" value="0.2, 0.2" />
     </tiledimage>
     <output name="out" type="float" nodename="tiledimage" />
   </nodegraph>
-  <nodegraph name="BlueRamp" xpos="315" ypos="657.618">
-    <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-61">
-      <input name="valuetl" type="color3" uniform="true" value="0, 0, 1" />
-      <input name="valuetr" type="color3" uniform="true" value="0, 0, 0.1" />
-      <input name="valuebl" type="color3" uniform="true" value="0, 0, 1" />
-      <input name="valuebr" type="color3" uniform="true" value="0, 0, 0.1" />
+  <nodegraph name="BlueRamp">
+    <ramp4 name="ramp4" type="color3">
+      <input name="valuetl" type="color3" value="0, 0, 1" />
+      <input name="valuetr" type="color3" value="0, 0, 0.1" />
+      <input name="valuebl" type="color3" value="0, 0, 1" />
+      <input name="valuebr" type="color3" value="0, 0, 0.1" />
     </ramp4>
     <output name="out" type="color3" nodename="ramp4" />
   </nodegraph>
-  <nodegraph name="YellowRamp" xpos="315" ypos="438.871">
-    <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-60">
-      <input name="valuetl" type="color3" uniform="true" value="1, 1, 0" />
-      <input name="valuetr" type="color3" uniform="true" value="0, 0, 0" />
-      <input name="valuebl" type="color3" uniform="true" value="1, 1, 0" />
-      <input name="valuebr" type="color3" value="1, 1, 1" uniform="true" />
+  <nodegraph name="YellowRamp">
+    <ramp4 name="ramp4" type="color3">
+      <input name="valuetl" type="color3" value="1, 1, 0" />
+      <input name="valuetr" type="color3" value="0, 0, 0" />
+      <input name="valuebl" type="color3" value="1, 1, 0" />
+      <input name="valuebr" type="color3" value="1, 1, 1" />
     </ramp4>
     <output name="out" type="color3" nodename="ramp4" />
   </nodegraph>
@@ -69,15 +68,15 @@
     <input name="specular" type="float" value="1" />
     <input name="specular_color" type="color3" nodegraph="BlueRamp" />
   </standard_surface>
-  <surfacematerial name="UnitMappedShaderMaterial" type="material" xpos="925" ypos="494">
+  <surfacematerial name="UnitMappedShaderMaterial" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="UnitMappedShader" />
     <input name="displacementshader" type="displacementshader" value="" />
   </surfacematerial>
 
   <!-- color space test -->
-  <nodegraph name="ColorSpaceGraph" xpos="10" ypos="82">
+  <nodegraph name="ColorSpaceGraph">
     <constant name="color_gamma22" type="color3">
-      <input name="value" type="color3" uniform="true" value="0.5, 0, 0" colorspace="gamma22" />
+      <input name="value" type="color3" value="0.5, 0, 0" colorspace="gamma22" />
     </constant>
     <output name="out" type="color3" nodename="color_gamma22" />
   </nodegraph>
@@ -96,21 +95,21 @@
   </surfacematerial>
 
   <!-- normal map test -->
-  <standard_surface name="NormalMapShader" type="surfaceshader" version="1.0.1" xpos="-29.5" ypos="-184">
+  <standard_surface name="NormalMapShader" type="surfaceshader" version="1.0.1">
     <input name="base_color" type="color3" value="0.2, 0.5, 0.9" />
     <input name="normal" type="vector3" nodegraph="Compound" />
   </standard_surface>
-  <surfacematerial name="NormalMapMaterial" type="material" xpos="160" ypos="-269">
+  <surfacematerial name="NormalMapMaterial" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="NormalMapShader" />
     <input name="displacementshader" type="displacementshader" value="" />
   </surfacematerial>
-  <nodegraph name="Compound" xpos="-351.5" ypos="-41">
-    <input name="file" type="filename" uniform="true" value="" />
-    <normalmap name="normalmap" type="vector3" xpos="20" ypos="-95">
+  <nodegraph name="Compound">
+    <input name="file" type="filename" value="" />
+    <normalmap name="normalmap" type="vector3">
       <input name="in" type="vector3" nodename="tiledimage" />
     </normalmap>
-    <tiledimage name="tiledimage" type="vector3" xpos="-218.5" ypos="-107.905">
-      <input name="file" type="filename" uniform="true" value="resources/Images/mesh_wire_norm.png" />
+    <tiledimage name="tiledimage" type="vector3">
+      <input name="file" type="filename" value="resources/Images/mesh_wire_norm.png" />
       <input name="uvtiling" type="vector2" value="10, 10" />
     </tiledimage>
     <output name="out" type="vector3" nodename="normalmap" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/nodegraph_standardsurface.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/nodegraph_standardsurface.mtlx
@@ -1,54 +1,54 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="IMPL_standard_surface_graph" type="" xpos="5.77241" ypos="16.6699">
-    <constant name="coat_affect_roughness" type="float" xpos="-5.97931" ypos="17.86">
+  <nodegraph name="IMPL_standard_surface_graph">
+    <constant name="coat_affect_roughness" type="float">
       <input name="value" type="float" value="1.0000" />
     </constant>
-    <invert name="invert1" type="float" xpos="-0.8" ypos="12.94">
+    <invert name="invert1" type="float">
       <input name="in" type="float" />
       <input name="amount" type="float" value="1.0" />
     </invert>
-    <multiply name="multiply5" type="float" xpos="-3.76552" ypos="17.24">
+    <multiply name="multiply5" type="float">
       <input name="in1" type="float" nodename="coat_affect_roughness" />
       <input name="in2" type="float" />
     </multiply>
-    <multiply name="multiply6" type="float" xpos="-2.28276" ypos="16.62">
+    <multiply name="multiply6" type="float">
       <input name="in1" type="float" nodename="multiply5" />
       <input name="in2" type="float" />
     </multiply>
-    <invert name="invert2" type="float" xpos="-0.8" ypos="16">
+    <invert name="invert2" type="float">
       <input name="in" type="float" nodename="multiply6" />
       <input name="amount" type="float" value="1.0" />
     </invert>
-    <multiply name="multiply7" type="float" xpos="0.682758" ypos="13.54">
+    <multiply name="multiply7" type="float">
       <input name="in1" type="float" nodename="invert1" />
       <input name="in2" type="float" nodename="invert2" />
     </multiply>
-    <invert name="invert3" type="float" xpos="2.16552" ypos="12.9056">
+    <invert name="invert3" type="float">
       <input name="in" type="float" nodename="multiply7" />
       <input name="amount" type="float" value="1.0" />
     </invert>
-    <roughness_anisotropy name="rougness2" type="vector2" xpos="3.64828" ypos="12.3">
+    <roughness_anisotropy name="rougness2" type="vector2">
       <input name="roughness" type="float" nodename="invert3" />
       <input name="anisotropy" type="float" />
     </roughness_anisotropy>
-    <oren_nayar_diffuse_bsdf name="Diffuse_BSDF" type="BSDF" xpos="3.64828" ypos="2.02564">
+    <oren_nayar_diffuse_bsdf name="Diffuse_BSDF" type="BSDF">
       <input name="weight" type="float" value="1.0000" />
       <input name="color" type="color3" value="1.0000, 1.0000, 1.0000" />
       <input name="roughness" type="float" />
       <input name="normal" type="vector3" />
     </oren_nayar_diffuse_bsdf>
-    <translucent_bsdf name="SSS_BSDF" type="BSDF" xpos="3.64828" ypos="6.96564">
+    <translucent_bsdf name="SSS_BSDF" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color" type="color3" value="1.0000, 1.0000, 1.0000" />
       <input name="normal" type="vector3" />
     </translucent_bsdf>
-    <mix name="mix1" type="BSDF" xpos="5.18621" ypos="4.66564">
+    <mix name="mix1" type="BSDF">
       <input name="fg" type="BSDF" nodename="Diffuse_BSDF" />
       <input name="bg" type="BSDF" nodename="SSS_BSDF" />
       <input name="mix" type="float" value="1.0000" />
     </mix>
-    <dielectric_bsdf name="Transmission_BSDF" type="BSDF" xpos="5.18621" ypos="9">
+    <dielectric_bsdf name="Transmission_BSDF" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="tint" type="color3" value="1.0000, 1.0000, 1.0000" />
       <input name="ior" type="float" value="0.2000" />
@@ -58,12 +58,12 @@
       <input name="distribution" type="string" value="ggx" />
       <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
-    <mix name="mix3" type="BSDF" xpos="7.16552" ypos="6.54984">
+    <mix name="mix3" type="BSDF">
       <input name="fg" type="BSDF" nodename="mix1" />
       <input name="bg" type="BSDF" nodename="Transmission_BSDF" />
       <input name="mix" type="float" value="1.0000" />
     </mix>
-    <dielectric_bsdf name="Specular_BSDF__layer_top" type="BSDF" xpos="8.65818" ypos="1.33436">
+    <dielectric_bsdf name="Specular_BSDF__layer_top" type="BSDF">
       <input name="weight" type="float" value="1.0000" />
       <input name="tint" type="color3" value="0.0000, 0.0000, 0.0000" />
       <input name="ior" type="float" value="0.7700" />
@@ -72,7 +72,7 @@
       <input name="tangent" type="vector3" />
       <input name="distribution" type="string" value="ggx" />
     </dielectric_bsdf>
-    <conductor_bsdf name="Metal_BSDF" type="BSDF" xpos="8.64828" ypos="8.78">
+    <conductor_bsdf name="Metal_BSDF" type="BSDF">
       <input name="weight" type="float" value="1.0000" />
       <input name="roughness" type="vector2" nodename="rougness2" />
       <input name="normal" type="vector3" />
@@ -81,25 +81,25 @@
       <input name="ior" type="color3" nodename="Metal_BSDF__artistic_ior" output="ior" />
       <input name="extinction" type="color3" nodename="Metal_BSDF__artistic_ior" output="extinction" />
     </conductor_bsdf>
-    <mix name="mix2" type="BSDF" xpos="10.2966" ypos="3.1">
+    <mix name="mix2" type="BSDF">
       <input name="fg" type="BSDF" nodename="Specular_BSDF" />
       <input name="bg" type="BSDF" nodename="Metal_BSDF" />
       <input name="mix" type="float" value="0.9000" />
     </mix>
-    <mix name="coat_attenuation" type="color3" xpos="10.2966" ypos="7.43436">
+    <mix name="coat_attenuation" type="color3">
       <input name="fg" type="color3" />
       <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
       <input name="mix" type="float" />
     </mix>
-    <multiply name="scale_bsdf1" type="BSDF" xpos="12.3184" ypos="2.4032">
+    <multiply name="scale_bsdf1" type="BSDF">
       <input name="in1" type="BSDF" nodename="mix2" />
       <input name="in2" type="color3" nodename="coat_attenuation" />
     </multiply>
-    <roughness_anisotropy name="coat_roughness2" type="vector2" xpos="12.2937" ypos="6.65742">
+    <roughness_anisotropy name="coat_roughness2" type="vector2">
       <input name="roughness" type="float" value="1.0000" />
       <input name="anisotropy" type="float" value="0.0000" />
     </roughness_anisotropy>
-    <dielectric_bsdf name="Coat_BSDF__layer_top" type="BSDF" xpos="13.869" ypos="2.47694">
+    <dielectric_bsdf name="Coat_BSDF__layer_top" type="BSDF">
       <input name="weight" type="float" value="1.0000" />
       <input name="tint" type="color3" value="1.0, 1.0, 1.0" />
       <input name="ior" type="float" value="0.5440" />
@@ -107,25 +107,25 @@
       <input name="normal" type="vector3" />
       <input name="distribution" type="string" value="ggx" />
     </dielectric_bsdf>
-    <multiply name="multiply3" type="color3" xpos="10.2966" ypos="11.74">
+    <multiply name="multiply3" type="color3">
       <input name="in1" type="color3" value="0.0010, 0.0000, 0.0000" />
       <input name="in2" type="float" value="1.0000" />
     </multiply>
-    <multiply name="multiply4" type="color3" xpos="12.0759" ypos="10.2656">
+    <multiply name="multiply4" type="color3">
       <input name="in1" type="color3" nodename="multiply3" />
       <input name="in2" type="color3" nodename="coat_attenuation" />
     </multiply>
-    <uniform_edf name="Emission_EDF" type="EDF" xpos="13.869" ypos="9.34564">
+    <uniform_edf name="Emission_EDF" type="EDF">
       <input name="color" type="color3" nodename="multiply4" />
     </uniform_edf>
-    <luminance name="luminance1" type="color3" xpos="12.0759" ypos="13.96">
+    <luminance name="luminance1" type="color3">
       <input name="in" type="color3" value="0.7000, 0.7000, 0.7000" />
     </luminance>
-    <swizzle name="luminance1_x" type="float" xpos="13.869" ypos="12.42">
+    <swizzle name="luminance1_x" type="float">
       <input name="in" type="color3" nodename="luminance1" />
       <input name="channels" type="string" value="r" />
     </swizzle>
-    <surface name="Surface_Constructor" type="surfaceshader" xpos="15.4276" ypos="6.84">
+    <surface name="Surface_Constructor" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="Coat_BSDF" />
       <input name="edf" type="EDF" nodename="Emission_EDF" />
       <input name="opacity" type="float" nodename="luminance1_x" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/normalmapped_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/normalmapped_surfaceshader.mtlx
@@ -18,7 +18,7 @@
       <input name="space" type="string" value="tangent" />
     </normalmap>
     <tiledimage name="tiledimage" type="vector3">
-      <input name="file" type="filename" uniform="true" value="resources/images/mesh_wire_norm.png" />
+      <input name="file" type="filename" value="resources/images/mesh_wire_norm.png" />
       <input name="realworldimagesize" type="vector2" value="1.0, 2.0" unit="centimeter" unittype="distance" />
       <input name="realworldtilesize" type="vector2" value="3.0, 2.0" unit="centimeter" unittype="distance" />
       <input name="uvtiling" type="vector2" value="12, 10" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/shader_ops.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/shader_ops.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="nodegraph1" type="">
+  <nodegraph name="nodegraph1">
     <add name="add_surface_shader" type="surfaceshader">
       <input name="in1" type="surfaceshader" value="" nodename="multiply_surface_shaderFloat" />
       <input name="in2" type="surfaceshader" value="" nodename="multiply_surface_shaderColor" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/surface_ops.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/surface_ops.mtlx
@@ -1,52 +1,52 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="nodegraph1" type="" xpos="6.44334" ypos="16.5914">
-    <roughness_dual name="roughness_dual1" type="vector2" xpos="3.37737" ypos="12.2247">
+  <nodegraph name="nodegraph1">
+    <roughness_dual name="roughness_dual1" type="vector2">
       <input name="roughness" type="vector2" value="0.2000, 0.4000" />
     </roughness_dual>
-    <subsurface_bsdf name="subsurface_brdf1" type="BSDF" xpos="2.0363" ypos="14.2553">
+    <subsurface_bsdf name="subsurface_brdf1" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color" type="color3" value="0.18, 0.18, 0.18" />
       <input name="radius" type="vector3" value="1.0, 1.0, 1.0" />
       <input name="anisotropy" type="float" value="0.0" />
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
     </subsurface_bsdf>
-    <sheen_bsdf name="sheen_brdf1" type="BSDF" xpos="2.02026" ypos="20.1608">
+    <sheen_bsdf name="sheen_brdf1" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color" type="color3" value="1.0, 1.0, 1.0" />
       <input name="roughness" type="float" value="0.3" />
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
     </sheen_bsdf>
-    <mix name="mix_edf1" type="EDF" xpos="4.84828" ypos="-0.84">
+    <mix name="mix_edf1" type="EDF">
       <input name="fg" type="EDF" value="" nodename="Emission_EDF" />
       <input name="bg" type="EDF" value="" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
-    <mix name="mix_surface1" type="surfaceshader" xpos="7.98621" ypos="5.96">
+    <mix name="mix_surface1" type="surfaceshader">
       <input name="fg" type="surfaceshader" value="" nodename="surface1" />
       <input name="bg" type="surfaceshader" value="" nodename="surface2" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
-    <mix name="mix_bsdf1" type="BSDF" xpos="3.57026" ypos="16.8768">
+    <mix name="mix_bsdf1" type="BSDF">
       <input name="fg" type="BSDF" value="" nodename="sheen_brdf1" />
       <input name="bg" type="BSDF" value="" nodename="subsurface_brdf1" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
-    <surface name="surface1" type="surfaceshader" xpos="6.50345" ypos="2.22">
+    <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" value="" nodename="conductor_brdf1" />
       <input name="edf" type="EDF" value="" nodename="mix_edf1" />
       <input name="opacity" type="float" value="1.0000" />
     </surface>
-    <surface name="surface2" type="surfaceshader" xpos="6.50345" ypos="11.58">
+    <surface name="surface2" type="surfaceshader">
       <input name="bsdf" type="BSDF" value="" nodename="SchlickBRDF" />
       <input name="edf" type="EDF" value="" nodename="Emission_EDF" />
       <input name="opacity" type="float" value="1.0" />
     </surface>
-    <uniform_edf name="Emission_EDF" type="EDF" xpos="3.06207" ypos="9.72">
+    <uniform_edf name="Emission_EDF" type="EDF">
       <input name="color" type="color3" value="0.2000, 1.0, 0.2000" />
     </uniform_edf>
     <output name="out" type="surfaceshader" nodename="mix_surface1" />
-    <conductor_bsdf name="conductor_brdf1" type="BSDF" xpos="4.84828" ypos="3.48">
+    <conductor_bsdf name="conductor_brdf1" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="roughness" type="vector2" value="0.0, 0.0" />
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
@@ -55,7 +55,7 @@
       <input name="ior" type="color3" nodename="conductor_brdf1__artistic_ior" output="ior" />
       <input name="extinction" type="color3" nodename="conductor_brdf1__artistic_ior" output="extinction" />
     </conductor_bsdf>
-    <generalized_schlick_bsdf name="SchlickBRDF__layer_top" type="BSDF" xpos="4.84828" ypos="10.32">
+    <generalized_schlick_bsdf name="SchlickBRDF__layer_top" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="1.0, 1.0, 1.0" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx
@@ -1,44 +1,44 @@
 <?xml version="1.0"?>
 <materialx version="1.38" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <nodegraph name="NG_transpGraph_image0" xpos="475.085" ypos="425.724" nodedef="ND_transpGraph_image0">
+  <nodegraph name="NG_transpGraph_image0" nodedef="ND_transpGraph_image0">
     <input name="opacity_file" type="filename" uniform="true" value="resources/Images/grid.png" />
-    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF" xpos="315" ypos="401">
+    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF">
       <input name="color" type="color3" value="0.8, 0.8, 0.8" />
     </burley_diffuse_bsdf>
-    <convert name="convert" type="color3" xpos="620" ypos="258">
+    <convert name="convert" type="color3">
       <input name="in" type="float" nodename="image" />
     </convert>
-    <image name="image" type="float" xpos="315" ypos="668">
+    <image name="image" type="float">
       <input name="file" type="filename" uniform="true" interfacename="opacity_file" />
     </image>
-    <standard_surface name="ss_opacity" type="surfaceshader" version="1.0.1" xpos="925" ypos="1269">
+    <standard_surface name="ss_opacity" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" value="1, 0.1, 0.2" />
     </standard_surface>
-    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1" xpos="925" ypos="9">
+    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
     </standard_surface>
-    <standard_surface name="ss_transmission" type="surfaceshader" version="1.0.1" xpos="925" ypos="1656">
+    <standard_surface name="ss_transmission" type="surfaceshader" version="1.0.1">
       <input name="transmission" type="float" value="0.1" />
       <input name="transmission_color" type="color3" value="0, 1, 0" />
       <input name="transmission_depth" type="float" value="20" />
       <input name="transmission_scatter" type="color3" value="1, 1, 1" />
       <input name="transmission_dispersion" type="float" value="20" />
     </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1" xpos="925" ypos="639">
+    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
       <input name="transmission" type="float" nodename="image" />
     </standard_surface>
-    <surface name="surface_opacity_mapped" type="surfaceshader" xpos="925" ypos="1026">
+    <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" nodename="image" />
     </surface>
-    <surface name="surface_opacity_unmapped" type="surfaceshader" xpos="925" ypos="396">
+    <surface name="surface_opacity_unmapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="burley_diffuse_bsdf" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" value="0.2" />
     </surface>
-    <conductor_bsdf name="conductor_bsdf" type="BSDF" xpos="315" ypos="1079" />
-    <mix name="mix" type="BSDF" xpos="656.186" ypos="938.924">
+    <conductor_bsdf name="conductor_bsdf" type="BSDF" />
+    <mix name="mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="burley_diffuse_bsdf" />
       <input name="bg" type="BSDF" nodename="conductor_bsdf" />
       <input name="mix" type="float" value="0.5" />
@@ -74,42 +74,42 @@
   <output name="surf_opacity_mapped" nodename="transptype_1" output="surf_opacity_mapped" type="surfaceshader" />
   <output name="ss_opacity_unmapped_out" nodename="transptype_1" output="ss_opacity_unmapped_out" type="surfaceshader" />
   <output name="ss_transm_unmapped_out" nodename="transptype_1" output="ss_transm_unmapped_out" type="surfaceshader" />
-  <nodegraph name="NG_transpGraph_proc0" xpos="766.624" ypos="438.194" nodedef="ND_transpGraph_proc0">
+  <nodegraph name="NG_transpGraph_proc0" nodedef="ND_transpGraph_proc0">
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="repeat" type="vector2" value="4, 4" />
-    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF" xpos="811.986" ypos="945.964">
+    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF">
       <input name="color" type="color3" interfacename="diffuse_color" value="0.18, 0.18, 0.18" />
     </burley_diffuse_bsdf>
-    <convert name="convert" type="color3" xpos="1230" ypos="99">
+    <convert name="convert" type="color3">
       <input name="in" type="float" nodename="ramp4" />
     </convert>
-    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1" xpos="1535" ypos="11.3131">
+    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
     </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1" xpos="1535" ypos="396">
+    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
       <input name="transmission" type="float" nodename="ramp4" />
     </standard_surface>
-    <surface name="surface_opacity_mapped" type="surfaceshader" xpos="1421.99" ypos="938.708">
+    <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" nodename="ramp4" />
     </surface>
-    <ramp4 name="ramp4" type="float" xpos="811.986" ypos="315.964">
+    <ramp4 name="ramp4" type="float">
       <input name="valuetr" type="float" value="1" />
       <input name="valuebl" type="float" value="1" />
       <input name="valuebr" type="float" value="0" />
       <input name="texcoord" type="vector2" nodename="modulo" />
     </ramp4>
-    <texcoord name="texcoord" type="vector2" xpos="-103.014" ypos="585.964" />
-    <multiply name="multiply" type="vector2" xpos="201.986" ypos="580.964">
+    <texcoord name="texcoord" type="vector2" />
+    <multiply name="multiply" type="vector2">
       <input name="in1" type="vector2" nodename="texcoord" />
       <input name="in2" type="vector2" interfacename="repeat" value="4, 4" />
     </multiply>
-    <modulo name="modulo" type="vector2" xpos="506.986" ypos="495.964">
+    <modulo name="modulo" type="vector2">
       <input name="in1" type="vector2" nodename="multiply" />
     </modulo>
-    <conductor_bsdf name="conductor_bsdf" type="BSDF" xpos="811.986" ypos="606.964" />
-    <mix name="mix" type="BSDF" xpos="1095.64" ypos="869.527">
+    <conductor_bsdf name="conductor_bsdf" type="BSDF" />
+    <mix name="mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="conductor_bsdf" />
       <input name="bg" type="BSDF" nodename="burley_diffuse_bsdf" />
       <input name="mix" type="float" value="0.5" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx
@@ -1,44 +1,44 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="transpGraph_image" xpos="475.085" ypos="425.724">
-    <input name="opacity_file" type="filename" uniform="true" value="resources/Images/grid.png" />
-    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF" xpos="315" ypos="401">
+  <nodegraph name="transpGraph_image">
+    <input name="opacity_file" type="filename" value="resources/Images/grid.png" />
+    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF">
       <input name="color" type="color3" value="0.8, 0.8, 0.8" />
     </burley_diffuse_bsdf>
-    <convert name="convert" type="color3" xpos="620" ypos="258">
+    <convert name="convert" type="color3">
       <input name="in" type="float" nodename="image" />
     </convert>
-    <image name="image" type="float" xpos="315" ypos="668">
-      <input name="file" type="filename" uniform="true" interfacename="opacity_file" />
+    <image name="image" type="float">
+      <input name="file" type="filename" interfacename="opacity_file" />
     </image>
-    <standard_surface name="ss_opacity" type="surfaceshader" version="1.0.1" xpos="925" ypos="1269">
+    <standard_surface name="ss_opacity" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" value="1, 0.1, 0.2" />
     </standard_surface>
-    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1" xpos="925" ypos="9">
+    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
     </standard_surface>
-    <standard_surface name="ss_transmission" type="surfaceshader" version="1.0.1" xpos="925" ypos="1656">
+    <standard_surface name="ss_transmission" type="surfaceshader" version="1.0.1">
       <input name="transmission" type="float" value="0.1" />
       <input name="transmission_color" type="color3" value="0, 1, 0" />
       <input name="transmission_depth" type="float" value="20" />
       <input name="transmission_scatter" type="color3" value="1, 1, 1" />
       <input name="transmission_dispersion" type="float" value="20" />
     </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1" xpos="925" ypos="639">
+    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
       <input name="transmission" type="float" nodename="image" />
     </standard_surface>
-    <surface name="surface_opacity_mapped" type="surfaceshader" xpos="925" ypos="1026">
+    <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" nodename="image" />
     </surface>
-    <surface name="surface_opacity_unmapped" type="surfaceshader" xpos="925" ypos="396">
+    <surface name="surface_opacity_unmapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="burley_diffuse_bsdf" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" value="0.2" />
     </surface>
-    <conductor_bsdf name="conductor_bsdf" type="BSDF" xpos="315" ypos="1079" />
-    <mix name="mix" type="BSDF" xpos="656.186" ypos="938.924">
+    <conductor_bsdf name="conductor_bsdf" type="BSDF" />
+    <mix name="mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="burley_diffuse_bsdf" />
       <input name="bg" type="BSDF" nodename="conductor_bsdf" />
       <input name="mix" type="float" value="0.5" />
@@ -50,42 +50,42 @@
     <output name="ss_opacity_unmapped_out" type="surfaceshader" nodename="ss_opacity" />
     <output name="ss_transm_unmapped_out" type="surfaceshader" nodename="ss_transmission" />
   </nodegraph>
-  <nodegraph name="transpGraph_proc" xpos="766.624" ypos="438.194">
+  <nodegraph name="transpGraph_proc">
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="repeat" type="vector2" value="4, 4" />
-    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF" xpos="811.986" ypos="945.964">
+    <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF">
       <input name="color" type="color3" interfacename="diffuse_color" value="0.18, 0.18, 0.18" />
     </burley_diffuse_bsdf>
-    <convert name="convert" type="color3" xpos="1230" ypos="99">
+    <convert name="convert" type="color3">
       <input name="in" type="float" nodename="ramp4" />
     </convert>
-    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1" xpos="1535" ypos="11.3131">
+    <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
     </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1" xpos="1535" ypos="396">
+    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
       <input name="transmission" type="float" nodename="ramp4" />
     </standard_surface>
-    <surface name="surface_opacity_mapped" type="surfaceshader" xpos="1421.99" ypos="938.708">
+    <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" nodename="ramp4" />
     </surface>
-    <ramp4 name="ramp4" type="float" xpos="811.986" ypos="315.964">
+    <ramp4 name="ramp4" type="float">
       <input name="valuetr" type="float" value="1" />
       <input name="valuebl" type="float" value="1" />
       <input name="valuebr" type="float" value="0" />
       <input name="texcoord" type="vector2" nodename="modulo" />
     </ramp4>
-    <texcoord name="texcoord" type="vector2" xpos="-103.014" ypos="585.964" />
-    <multiply name="multiply" type="vector2" xpos="201.986" ypos="580.964">
+    <texcoord name="texcoord" type="vector2" />
+    <multiply name="multiply" type="vector2">
       <input name="in1" type="vector2" nodename="texcoord" />
       <input name="in2" type="vector2" interfacename="repeat" value="4, 4" />
     </multiply>
-    <modulo name="modulo" type="vector2" xpos="506.986" ypos="495.964">
+    <modulo name="modulo" type="vector2">
       <input name="in1" type="vector2" nodename="multiply" />
     </modulo>
-    <conductor_bsdf name="conductor_bsdf" type="BSDF" xpos="811.986" ypos="606.964" />
-    <mix name="mix" type="BSDF" xpos="1095.64" ypos="869.527">
+    <conductor_bsdf name="conductor_bsdf" type="BSDF" />
+    <mix name="mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="conductor_bsdf" />
       <input name="bg" type="BSDF" nodename="burley_diffuse_bsdf" />
       <input name="mix" type="float" value="0.5" />

--- a/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
@@ -13,26 +13,26 @@
   - hsvadjust
   - saturate
   -->
-  <nodegraph name="rgb_to_hsv_to_rgb_color3" type="" xpos="6.05808" ypos="15.2766">
-    <hsvtorgb name="hsvtorgb1" type="color3" xpos="4.42069" ypos="7.5">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="rgbtohsv1" />
+  <nodegraph name="rgb_to_hsv_to_rgb_color3">
+    <hsvtorgb name="hsvtorgb1" type="color3">
+      <input name="in" type="color3" nodename="rgbtohsv1" />
     </hsvtorgb>
-    <rgbtohsv name="rgbtohsv1" type="color3" xpos="5.90819" ypos="6.67748">
+    <rgbtohsv name="rgbtohsv1" type="color3">
       <input name="in" type="color3" value="0.5, 0.5, 0.5" />
     </rgbtohsv>
     <output name="out" type="color3" nodename="hsvtorgb1" />
   </nodegraph>
-  <nodegraph name="rgb_to_hsv_to_rgb_color4" type="" xpos="7.04042" ypos="15.2612">
-    <hsvtorgb name="hsvtorgb1" type="color4" xpos="6.00513" ypos="6.8723">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" nodename="rgbtohsv1" />
+  <nodegraph name="rgb_to_hsv_to_rgb_color4">
+    <hsvtorgb name="hsvtorgb1" type="color4">
+      <input name="in" type="color4" nodename="rgbtohsv1" />
     </hsvtorgb>
-    <rgbtohsv name="rgbtohsv1" type="color4" xpos="6.39423" ypos="5.84506">
+    <rgbtohsv name="rgbtohsv1" type="color4">
       <input name="in" type="color4" value="0.5, 0.5, 0.5, 1.0" />
     </rgbtohsv>
     <output name="out" type="color4" nodename="hsvtorgb1" />
   </nodegraph>
-  <nodegraph name="remap_float" type="" xpos="6.02734" ypos="17.9519">
-    <remap name="remap1" type="float" xpos="5" ypos="10.24">
+  <nodegraph name="remap_float">
+    <remap name="remap1" type="float">
       <input name="in" type="float" value="0.2000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -41,8 +41,8 @@
     </remap>
     <output name="out" type="float" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_color2" type="" xpos="7.03834" ypos="17.9585">
-    <remap name="remap1" type="vector2" xpos="5" ypos="10.24">
+  <nodegraph name="remap_color2">
+    <remap name="remap1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="vector2" value="0.1000, -0.2000" />
       <input name="inhigh" type="vector2" value="0.9000, 1.2000" />
@@ -51,8 +51,8 @@
     </remap>
     <output name="out" type="vector2" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_color2FA" type="" xpos="8.02426" ypos="17.9496">
-    <remap name="remap1" type="vector2" xpos="5" ypos="10.24">
+  <nodegraph name="remap_color2FA">
+    <remap name="remap1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -61,8 +61,8 @@
     </remap>
     <output name="out" type="vector2" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_color3" type="" xpos="9.01287" ypos="17.9537">
-    <remap name="remap1" type="vector3" xpos="5" ypos="10.24">
+  <nodegraph name="remap_color3">
+    <remap name="remap1" type="vector3">
       <input name="in" type="vector3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="vector3" value="0.1000, -0.2000, 0.4000" />
       <input name="inhigh" type="vector3" value="0.9000, 1.2000, 0.6000" />
@@ -71,8 +71,8 @@
     </remap>
     <output name="out" type="vector3" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_color3FA" type="" xpos="7.02628" ypos="19.1991">
-    <remap name="remap1" type="color3" xpos="5" ypos="10.24">
+  <nodegraph name="remap_color3FA">
+    <remap name="remap1" type="color3">
       <input name="in" type="color3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -81,8 +81,8 @@
     </remap>
     <output name="out" type="color3" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_color4" type="" xpos="8.02614" ypos="19.1626">
-    <remap name="remap1" type="color4" xpos="5" ypos="10.24">
+  <nodegraph name="remap_color4">
+    <remap name="remap1" type="color4">
       <input name="in" type="color4" value="0.2000, 0.6000, 0.8000, 1.0" />
       <input name="inlow" type="color4" value="0.1000, -0.2000, 0.4000, 0.0" />
       <input name="inhigh" type="color4" value="0.9000, 1.2000, 0.6000, 1.0" />
@@ -91,8 +91,8 @@
     </remap>
     <output name="out" type="color4" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_color4FA" type="" xpos="9.04342" ypos="19.1525">
-    <remap name="remap1" type="color4" xpos="5" ypos="10.24">
+  <nodegraph name="remap_color4FA">
+    <remap name="remap1" type="color4">
       <input name="in" type="color4" value="0.2000, 0.6000, 0.8000, 1.0000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -101,8 +101,8 @@
     </remap>
     <output name="out" type="color4" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_vector2" type="" xpos="7.01931" ypos="20.476">
-    <remap name="remap1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="remap_vector2">
+    <remap name="remap1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="vector2" value="0.1000, -0.2000" />
       <input name="inhigh" type="vector2" value="0.9000, 1.2000" />
@@ -111,8 +111,8 @@
     </remap>
     <output name="out" type="vector2" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_vector2FA" type="" xpos="8.041" ypos="20.4335">
-    <remap name="remap1" type="vector2" xpos="6.2069" ypos="7.14">
+  <nodegraph name="remap_vector2FA">
+    <remap name="remap1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -121,8 +121,8 @@
     </remap>
     <output name="out" type="vector2" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_vector3" type="" xpos="9.05757" ypos="20.4315">
-    <remap name="remap1" type="vector3" xpos="5.74483" ypos="5.56">
+  <nodegraph name="remap_vector3">
+    <remap name="remap1" type="vector3">
       <input name="in" type="vector3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="vector3" value="0.1000, -0.2000, 0.4000" />
       <input name="inhigh" type="vector3" value="0.9000, 1.2000, 0.6000" />
@@ -131,8 +131,8 @@
     </remap>
     <output name="out" type="vector3" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_vector3FA" type="" xpos="6.99933" ypos="21.6661">
-    <remap name="remap1" type="vector3" xpos="5.74483" ypos="5.56">
+  <nodegraph name="remap_vector3FA">
+    <remap name="remap1" type="vector3">
       <input name="in" type="vector3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -141,8 +141,8 @@
     </remap>
     <output name="out" type="vector3" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_vector4" type="" xpos="8.05842" ypos="21.6156">
-    <remap name="remap1" type="vector4" xpos="5.74483" ypos="5.56">
+  <nodegraph name="remap_vector4">
+    <remap name="remap1" type="vector4">
       <input name="in" type="vector4" value="0.2000, 0.6000, 0.8000, 1.0" />
       <input name="inlow" type="vector4" value="0.1000, -0.2000, 0.4000, 0.0" />
       <input name="inhigh" type="vector4" value="0.9000, 1.2000, 0.6000, 1.0" />
@@ -151,8 +151,8 @@
     </remap>
     <output name="out" type="vector4" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="remap_vector4FA" type="" xpos="9.07848" ypos="21.6439">
-    <remap name="remap1" type="vector4" xpos="5.74483" ypos="5.56">
+  <nodegraph name="remap_vector4FA">
+    <remap name="remap1" type="vector4">
       <input name="in" type="vector4" value="0.2000, 0.6000, 0.8000, 1.0" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -162,176 +162,176 @@
     <output name="out" type="vector4" nodename="remap1" />
   </nodegraph>
   <!--
-  <nodegraph name="curveadjust_float" type="" xpos="6.08445" ypos="34.3366">
-    <curveadjust name="curveadjust1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="curveadjust_float">
+    <curveadjust name="curveadjust1" type="float">
       <input name="in" type="float" value="0.5000" />
       <input name="knots" type="vector2array" value="" />
     </curveadjust>
     <output name="out" type="float" nodename="curveadjust1" />
   </nodegraph>
-  <nodegraph name="curveadjust_color2" type="" xpos="7.06648" ypos="34.351">
-    <curveadjust name="curveadjust1" type="color2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="curveadjust_color2">
+    <curveadjust name="curveadjust1" type="color2">
       <input name="in" type="color2" value="1.0000, 0.5000" />
       <input name="knots" type="vector2array" value="" />
     </curveadjust>
     <output name="out" type="color2" nodename="curveadjust1" />
   </nodegraph>
-  <nodegraph name="curveadjust_color3" type="" xpos="8.13078" ypos="34.351">
-    <curveadjust name="curveadjust1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="curveadjust_color3">
+    <curveadjust name="curveadjust1" type="color3">
       <input name="in" type="color3" value="1.0000, 0.0, 0.5000" />
       <input name="knots" type="vector2array" value="" />
     </curveadjust>
     <output name="out" type="color3" nodename="curveadjust1" />
   </nodegraph>
-  <nodegraph name="curveadjust_color4" type="" xpos="9.17608" ypos="34.3372">
-    <curveadjust name="curveadjust1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="curveadjust_color4">
+    <curveadjust name="curveadjust1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.0, 0.5000, 0.5000" />
       <input name="knots" type="vector2array" value="" />
     </curveadjust>
     <output name="out" type="color4" nodename="curveadjust1" />
   </nodegraph>
-  <nodegraph name="curveadjust_vector2" type="" xpos="7.07077" ypos="35.7288">
-    <curveadjust name="curveadjust1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="curveadjust_vector2">
+    <curveadjust name="curveadjust1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.5000" />
       <input name="knots" type="vector2array" value="" />
     </curveadjust>
     <output name="out" type="vector2" nodename="curveadjust1" />
   </nodegraph>
-  <nodegraph name="curveadjust_vector3" type="" xpos="8.13982" ypos="35.715">
-    <curveadjust name="curveadjust1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="curveadjust_vector3">
+    <curveadjust name="curveadjust1" type="vector3">
       <input name="in" type="vector3" value="1.0000, 0.0, 0.5000" />
       <input name="knots" type="vector2array" value="" />
     </curveadjust>
     <output name="out" type="vector3" nodename="curveadjust1" />
   </nodegraph>
-  <nodegraph name="curveadjust_vector4" type="" xpos="9.18512" ypos="35.6876">
-    <curveadjust name="curveadjust1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="curveadjust_vector4">
+    <curveadjust name="curveadjust1" type="vector4">
       <input name="in" type="vector4" value="1.0000, 0.0, 0.5000, 0.5000" />
       <input name="knots" type="vector2array" value="" />
     </curveadjust>
     <output name="out" type="vector4" nodename="curveadjust1" />
   </nodegraph>
 !-->
-  <nodegraph name="luminance_color3" type="" xpos="6.10149" ypos="37.0378">
-    <luminance name="luminance1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="luminance_color3">
+    <luminance name="luminance1" type="color3">
       <input name="in" type="color3" value="1.0000, 0.7500, 0.5000" />
       <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />
     </luminance>
     <output name="out" type="color3" nodename="luminance1" />
   </nodegraph>
-  <nodegraph name="luminance_color4" type="" xpos="7.07552" ypos="37.024">
-    <luminance name="luminance1" type="color4" xpos="5.74483" ypos="4.73222">
+  <nodegraph name="luminance_color4">
+    <luminance name="luminance1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.7500, 0.5000, 0.2500" />
       <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />
     </luminance>
     <output name="out" type="color4" nodename="luminance1" />
   </nodegraph>
-  <nodegraph name="contrast_float" type="" xpos="6.09198" ypos="38.5398">
-    <contrast name="contrast1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_float">
+    <contrast name="contrast1" type="float">
       <input name="in" type="float" value="1.0000" />
       <input name="amount" type="float" value="0.0000" />
       <input name="pivot" type="float" value="0.5" />
     </contrast>
     <output name="out" type="float" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_color2" type="" xpos="7.08502" ypos="38.526">
-    <contrast name="contrast1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_color2">
+    <contrast name="contrast1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.5000" />
       <input name="amount" type="vector2" value="0.0, 0.5000" />
       <input name="pivot" type="vector2" value="0.5, 0.5" />
     </contrast>
     <output name="out" type="vector2" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_color2FA" type="" xpos="8.13507" ypos="38.526">
-    <contrast name="contrast1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_color2FA">
+    <contrast name="contrast1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.5000" />
       <input name="amount" type="float" value="1.0000" />
       <input name="pivot" type="float" value="0.5" />
     </contrast>
     <output name="out" type="vector2" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_color3" type="" xpos="9.19937" ypos="38.5122">
-    <contrast name="contrast1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_color3">
+    <contrast name="contrast1" type="color3">
       <input name="in" type="color3" value="1.0000, 0.5000, 0.2000" />
       <input name="amount" type="color3" value="0.0000, 0.5000, 1.0000" />
       <input name="pivot" type="color3" value="0.5, 0.5, 0.5" />
     </contrast>
     <output name="out" type="color3" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_color3FA" type="" xpos="7.06323" ypos="39.9146">
-    <contrast name="contrast1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_color3FA">
+    <contrast name="contrast1" type="color3">
       <input name="in" type="color3" value="1.0000, 0.5000, 0.2000" />
       <input name="amount" type="float" value="1.0000" />
       <input name="pivot" type="float" value="0.5" />
     </contrast>
     <output name="out" type="color3" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_color4" type="" xpos="8.12279" ypos="39.882">
-    <contrast name="contrast1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_color4">
+    <contrast name="contrast1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.5000, 0.2000, 1.0" />
       <input name="amount" type="color4" value="0.0, 0.5000, 1.0000, 1.0" />
       <input name="pivot" type="color4" value="0.5, 0.5, 0.5, 0.5" />
     </contrast>
     <output name="out" type="color4" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_color4FA" type="" xpos="9.2061" ypos="39.8544">
-    <contrast name="contrast1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_color4FA">
+    <contrast name="contrast1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.5000, 0.2000, 1.0" />
       <input name="amount" type="float" value="1.0000" />
       <input name="pivot" type="float" value="0.5" />
     </contrast>
     <output name="out" type="color4" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_vector2" type="" xpos="7.07323" ypos="41.2942">
-    <contrast name="contrast1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_vector2">
+    <contrast name="contrast1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.5000" />
       <input name="amount" type="vector2" value="0.0000, 0.5000" />
       <input name="pivot" type="vector2" value="0.5, 0.5" />
     </contrast>
     <output name="out" type="vector2" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_vector2FA" type="" xpos="8.12803" ypos="41.2666">
-    <contrast name="contrast1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_vector2FA">
+    <contrast name="contrast1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.5000" />
       <input name="amount" type="float" value="1.0000" />
       <input name="pivot" type="float" value="0.5" />
     </contrast>
     <output name="out" type="vector2" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_vector3" type="" xpos="9.2161" ypos="41.2528">
-    <contrast name="contrast1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_vector3">
+    <contrast name="contrast1" type="vector3">
       <input name="in" type="vector3" value="1.0000, 0.5000, 0.2000" />
       <input name="amount" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="pivot" type="vector3" value="0.5, 0.5, 0.5" />
     </contrast>
     <output name="out" type="vector3" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="constrast_vector3FA" type="" xpos="7.05897" ypos="42.741">
-    <contrast name="contrast1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="constrast_vector3FA">
+    <contrast name="contrast1" type="vector3">
       <input name="in" type="vector3" value="1.0000, 0.5000, 0.2000" />
       <input name="amount" type="float" value="1.0000" />
       <input name="pivot" type="float" value="0.5" />
     </contrast>
     <output name="out" type="vector3" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_vector4" type="" xpos="8.14592" ypos="42.6996">
-    <contrast name="contrast1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="contrast_vector4">
+    <contrast name="contrast1" type="vector4">
       <input name="in" type="vector4" value="1.0000, 0.5000, 0.2000, 1.0" />
       <input name="amount" type="vector4" value="0.0, 0.5000, 1.0000, 1.0" />
       <input name="pivot" type="vector4" value="0.5, 0.5, 0.5, 0.5" />
     </contrast>
     <output name="out" type="vector4" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="contrast_vector4FA" type="" xpos="9.22085" ypos="42.6858">
-    <contrast name="contrast1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="contrast_vector4FA">
+    <contrast name="contrast1" type="vector4">
       <input name="in" type="vector4" value="1.0000, 0.5000, 0.2000, 1.0" />
       <input name="amount" type="float" value="1.0000" />
       <input name="pivot" type="float" value="0.5" />
     </contrast>
     <output name="out" type="vector4" nodename="contrast1" />
   </nodegraph>
-  <nodegraph name="range_float" type="" xpos="6.07417" ypos="23.3842">
-    <range name="range1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="range_float">
+    <range name="range1" type="float">
       <input name="in" type="float" value="0.2000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -342,8 +342,8 @@
     </range>
     <output name="out" type="float" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_color2" type="" xpos="7.04345" ypos="23.3855">
-    <range name="range1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="range_color2">
+    <range name="range1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="vector2" value="0.1000, -0.2000" />
       <input name="inhigh" type="vector2" value="0.9000, 1.2000" />
@@ -354,8 +354,8 @@
     </range>
     <output name="out" type="vector2" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_color2FA" type="" xpos="8.11251" ypos="23.3717">
-    <range name="range1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="range_color2FA">
+    <range name="range1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -366,8 +366,8 @@
     </range>
     <output name="out" type="vector2" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_color3" type="" xpos="9.18157" ypos="23.3304">
-    <range name="range1" type="color3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_color3">
+    <range name="range1" type="color3">
       <input name="in" type="color3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="color3" value="0.1000, -0.2000, 0.4000" />
       <input name="inhigh" type="color3" value="0.9000, 1.2000, 0.6000" />
@@ -378,8 +378,8 @@
     </range>
     <output name="out" type="color3" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_color3FA" type="" xpos="7.05295" ypos="24.7634">
-    <range name="range1" type="color3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_color3FA">
+    <range name="range1" type="color3">
       <input name="in" type="color3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -390,8 +390,8 @@
     </range>
     <output name="out" type="color3" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_color4" type="" xpos="8.0989" ypos="24.7372">
-    <range name="range1" type="color4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_color4">
+    <range name="range1" type="color4">
       <input name="in" type="color4" value="0.2000, 0.6000, 0.8000, 1.0" />
       <input name="inlow" type="color4" value="0.1000, -0.2000, 0.4000, 0.0" />
       <input name="inhigh" type="color4" value="0.9000, 1.2000, 0.6000, 1.0" />
@@ -402,8 +402,8 @@
     </range>
     <output name="out" type="color4" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_color4FA" type="" xpos="9.16796" ypos="24.6959">
-    <range name="range1" type="color4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_color4FA">
+    <range name="range1" type="color4">
       <input name="in" type="color4" value="0.2000, 0.6000, 0.8000, 1.0" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -414,8 +414,8 @@
     </range>
     <output name="out" type="color4" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_vector2" type="" xpos="7.0631" ypos="26.1702">
-    <range name="range1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_vector2">
+    <range name="range1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="vector2" value="0.1000, -0.2000" />
       <input name="inhigh" type="vector2" value="0.9000, 1.2000" />
@@ -426,8 +426,8 @@
     </range>
     <output name="out" type="vector2" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_vector2FA" type="" xpos="8.13216" ypos="26.1151">
-    <range name="range1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_vector2FA">
+    <range name="range1" type="vector2">
       <input name="in" type="vector2" value="0.2000, 0.5000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -438,8 +438,8 @@
     </range>
     <output name="out" type="vector2" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_vector3" type="" xpos="9.17271" ypos="26.0738">
-    <range name="range1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_vector3">
+    <range name="range1" type="vector3">
       <input name="in" type="vector3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="vector3" value="0.1000, -0.2000, 0.4000" />
       <input name="inhigh" type="vector3" value="0.9000, 1.2000, 0.6000" />
@@ -450,8 +450,8 @@
     </range>
     <output name="out" type="vector3" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_vector3FA" type="" xpos="7.0536" ypos="27.6032">
-    <range name="range1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_vector3FA">
+    <range name="range1" type="vector3">
       <input name="in" type="vector3" value="0.2000, 0.6000, 0.8000" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -462,8 +462,8 @@
     </range>
     <output name="out" type="vector3" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_vector4" type="" xpos="8.11791" ypos="27.5757">
-    <range name="range1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_vector4">
+    <range name="range1" type="vector4">
       <input name="in" type="vector4" value="0.2000, 0.6000, 0.8000, 1.0" />
       <input name="inlow" type="vector4" value="0.1000, -0.2000, 0.4000, 0.0" />
       <input name="inhigh" type="vector4" value="0.9000, 1.2000, 0.6000, 1.0" />
@@ -474,8 +474,8 @@
     </range>
     <output name="out" type="vector4" nodename="range1" />
   </nodegraph>
-  <nodegraph name="range_vector4FA" type="" xpos="9.17746" ypos="27.5343">
-    <range name="range1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="range_vector4FA">
+    <range name="range1" type="vector4">
       <input name="in" type="vector4" value="0.2000, 0.6000, 0.8000, 1.0" />
       <input name="inlow" type="float" value="0.1000" />
       <input name="inhigh" type="float" value="0.9000" />
@@ -486,30 +486,30 @@
     </range>
     <output name="out" type="vector4" nodename="range1" />
   </nodegraph>
-  <nodegraph name="hsvadjust_color3" type="" xpos="6.03739" ypos="44.3042">
-    <hsvadjust name="hsvadjust1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="hsvadjust_color3">
+    <hsvadjust name="hsvadjust1" type="color3">
       <input name="in" type="color3" value="0.5000, 0.5000, 0.5000" />
       <input name="amount" type="vector3" value="1.0000, 0.7500, 0.5000" />
     </hsvadjust>
     <output name="out" type="color3" nodename="hsvadjust1" />
   </nodegraph>
-  <nodegraph name="hsvadjust_color4" type="" xpos="7.04579" ypos="44.2892">
-    <hsvadjust name="hsvadjust1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="hsvadjust_color4">
+    <hsvadjust name="hsvadjust1" type="color4">
       <input name="in" type="color4" value="0.5000, 0.5000, 0.5000, 0.5000" />
       <input name="amount" type="vector3" value="1.0000, 0.7500, 0.5000" />
     </hsvadjust>
     <output name="out" type="color4" nodename="hsvadjust1" />
   </nodegraph>
-  <nodegraph name="saturate_color3" type="" xpos="6.02899" ypos="45.8736">
-    <saturate name="saturate1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="saturate_color3">
+    <saturate name="saturate1" type="color3">
       <input name="in" type="color3" value="1.0000, 0.5000, 0.2500" />
       <input name="amount" type="float" value="0.5000" />
       <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />
     </saturate>
     <output name="out" type="color3" nodename="saturate1" />
   </nodegraph>
-  <nodegraph name="saturate_color4" type="" xpos="7.05529" ypos="45.8386">
-    <saturate name="saturate1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="saturate_color4">
+    <saturate name="saturate1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.5000, 0.2500, 1.0" />
       <input name="amount" type="float" value="0.5000" />
       <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" />

--- a/resources/Materials/TestSuite/stdlib/adjustment/hsvtorgb.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/hsvtorgb.mtlx
@@ -5,20 +5,20 @@
   - rgbtohsv
   - hsvtorgb
   -->
-  <nodegraph name="rgb_to_hsv_to_rgb_color3" type="" xpos="6.05808" ypos="15.2766">
-    <hsvtorgb name="hsvtorgb1" type="color3" xpos="4.42069" ypos="7.5">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="rgbtohsv1" />
+  <nodegraph name="rgb_to_hsv_to_rgb_color3">
+    <hsvtorgb name="hsvtorgb1" type="color3">
+      <input name="in" type="color3" nodename="rgbtohsv1" />
     </hsvtorgb>
-    <rgbtohsv name="rgbtohsv1" type="color3" xpos="5.90819" ypos="6.67748">
+    <rgbtohsv name="rgbtohsv1" type="color3">
       <input name="in" type="color3" value="0.5, 0.5, 0.5" />
     </rgbtohsv>
     <output name="out" type="color3" nodename="hsvtorgb1" />
   </nodegraph>
-  <nodegraph name="rgb_to_hsv_to_rgb_color4" type="" xpos="7.04042" ypos="15.2612">
-    <hsvtorgb name="hsvtorgb1" type="color4" xpos="6.00513" ypos="6.8723">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" nodename="rgbtohsv1" />
+  <nodegraph name="rgb_to_hsv_to_rgb_color4">
+    <hsvtorgb name="hsvtorgb1" type="color4">
+      <input name="in" type="color4" nodename="rgbtohsv1" />
     </hsvtorgb>
-    <rgbtohsv name="rgbtohsv1" type="color4" xpos="6.39423" ypos="5.84506">
+    <rgbtohsv name="rgbtohsv1" type="color4">
       <input name="in" type="color4" value="0.5, 0.5, 0.5, 1.0" />
     </rgbtohsv>
     <output name="out" type="color4" nodename="hsvtorgb1" />

--- a/resources/Materials/TestSuite/stdlib/adjustment/smoothstep.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/smoothstep.mtlx
@@ -4,112 +4,112 @@
   Basic adjustment function tests each test is in a separate graph for each variation in input type.
   - smoothstep
   -->
-  <nodegraph name="smoothstep_float_range_min" type="" xpos="6.07605" ypos="29.1097">
-    <smoothstep name="smoothstep1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="smoothstep_float_range_min">
+    <smoothstep name="smoothstep1" type="float">
       <input name="in" type="float" value="0.2000" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />
     </smoothstep>
     <output name="out" type="float" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_float_range_max" type="" xpos="6.07605" ypos="29.1097">
-    <smoothstep name="smoothstep1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="smoothstep_float_range_max">
+    <smoothstep name="smoothstep1" type="float">
       <input name="in" type="float" value="0.8000" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />
     </smoothstep>
     <output name="out" type="float" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_color2" type="" xpos="7.06205" ypos="29.1176">
-    <smoothstep name="smoothstep1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_color2">
+    <smoothstep name="smoothstep1" type="vector2">
       <input name="in" type="vector2" value="0.6000, 0.5000" />
       <input name="low" type="vector2" value="0.2000, 0.2000" />
       <input name="high" type="vector2" value="0.8000, 0.8000" />
     </smoothstep>
     <output name="out" type="vector2" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_color2FA" type="" xpos="8.09902" ypos="29.1395">
-    <smoothstep name="smoothstep1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_color2FA">
+    <smoothstep name="smoothstep1" type="vector2">
       <input name="in" type="vector2" value="0.6000, 0.5000" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />
     </smoothstep>
     <output name="out" type="vector2" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_color3" type="" xpos="9.12894" ypos="29.1314">
-    <smoothstep name="smoothstep1" type="color3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_color3">
+    <smoothstep name="smoothstep1" type="color3">
       <input name="in" type="color3" value="0.6000, 0.5000, 0.2000" />
       <input name="low" type="color3" value="0.2000, 0.2000, 0.0" />
       <input name="high" type="color3" value="0.8000, 0.8000, 1.0" />
     </smoothstep>
     <output name="out" type="color3" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_color3FA" type="" xpos="7.0691" ypos="30.4265">
-    <smoothstep name="smoothstep1" type="color3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_color3FA">
+    <smoothstep name="smoothstep1" type="color3">
       <input name="in" type="color3" value="0.6000, 0.5000, 0.0000" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />
     </smoothstep>
     <output name="out" type="color3" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_color4" type="" xpos="8.10183" ypos="30.4116">
-    <smoothstep name="smoothstep1" type="color4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_color4">
+    <smoothstep name="smoothstep1" type="color4">
       <input name="in" type="color4" value="0.6000, 0.5000, 0.2000, 1.0" />
       <input name="low" type="color4" value="0.2000, 0.2000, 0.0, 0.0" />
       <input name="high" type="color4" value="0.8000, 0.8000, 1.0, 1.0" />
     </smoothstep>
     <output name="out" type="color4" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_color4FA" type="" xpos="9.13292" ypos="30.4034">
-    <smoothstep name="smoothstep1" type="color4" xpos="5.75172" ypos="4.72">
+  <nodegraph name="smoothstep_color4FA">
+    <smoothstep name="smoothstep1" type="color4">
       <input name="in" type="color4" value="0.6000, 0.5000, 0.0000, 1.0" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />
     </smoothstep>
     <output name="out" type="color4" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_vector2" type="" xpos="7.0691" ypos="31.7173">
-    <smoothstep name="smoothstep1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_vector2">
+    <smoothstep name="smoothstep1" type="vector2">
       <input name="in" type="vector2" value="0.6000, 0.5000" />
       <input name="low" type="vector2" value="0.2000, 0.2000" />
       <input name="high" type="vector2" value="0.8000, 0.8000" />
     </smoothstep>
     <output name="out" type="vector2" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_vector2FA" type="" xpos="8.10624" ypos="31.7044">
-    <smoothstep name="smoothstep1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_vector2FA">
+    <smoothstep name="smoothstep1" type="vector2">
       <input name="in" type="vector2" value="0.6000, 0.5000" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />
     </smoothstep>
     <output name="out" type="vector2" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_vector3" type="" xpos="9.14247" ypos="31.6569">
-    <smoothstep name="smoothstep1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_vector3">
+    <smoothstep name="smoothstep1" type="vector3">
       <input name="in" type="vector3" value="0.6000, 0.5000, 0.2000" />
       <input name="low" type="vector3" value="0.2000, 0.2000, 0.0" />
       <input name="high" type="vector3" value="0.8000, 0.8000, 1.0" />
     </smoothstep>
     <output name="out" type="vector3" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_vector3FA" type="" xpos="7.05728" ypos="33.013">
-    <smoothstep name="smoothstep1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_vector3FA">
+    <smoothstep name="smoothstep1" type="vector3">
       <input name="in" type="vector3" value="0.6000, 0.5000, 0.0" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />
     </smoothstep>
     <output name="out" type="vector3" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_vector4" type="" xpos="8.12072" ypos="32.9952">
-    <smoothstep name="smoothstep1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_vector4">
+    <smoothstep name="smoothstep1" type="vector4">
       <input name="in" type="vector4" value="0.6000, 0.5000, 0.2000, 1.0" />
       <input name="low" type="vector4" value="0.2000, 0.2000, 0.0, 0.0" />
       <input name="high" type="vector4" value="0.8000, 0.8000, 1.0, 1.0" />
     </smoothstep>
     <output name="out" type="vector4" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_vector4FA" type="" xpos="9.14783" ypos="32.9952">
-    <smoothstep name="smoothstep1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="smoothstep_vector4FA">
+    <smoothstep name="smoothstep1" type="vector4">
       <input name="in" type="vector4" value="0.6000, 0.5000, 0.0, 1.0" />
       <input name="low" type="float" value="0.2000" />
       <input name="high" type="float" value="0.8000" />

--- a/resources/Materials/TestSuite/stdlib/application/syntax.mtlx
+++ b/resources/Materials/TestSuite/stdlib/application/syntax.mtlx
@@ -1,32 +1,32 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="syntaxGraph" type="" xpos="6.21379" ypos="15.54">
-    <constant name="gl_consttant" type="float" xpos="3.93793" ypos="5.52012">
+  <nodegraph name="syntaxGraph">
+    <constant name="gl_consttant" type="float">
       <input name="value" type="float" value="0.0" />
     </constant>
-    <convert name="gl_consttant1" type="color3" xpos="6.13762" ypos="4.73084">
-      <input name="in" type="float" value="0.0" nodename="gl_consttant" />
+    <convert name="gl_consttant1" type="color3">
+      <input name="in" type="float" nodename="gl_consttant" />
     </convert>
     <output name="out_gl_constant" type="color3" nodename="gl_consttant1" />
-    <constant name="webgl_constant" type="float" xpos="3.93793" ypos="8.66">
+    <constant name="webgl_constant" type="float">
       <input name="value" type="float" value="0.0" />
     </constant>
-    <convert name="webgl_constant1" type="color3" xpos="6.08276" ypos="8">
-      <input name="in" type="float" value="0.0" nodename="webgl_constant" />
+    <convert name="webgl_constant1" type="color3">
+      <input name="in" type="float" nodename="webgl_constant" />
     </convert>
     <output name="out_webgl_constant" type="color3" nodename="webgl_constant1" />
-    <constant name="_webgl_constant" type="float" xpos="3.93793" ypos="11.78">
+    <constant name="_webgl_constant" type="float">
       <input name="value" type="float" value="0.0" />
     </constant>
-    <convert name="_webgl_constant1" type="color3" xpos="6.08276" ypos="11.12">
-      <input name="in" type="float" value="0.0" nodename="_webgl_constant" />
+    <convert name="_webgl_constant1" type="color3">
+      <input name="in" type="float" nodename="_webgl_constant" />
     </convert>
     <output name="out__webgl_constant" type="color3" nodename="_webgl_constant1" />
-    <constant name="__doubleUnderScore" type="float" xpos="3.93793" ypos="14.9">
+    <constant name="__doubleUnderScore" type="float">
       <input name="value" type="float" value="0.0" />
     </constant>
-    <convert name="__doubleUnderScore1" type="color3" xpos="6.08276" ypos="14.24">
-      <input name="in" type="float" value="0.0" nodename="__doubleUnderScore" />
+    <convert name="__doubleUnderScore1" type="color3">
+      <input name="in" type="float" nodename="__doubleUnderScore" />
     </convert>
     <output name="out__doubleUnderScore" type="color3" nodename="__doubleUnderScore1" />
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/application/timeFrame.mtlx
+++ b/resources/Materials/TestSuite/stdlib/application/timeFrame.mtlx
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="timeGraph" type="" xpos="8.5931" ypos="20.52">
-    <time name="time1" type="float" xpos="3.51724" ypos="7.38">
+  <nodegraph name="timeGraph">
+    <time name="time1" type="float">
       <input name="fps" type="float" value="36.0000" />
     </time>
-    <remap name="remap1" type="float" xpos="5.24828" ypos="7.86">
-      <input name="in" type="float" value="0.0" nodename="time1" />
+    <remap name="remap1" type="float">
+      <input name="in" type="float" nodename="time1" />
       <input name="inlow" type="float" value="0.0" />
       <input name="inhigh" type="float" value="100.0000" />
       <input name="outlow" type="float" value="0.0" />
@@ -13,10 +13,10 @@
     </remap>
     <output name="out" type="float" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="frameGraph" type="" xpos="8.75862" ypos="15.63">
-    <frame name="frame1" type="float" xpos="3.73793" ypos="5.38" />
-    <remap name="remap1" type="float" xpos="5.29655" ypos="7.98">
-      <input name="in" type="float" value="0.0" nodename="frame1" />
+  <nodegraph name="frameGraph">
+    <frame name="frame1" type="float" />
+    <remap name="remap1" type="float">
+      <input name="in" type="float" nodename="frame1" />
       <input name="inlow" type="float" value="0.0" />
       <input name="inhigh" type="float" value="100.0000" />
       <input name="outlow" type="float" value="0.0" />

--- a/resources/Materials/TestSuite/stdlib/application/unique_identifiers.mtlx
+++ b/resources/Materials/TestSuite/stdlib/application/unique_identifiers.mtlx
@@ -6,21 +6,21 @@
     <output name="out" type="float" value="0" />
     <output name="out2" type="float" value="0" />
   </nodedef>
-  <nodegraph name="NG_blah2_float_float" xpos="429.375" ypos="144.668" nodedef="ND_blah2_float_float">
+  <nodegraph name="NG_blah2_float_float" nodedef="ND_blah2_float_float">
     <input name="out1" type="float" value="1" />
     <input name="out3" type="vector2" value="0, 0" />
-    <constant name="constant" type="float" xpos="238.75" ypos="221.893">
+    <constant name="constant" type="float">
       <input name="value" type="float" value="10" uniform="true" uivisible="true" />
     </constant>
-    <multiply name="multiply" type="float" xpos="620" ypos="69.5769">
+    <multiply name="multiply" type="float">
       <input name="in1" type="float" nodename="constant" uivisible="true" />
       <input name="in2" type="float" nodename="swizzle" uivisible="true" />
     </multiply>
-    <multiply name="multiply1" type="float" xpos="620" ypos="288.577">
+    <multiply name="multiply1" type="float">
       <input name="in1" type="float" nodename="constant" uivisible="true" />
       <input name="in2" type="float" interfacename="out1" value="1" uivisible="true" />
     </multiply>
-    <swizzle name="swizzle" type="float" xpos="238.75" ypos="4.31593">
+    <swizzle name="swizzle" type="float">
       <input name="in" type="vector2" interfacename="out3" value="0, 0" uivisible="true" />
     </swizzle>
     <output name="out" type="float" nodename="multiply" />

--- a/resources/Materials/TestSuite/stdlib/channel/channel.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/channel.mtlx
@@ -1,37 +1,37 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="combine_color2" type="" xpos="6.25517" ypos="49.37">
-    <combine2 name="combine1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="combine_color2">
+    <combine2 name="combine1" type="vector2">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
     </combine2>
     <output name="out" type="vector2" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_vector2" type="" xpos="7.32069" ypos="49.35">
-    <combine2 name="combine1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="combine_vector2">
+    <combine2 name="combine1" type="vector2">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
     </combine2>
     <output name="out" type="vector2" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_color3" type="" xpos="8.36207" ypos="49.32">
-    <combine3 name="combine1" type="color3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="combine_color3">
+    <combine3 name="combine1" type="color3">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
       <input name="in3" type="float" value="0.2500" />
     </combine3>
     <output name="out" type="color3" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_vector3" type="" xpos="9.38276" ypos="49.32">
-    <combine3 name="combine1" type="vector3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="combine_vector3">
+    <combine3 name="combine1" type="vector3">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
       <input name="in3" type="float" value="0.2500" />
     </combine3>
     <output name="out" type="vector3" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_color4" type="" xpos="7.32759" ypos="50.72">
-    <combine4 name="combine1" type="color4" xpos="5.74483" ypos="4.28">
+  <nodegraph name="combine_color4">
+    <combine4 name="combine1" type="color4">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
       <input name="in3" type="float" value="0.2500" />
@@ -39,8 +39,8 @@
     </combine4>
     <output name="out" type="color4" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_vector4" type="" xpos="8.35862" ypos="50.7">
-    <combine4 name="combine1" type="vector4" xpos="5.74483" ypos="4.28">
+  <nodegraph name="combine_vector4">
+    <combine4 name="combine1" type="vector4">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
       <input name="in3" type="float" value="0.2500" />
@@ -48,64 +48,64 @@
     </combine4>
     <output name="out" type="vector4" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_color4CF" type="" xpos="9.3931" ypos="50.68">
-    <combine2 name="combine1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="combine_color4CF">
+    <combine2 name="combine1" type="color4">
       <input name="in1" type="color3" value="0.5000, 1.0000, 0.2500" />
       <input name="in2" type="float" value="0.7500" />
     </combine2>
     <output name="out" type="color4" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_vector4VF" type="" xpos="7.32759" ypos="52.09">
-    <combine2 name="combine1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="combine_vector4VF">
+    <combine2 name="combine1" type="vector4">
       <input name="in1" type="vector3" value="0.5000, 1.0000, 0.2500" />
       <input name="in2" type="float" value="0.7500" />
     </combine2>
     <output name="out" type="vector4" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="combine_vector4VV" type="" xpos="9.4069" ypos="52.06">
-    <combine2 name="combine1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="combine_vector4VV">
+    <combine2 name="combine1" type="vector4">
       <input name="in1" type="vector2" value="0.5000, 1.0000" />
       <input name="in2" type="vector2" value="0.2500, 1.0000" />
     </combine2>
     <output name="out" type="vector4" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="extract_color2" type="" xpos="6.26897" ypos="53.37">
-    <extract name="extract1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="extract_color2">
+    <extract name="extract1" type="float">
       <input name="in" type="vector2" value="0.5000, 1.0" />
       <input name="index" type="integer" value="1" />
     </extract>
     <output name="out" type="float" nodename="extract1" />
   </nodegraph>
-  <nodegraph name="extract_color3" type="" xpos="7.34483" ypos="53.34">
-    <extract name="extract1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="extract_color3">
+    <extract name="extract1" type="float">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="index" type="integer" value="1" />
     </extract>
     <output name="out" type="float" nodename="extract1" />
   </nodegraph>
-  <nodegraph name="extract_color4" type="" xpos="8.37931" ypos="53.33">
-    <extract name="extract1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="extract_color4">
+    <extract name="extract1" type="float">
       <input name="in" type="color4" value="0.0000, 0.2500, 0.7500, 1.0" />
       <input name="index" type="integer" value="1" />
     </extract>
     <output name="out" type="float" nodename="extract1" />
   </nodegraph>
-  <nodegraph name="extract_vector2" type="" xpos="9.41379" ypos="53.31">
-    <extract name="extract1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="extract_vector2">
+    <extract name="extract1" type="float">
       <input name="in" type="vector2" value="0.5000, 1.0000" />
       <input name="index" type="integer" value="1" />
     </extract>
     <output name="out" type="float" nodename="extract1" />
   </nodegraph>
-  <nodegraph name="extract_vector3" type="" xpos="7.33793" ypos="54.64">
-    <extract name="extract1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="extract_vector3">
+    <extract name="extract1" type="float">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="index" type="integer" value="1" />
     </extract>
     <output name="out" type="float" nodename="extract1" />
   </nodegraph>
-  <nodegraph name="extract_vector4" type="" xpos="8.38276" ypos="54.62">
-    <extract name="extract1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="extract_vector4">
+    <extract name="extract1" type="float">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="index" type="integer" value="1" />
     </extract>

--- a/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
@@ -5,67 +5,55 @@
     Output test
 
     -->
-  <nodegraph name="image4_to_color2_ra_out" type="">
+  <nodegraph name="image4_to_color2_ra_out">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="frameendaction" type="string" value="periodic" />
     </image>
     <output name="out" type="vector2" nodename="image4" channels="rr" />
   </nodegraph>
-  <nodegraph name="image4_to_color3_bgr_out" type="">
+  <nodegraph name="image4_to_color3_bgr_out">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="frameendaction" type="string" value="periodic" />
     </image>
     <output name="out" type="color3" nodename="image4" channels="bbb" />
   </nodegraph>
-  <nodegraph name="image4_to_float_g_out" type="">
+  <nodegraph name="image4_to_float_g_out">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="frameendaction" type="string" value="periodic" />
     </image>
     <output name="out" type="float" nodename="image4" channels="g" />
   </nodegraph>
-  <nodegraph name="float_to_color4_rrrr_out" type="">
+  <nodegraph name="float_to_color4_rrrr_out">
     <constant name="constant1" type="float">
       <input name="value" type="float" value="1.0" />
     </constant>
     <output name="out" type="color4" nodename="constant1" channels="rrrr" />
   </nodegraph>
-  <nodegraph name="color2_to_color4_arar_out" type="">
+  <nodegraph name="color2_to_color4_arar_out">
     <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.0, 0.5" />
     </constant>
     <output name="out" type="color4" nodename="constant1" channels="yxyx" />
   </nodegraph>
-  <nodegraph name="color3_to_color4_bgr1_out" type="">
+  <nodegraph name="color3_to_color4_bgr1_out">
     <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.5, 0.7, 1.0" />
     </constant>
     <output name="out" type="color4" nodename="constant1" channels="bgr1" />
   </nodegraph>
-  <nodegraph name="color4_to_color3_bgr_out" type="">
+  <nodegraph name="color4_to_color3_bgr_out">
     <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.5, 0.7, 0.9, 1.0" />
     </constant>
     <output name="out" type="color3" nodename="constant1" channels="bgr" />
   </nodegraph>
-  <nodegraph name="color4_to_color2_bg_out" type="">
+  <nodegraph name="color4_to_color2_bg_out">
     <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.5, 0.7, 0.9, 1.0" />
     </constant>
     <output name="out" type="vector2" nodename="constant1" channels="bg" />
   </nodegraph>
-  <nodegraph name="color4_to_float_g_out" type="">
+  <nodegraph name="color4_to_float_g_out">
     <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.0, 0.5, 0.75, 1.0" />
     </constant>
@@ -76,13 +64,11 @@
    Input tests
 
     -->
-  <nodegraph name="image4_to_color3_bga_in" type="">
+  <nodegraph name="image4_to_color3_bga_in">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
       <input name="uaddressmode" type="string" value="constant" />
       <input name="vaddressmode" type="string" value="clamp" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="frameendaction" type="string" value="periodic" />
     </image>
     <add name="add1" type="color3">
       <input name="in1" type="color3" nodename="image4" channels="bgr" />
@@ -90,13 +76,11 @@
     </add>
     <output name="out" type="color3" nodename="add1" />
   </nodegraph>
-  <nodegraph name="image4_to_color2_ga_in" type="">
+  <nodegraph name="image4_to_color2_ga_in">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
       <input name="uaddressmode" type="string" value="constant" />
       <input name="vaddressmode" type="string" value="clamp" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="frameendaction" type="string" value="periodic" />
     </image>
     <add name="add1" type="vector2">
       <input name="in1" type="vector2" nodename="image4" channels="gg" />
@@ -104,13 +88,11 @@
     </add>
     <output name="out" type="vector2" nodename="add1" />
   </nodegraph>
-  <nodegraph name="image4_to_float_g_in" type="">
+  <nodegraph name="image4_to_float_g_in">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
       <input name="uaddressmode" type="string" value="constant" />
       <input name="vaddressmode" type="string" value="clamp" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="frameendaction" type="string" value="periodic" />
     </image>
     <add name="add1" type="float">
       <input name="in1" type="float" nodename="image4" channels="g" />
@@ -118,7 +100,7 @@
     </add>
     <output name="out" type="float" nodename="add1" />
   </nodegraph>
-  <nodegraph name="float_to_color4_rrrr_in" type="">
+  <nodegraph name="float_to_color4_rrrr_in">
     <constant name="constant1" type="float">
       <input name="value" type="float" value="1.0" />
     </constant>
@@ -128,7 +110,7 @@
     </add>
     <output name="out" type="color4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="color2_to_color4_arar_in" type="">
+  <nodegraph name="color2_to_color4_arar_in">
     <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.0, 0.5" />
     </constant>
@@ -138,7 +120,7 @@
     </add>
     <output name="out" type="color4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="color3_to_color4_bgr1_in" type="">
+  <nodegraph name="color3_to_color4_bgr1_in">
     <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.5, 0.7, 1.0" />
     </constant>
@@ -148,7 +130,7 @@
     </add>
     <output name="out" type="color4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="color4_to_color3_rga_in" type="">
+  <nodegraph name="color4_to_color3_rga_in">
     <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.0, 0.5, 0.75, 1.0" />
     </constant>
@@ -158,7 +140,7 @@
     </add>
     <output name="out" type="color3" nodename="add1" />
   </nodegraph>
-  <nodegraph name="color4_to_color2_rg_in" type="">
+  <nodegraph name="color4_to_color2_rg_in">
     <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.0, 0.5, 0.75, 1.0" />
     </constant>
@@ -168,7 +150,7 @@
     </add>
     <output name="out" type="vector2" nodename="add1" />
   </nodegraph>
-  <nodegraph name="color4_to_float_g_in" type="">
+  <nodegraph name="color4_to_float_g_in">
     <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.0, 0.5, 0.75, 1.0" />
     </constant>

--- a/resources/Materials/TestSuite/stdlib/channel/convert.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/convert.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="convert_boolean_float" type="">
+  <nodegraph name="convert_boolean_float">
     <constant name="constant1" type="boolean">
       <input name="value" type="boolean" value="false" />
     </constant>
@@ -9,7 +9,7 @@
     </convert>
     <output name="out" type="float" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_integer_float" type="">
+  <nodegraph name="convert_integer_float">
     <constant name="constant1" type="integer">
       <input name="value" type="integer" value="42" />
     </constant>
@@ -18,125 +18,125 @@
     </convert>
     <output name="out" type="float" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_float_color3" type="" xpos="7.21163" ypos="18.7398">
-    <constant name="constant1" type="float" xpos="5.74483" ypos="4.9">
+  <nodegraph name="convert_float_color3">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
-    <convert name="convert1" type="color3" xpos="6.87231" ypos="4.83112">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+    <convert name="convert1" type="color3">
+      <input name="in" type="float" nodename="constant1" />
     </convert>
     <output name="out" type="color3" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_float_color4" type="" xpos="8.19465" ypos="18.7452">
-    <constant name="constant1" type="float" xpos="5.74483" ypos="4.9">
+  <nodegraph name="convert_float_color4">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
-    <convert name="convert1" type="color4" xpos="6.78518" ypos="4.59372">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+    <convert name="convert1" type="color4">
+      <input name="in" type="float" nodename="constant1" />
     </convert>
     <output name="out" type="color4" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_float_vector2" type="" xpos="9.16771" ypos="18.7381">
-    <constant name="constant1" type="float" xpos="5.74483" ypos="4.9">
+  <nodegraph name="convert_float_vector2">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
-    <convert name="convert1" type="vector2" xpos="6.2069" ypos="8.3">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+    <convert name="convert1" type="vector2">
+      <input name="in" type="float" nodename="constant1" />
     </convert>
     <output name="out" type="vector2" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_float_vector3" type="" xpos="7.2073" ypos="20.0439">
-    <convert name="convert1" type="vector3" xpos="5.94072" ypos="4.74778">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="convert_float_vector3">
+    <convert name="convert1" type="vector3">
+      <input name="in" type="float" nodename="constant1" />
     </convert>
-    <constant name="constant1" type="float" xpos="4.80343" ypos="4.99136">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
     <output name="out" type="vector3" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_float_vector4" type="" xpos="8.19021" ypos="20.041">
-    <constant name="constant1" type="float" xpos="5.74483" ypos="4.9">
+  <nodegraph name="convert_float_vector4">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
-    <convert name="convert1" type="vector4" xpos="6.2069" ypos="8.3">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+    <convert name="convert1" type="vector4">
+      <input name="in" type="float" nodename="constant1" />
     </convert>
     <output name="out" type="vector4" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_vector3_color3" type="" xpos="7.2142" ypos="21.3512">
-    <constant name="constant1" type="vector3" xpos="5.74483" ypos="4.9">
+  <nodegraph name="convert_vector3_color3">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="0.2000, 0.8000, 0.5000" />
     </constant>
-    <convert name="convert1" type="color3" xpos="6.82478" ypos="4.63968">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+    <convert name="convert1" type="color3">
+      <input name="in" type="vector3" nodename="constant1" />
     </convert>
     <output name="out" type="color3" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_vector4_color4" type="" xpos="8.19465" ypos="21.3639">
-    <convert name="convert1" type="color4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="convert_vector4_color4">
+    <convert name="convert1" type="color4">
+      <input name="in" type="vector4" nodename="constant1" />
     </convert>
-    <constant name="constant1" type="vector4" xpos="4.58608" ypos="5.0614">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="0.2000, 0.8000, 0.5000, 1.0" />
     </constant>
     <output name="out" type="color4" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_color3_vector3" type="" xpos="7.20928" ypos="22.6541">
-    <convert name="convert1" type="vector3" xpos="5.74483" ypos="4.74">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="convert_color3_vector3">
+    <convert name="convert1" type="vector3">
+      <input name="in" type="color3" nodename="constant1" />
     </convert>
-    <constant name="constant1" type="color3" xpos="4.56192" ypos="5.05362">
+    <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.2000, 0.8000, 0.5000" />
     </constant>
     <output name="out" type="vector3" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_color4_vector4" type="" xpos="8.19711" ypos="22.6479">
-    <constant name="constant1" type="color4" xpos="5.74483" ypos="4.9">
+  <nodegraph name="convert_color4_vector4">
+    <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.2000, 0.8000, 0.5000, 1.0" />
     </constant>
-    <convert name="convert1" type="vector4" xpos="6.2069" ypos="8.3">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+    <convert name="convert1" type="vector4">
+      <input name="in" type="color4" nodename="constant1" />
     </convert>
     <output name="out" type="vector4" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_color3_color4" type="" xpos="9.19481" ypos="22.6622">
-    <convert name="convert1" type="color4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="convert_color3_color4">
+    <convert name="convert1" type="color4">
+      <input name="in" type="color3" nodename="constant1" />
     </convert>
-    <constant name="constant1" type="color3" xpos="4.69341" ypos="4.96802">
+    <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.2000, 0.8000, 0.5000" />
     </constant>
     <output name="out" type="color4" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="convert_color4_color3" type="" xpos="7.21273" ypos="23.9009">
-    <convert name="convert1" type="color3" xpos="5.74483" ypos="4.74">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="convert_color4_color3">
+    <convert name="convert1" type="color3">
+      <input name="in" type="color4" nodename="constant1" />
     </convert>
-    <constant name="constant1" type="color4" xpos="4.5807" ypos="4.99136">
+    <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.2000, 0.8000, 0.5000, 1.0" />
     </constant>
     <output name="out" type="color3" nodename="convert1" />
   </nodegraph>
-  <nodegraph name="vec2vec3vec2" type="" xpos="5.60538" ypos="15.7694">
-    <convert name="convertvec2to3" type="vector3" xpos="5.55868" ypos="8.87452">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+  <nodegraph name="vec2vec3vec2">
+    <convert name="convertvec2to3" type="vector3">
+      <input name="in" type="vector2" nodename="texcoord1" />
     </convert>
-    <convert name="convert3to2" type="vector2" xpos="6.70096" ypos="6.95576">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="convertvec2to3" />
+    <convert name="convert3to2" type="vector2">
+      <input name="in" type="vector3" nodename="convertvec2to3" />
     </convert>
     <output name="out" type="vector2" nodename="convert3to2" />
-    <texcoord name="texcoord1" type="vector2" xpos="4.19299" ypos="6.48808">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
   </nodegraph>
-  <nodegraph name="vec3vec4vec3" type="" xpos="5.8069" ypos="20.08">
-    <convert name="convert3to4" type="vector4" xpos="5.34373" ypos="7.63674">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="normal1" />
+  <nodegraph name="vec3vec4vec3">
+    <convert name="convert3to4" type="vector4">
+      <input name="in" type="vector3" nodename="normal1" />
     </convert>
-    <convert name="conver4to3" type="vector3" xpos="6.45086" ypos="9.31894">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="convert3to4" />
+    <convert name="conver4to3" type="vector3">
+      <input name="in" type="vector4" nodename="convert3to4" />
     </convert>
-    <normal name="normal1" type="vector3" xpos="5.08526" ypos="4.2888">
+    <normal name="normal1" type="vector3">
       <input name="space" type="string" value="object" />
     </normal>
     <output name="out" type="vector3" nodename="conver4to3" />

--- a/resources/Materials/TestSuite/stdlib/channel/swizzle.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/swizzle.mtlx
@@ -1,336 +1,336 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="swizzle_float_color2" type="" xpos="6.21568" ypos="25.2003">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_float_color2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="float" value="0.5000" />
       <input name="channels" type="string" value="rr" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_float_color3" type="" xpos="7.20877" ypos="25.1899">
-    <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_float_color3">
+    <swizzle name="swizzle1" type="color3">
       <input name="in" type="float" value="0.5000" />
       <input name="channels" type="string" value="rrr" />
     </swizzle>
     <output name="out" type="color3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_float_color4" type="" xpos="8.21248" ypos="25.1654">
-    <swizzle name="swizzle1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_float_color4">
+    <swizzle name="swizzle1" type="color4">
       <input name="in" type="float" value="0.5000" />
       <input name="channels" type="string" value="rrrr" />
     </swizzle>
     <output name="out" type="color4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_float_vector2" type="" xpos="9.22519" ypos="25.1458">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_float_vector2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="float" value="0.5000" />
       <input name="channels" type="string" value="rr" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_float_vector3" type="" xpos="7.22341" ypos="26.5359">
-    <swizzle name="swizzle1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_float_vector3">
+    <swizzle name="swizzle1" type="vector3">
       <input name="in" type="float" value="0.5000" />
       <input name="channels" type="string" value="rrr" />
     </swizzle>
     <output name="out" type="vector3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_float_vector4" type="" xpos="8.22618" ypos="26.5237">
-    <swizzle name="swizzle1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_float_vector4">
+    <swizzle name="swizzle1" type="vector4">
       <input name="in" type="float" value="0.5000" />
       <input name="channels" type="string" value="rrrr" />
     </swizzle>
     <output name="out" type="vector4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_float" type="" xpos="9.24226" ypos="26.5139">
-    <swizzle name="swizzle1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color2_float">
+    <swizzle name="swizzle1" type="float">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="channels" type="string" value="y" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_color2" type="" xpos="7.2118" ypos="28.0137">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color2_color2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="channels" type="string" value="yx" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_color3" type="" xpos="8.23801" ypos="27.9999">
-    <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color2_color3">
+    <swizzle name="swizzle1" type="color3">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="channels" type="string" value="yxy" />
     </swizzle>
     <output name="out" type="color3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_color4" type="" xpos="9.26083" ypos="27.9705">
-    <swizzle name="swizzle1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color2_color4">
+    <swizzle name="swizzle1" type="color4">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="channels" type="string" value="xyxy" />
     </swizzle>
     <output name="out" type="color4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_vector2" type="" xpos="7.21855" ypos="29.5494">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color2_vector2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="channels" type="string" value="yx" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_vector3" type="" xpos="8.25449" ypos="29.5396">
-    <swizzle name="swizzle1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color2_vector3">
+    <swizzle name="swizzle1" type="vector3">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="channels" type="string" value="yxy" />
     </swizzle>
     <output name="out" type="vector3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_vector4" type="" xpos="9.27394" ypos="29.52">
-    <swizzle name="swizzle1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color2_vector4">
+    <swizzle name="swizzle1" type="vector4">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="channels" type="string" value="xyxy" />
     </swizzle>
     <output name="out" type="vector4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color3_float" type="" xpos="7.23249" ypos="31.0317">
-    <swizzle name="swizzle1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color3_float">
+    <swizzle name="swizzle1" type="float">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="g" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color3_color2" type="" xpos="8.27856" ypos="30.9888">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color3_color2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="br" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color3_color3" type="" xpos="9.29463" ypos="30.9497">
-    <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color3_color3">
+    <swizzle name="swizzle1" type="color3">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="bgr" />
     </swizzle>
     <output name="out" type="color3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color3_color4" type="" xpos="7.21874" ypos="32.5258">
-    <swizzle name="swizzle1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color3_color4">
+    <swizzle name="swizzle1" type="color4">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="bgrg" />
     </swizzle>
     <output name="out" type="color4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color3_vector2" type="" xpos="8.29558" ypos="32.4964">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color3_vector2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="color3" value="0.0000, 0.5000, 1.0000" />
       <input name="channels" type="string" value="br" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color3_vector3" type="" xpos="9.31503" ypos="32.4886">
-    <swizzle name="swizzle1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color3_vector3">
+    <swizzle name="swizzle1" type="vector3">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="bgr" />
     </swizzle>
     <output name="out" type="vector3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color3_vector4" type="" xpos="7.23678" ypos="34.035">
-    <swizzle name="swizzle1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color3_vector4">
+    <swizzle name="swizzle1" type="vector4">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="bgrg" />
     </swizzle>
     <output name="out" type="vector4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_float" type="" xpos="8.29675" ypos="34.0056">
-    <swizzle name="swizzle1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color4_float">
+    <swizzle name="swizzle1" type="float">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="a" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_color2" type="" xpos="9.33249" ypos="33.9864">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color4_color2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="ab" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_color3" type="" xpos="7.23958" ypos="35.4984">
-    <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color4_color3">
+    <swizzle name="swizzle1" type="color3">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="abg" />
     </swizzle>
     <output name="out" type="color3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_color4" type="" xpos="8.31267" ypos="35.4504">
-    <swizzle name="swizzle1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color4_color4">
+    <swizzle name="swizzle1" type="color4">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="agrb" />
     </swizzle>
     <output name="out" type="color4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_vector2" type="" xpos="9.35855" ypos="35.4606">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color4_vector2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="ab" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_vector3" type="" xpos="7.26621" ypos="36.9482">
-    <swizzle name="swizzle1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color4_vector3">
+    <swizzle name="swizzle1" type="vector3">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="abg" />
     </swizzle>
     <output name="out" type="vector3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_vector4" type="" xpos="8.31845" ypos="36.9312">
-    <swizzle name="swizzle1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_color4_vector4">
+    <swizzle name="swizzle1" type="vector4">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="agrb" />
     </swizzle>
     <output name="out" type="vector4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector2_float" type="" xpos="9.37783" ypos="36.9414">
-    <swizzle name="swizzle1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector2_float">
+    <swizzle name="swizzle1" type="float">
       <input name="in" type="vector2" value="0.0, 1.0000" />
       <input name="channels" type="string" value="y" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector2_color2" type="" xpos="7.25878" ypos="38.4682">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector2_color2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector2" value="0.0, 1.0000" />
       <input name="channels" type="string" value="yx" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector2_color3" type="" xpos="8.32886" ypos="38.4486">
-    <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector2_color3">
+    <swizzle name="swizzle1" type="color3">
       <input name="in" type="vector2" value="0.0, 1.0000" />
       <input name="channels" type="string" value="yxy" />
     </swizzle>
     <output name="out" type="color3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector2_color4" type="" xpos="9.38149" ypos="38.4392">
-    <swizzle name="swizzle1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector2_color4">
+    <swizzle name="swizzle1" type="color4">
       <input name="in" type="vector2" value="0.0, 1.0000" />
       <input name="channels" type="string" value="xyxy" />
     </swizzle>
     <output name="out" type="color4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector2_vector2" type="" xpos="7.26759" ypos="39.9862">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector2_vector2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector2" value="0.0, 1.0000" />
       <input name="channels" type="string" value="yx" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector2_vector3" type="" xpos="8.3208" ypos="39.9826">
-    <swizzle name="swizzle1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector2_vector3">
+    <swizzle name="swizzle1" type="vector3">
       <input name="in" type="vector2" value="0.0, 1.0000" />
       <input name="channels" type="string" value="yxy" />
     </swizzle>
     <output name="out" type="vector3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector2_vector4" type="" xpos="9.37343" ypos="39.9732">
-    <swizzle name="swizzle1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector2_vector4">
+    <swizzle name="swizzle1" type="vector4">
       <input name="in" type="vector2" value="0.0, 1.0000" />
       <input name="channels" type="string" value="xyxy" />
     </swizzle>
     <output name="out" type="vector4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_float" type="" xpos="7.2811" ypos="41.5294">
-    <swizzle name="swizzle1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector3_float">
+    <swizzle name="swizzle1" type="float">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="y" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_color2" type="" xpos="8.34643" ypos="41.496">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector3_color2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="zx" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_color3" type="" xpos="9.38556" ypos="41.4868">
-    <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector3_color3">
+    <swizzle name="swizzle1" type="color3">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="zyx" />
     </swizzle>
     <output name="out" type="color3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_color4" type="" xpos="7.29258" ypos="43.1184">
-    <swizzle name="swizzle1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector3_color4">
+    <swizzle name="swizzle1" type="color4">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="zyxy" />
     </swizzle>
     <output name="out" type="color4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_vector2" type="" xpos="8.3501" ypos="43.0918">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector3_vector2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="zx" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_vector3" type="" xpos="9.38248" ypos="43.0922">
-    <swizzle name="swizzle1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector3_vector3">
+    <swizzle name="swizzle1" type="vector3">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="zyx" />
     </swizzle>
     <output name="out" type="vector3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_vector4" type="" xpos="7.29998" ypos="44.6092">
-    <swizzle name="swizzle1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector3_vector4">
+    <swizzle name="swizzle1" type="vector4">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="zyxy" />
     </swizzle>
     <output name="out" type="vector4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector4_float" type="" xpos="8.35147" ypos="44.5852">
-    <swizzle name="swizzle1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector4_float">
+    <swizzle name="swizzle1" type="float">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="w" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector4_color2" type="" xpos="9.38385" ypos="44.5856">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector4_color2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="wz" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector4_color3" type="" xpos="7.32189" ypos="46.1222">
-    <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector4_color3">
+    <swizzle name="swizzle1" type="color3">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="wzy" />
     </swizzle>
     <output name="out" type="color3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector4_color4" type="" xpos="8.35147" ypos="46.099">
-    <swizzle name="swizzle1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector4_color4">
+    <swizzle name="swizzle1" type="color4">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="wyxz" />
     </swizzle>
     <output name="out" type="color4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector4_vector2" type="" xpos="9.38047" ypos="46.0994">
-    <swizzle name="swizzle1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector4_vector2">
+    <swizzle name="swizzle1" type="vector2">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="wz" />
     </swizzle>
     <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector4_vector3" type="" xpos="7.31852" ypos="47.8024">
-    <swizzle name="swizzle1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector4_vector3">
+    <swizzle name="swizzle1" type="vector3">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="wzy" />
     </swizzle>
     <output name="out" type="vector3" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector4_vector4" type="" xpos="8.3567" ypos="47.7944">
-    <swizzle name="swizzle1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="swizzle_vector4_vector4">
+    <swizzle name="swizzle1" type="vector4">
       <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
       <input name="channels" type="string" value="wyxz" />
     </swizzle>

--- a/resources/Materials/TestSuite/stdlib/color_management/color3_vec3_cm_test.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color3_vec3_cm_test.mtlx
@@ -4,8 +4,6 @@
   <nodegraph name="height_to_normal_cm">
     <image name="b_image" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_texture" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
     </image>
     <extract name="extract1" type="float">
       <input name="in" type="color3" nodename="b_image" />
@@ -21,8 +19,6 @@
   <nodegraph name="normalmap_cm">
     <image name="b_image" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_texture" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
     </image>
     <convert name="c3tov3" type="vector3">
       <input name="in" type="color3" nodename="b_image" />

--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -5,98 +5,98 @@
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="lin_rec709" />
     </image>
     <standard_surface name="image_lin_rec709_standard_surface" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="image_lin_rec709" />
+      <input name="base_color" type="color3" nodename="image_lin_rec709" />
     </standard_surface>
     <output name="image_lin_rec709_output" type="surfaceshader" nodename="image_lin_rec709_standard_surface" />
     <image name="image_gamma18" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma18" />
     </image>
     <standard_surface name="image_gamma18_standard_surface2" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="image_gamma18" />
+      <input name="base_color" type="color3" nodename="image_gamma18" />
     </standard_surface>
     <output name="image_gamma18_output" type="surfaceshader" nodename="image_gamma18_standard_surface2" />
     <image name="image_gamma22" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma22" />
     </image>
     <standard_surface name="image_gamma22_standard_surface3" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="image_gamma22" />
+      <input name="base_color" type="color3" nodename="image_gamma22" />
     </standard_surface>
     <output name="image_gamma22_output" type="surfaceshader" nodename="image_gamma22_standard_surface3" />
     <image name="image_gamma24" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma24" />
     </image>
     <standard_surface name="image_gamma24_standard_surface4" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="image_gamma24" />
+      <input name="base_color" type="color3" nodename="image_gamma24" />
     </standard_surface>
     <output name="image_gamma24_output" type="surfaceshader" nodename="image_gamma24_standard_surface4" />
     <image name="image_acescg" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="acescg" />
     </image>
     <standard_surface name="image_acescg_standard_surface5" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="image_acescg" />
+      <input name="base_color" type="color3" nodename="image_acescg" />
     </standard_surface>
     <output name="image_acescg_output" type="surfaceshader" nodename="image_acescg_standard_surface5" />
     <image name="image_g22_ap1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="g22_ap1" />
     </image>
     <standard_surface name="image_g22_ap1_standard_surface5" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="image_g22_ap1" />
+      <input name="base_color" type="color3" nodename="image_g22_ap1" />
     </standard_surface>
     <output name="image_g22_ap1_output" type="surfaceshader" nodename="image_g22_ap1_standard_surface5" />
     <image name="image_srgb_texture" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_texture" />
     </image>
     <standard_surface name="image_srgb_texture_standard_surface6" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="image_srgb_texture" />
+      <input name="base_color" type="color3" nodename="image_srgb_texture" />
     </standard_surface>
     <output name="image_srgb_texture_output" type="surfaceshader" nodename="image_srgb_texture_standard_surface6" />
     <constant name="color_lin_rec709" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_rec709" />
     </constant>
     <standard_surface name="color_lin_rec709_standard_surface" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="color_lin_rec709" channels="rgb" />
+      <input name="base_color" type="color3" nodename="color_lin_rec709" channels="rgb" />
     </standard_surface>
     <output name="color_lin_rec709_output" type="surfaceshader" nodename="color_lin_rec709_standard_surface" />
     <constant name="color_gamma18" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma18" />
     </constant>
     <standard_surface name="color_gamma18_standard_surface2" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="color_gamma18" channels="rgb" />
+      <input name="base_color" type="color3" nodename="color_gamma18" channels="rgb" />
     </standard_surface>
     <output name="color_gamma18_output" type="surfaceshader" nodename="color_gamma18_standard_surface2" />
     <constant name="color_gamma22" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma22" />
     </constant>
     <standard_surface name="color_gamma22_standard_surface3" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="color_gamma22" channels="rgb" />
+      <input name="base_color" type="color3" nodename="color_gamma22" channels="rgb" />
     </standard_surface>
     <output name="color_gamma22_output" type="surfaceshader" nodename="color_gamma22_standard_surface3" />
     <constant name="color_gamma24" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma24" />
     </constant>
     <standard_surface name="color_gamma24_standard_surface4" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="color_gamma24" channels="rgb" />
+      <input name="base_color" type="color3" nodename="color_gamma24" channels="rgb" />
     </standard_surface>
     <output name="color_gamma24_output" type="surfaceshader" nodename="color_gamma24_standard_surface4" />
     <constant name="color_acescg" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="acescg" />
     </constant>
     <standard_surface name="color_acescg_standard_surface5" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="color_acescg" channels="rgb" />
+      <input name="base_color" type="color3" nodename="color_acescg" channels="rgb" />
     </standard_surface>
     <output name="color_acescg_output" type="surfaceshader" nodename="color_acescg_standard_surface5" />
     <constant name="color_g22_ap1" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="g22_ap1" />
     </constant>
     <standard_surface name="color_g22_ap1_standard_surface5" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="color_g22_ap1" channels="rgb" />
+      <input name="base_color" type="color3" nodename="color_g22_ap1" channels="rgb" />
     </standard_surface>
     <output name="color_g22_ap1_output" type="surfaceshader" nodename="color_g22_ap1_standard_surface5" />
     <constant name="color_srgb_texture" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="srgb_texture" />
     </constant>
     <standard_surface name="color_srgb_texture_standard_surface6" type="surfaceshader">
-      <input name="base_color" type="color3" value="1, 1, 1" nodename="color_srgb_texture" channels="rgb" />
+      <input name="base_color" type="color3" nodename="color_srgb_texture" channels="rgb" />
     </standard_surface>
     <output name="color_srgb_texture_output" type="surfaceshader" nodename="color_srgb_texture_standard_surface6" />
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/compositing/compositing.mtlx
+++ b/resources/Materials/TestSuite/stdlib/compositing/compositing.mtlx
@@ -21,342 +21,342 @@
   - premult
   - unpremult
 -->
-  <nodegraph name="plus_float" type="" xpos="6.21379" ypos="18.74">
-    <plus name="plus1" type="float" xpos="5.4762" ypos="4.59668">
+  <nodegraph name="plus_float">
+    <plus name="plus1" type="float">
       <input name="fg" type="float" value="0.4000" />
       <input name="bg" type="float" value="0.3000" />
       <input name="mix" type="float" value="0.5000" />
     </plus>
     <output name="out" type="float" nodename="plus1" />
   </nodegraph>
-  <nodegraph name="plus_color3" type="" xpos="8.21937" ypos="18.7209">
-    <plus name="plus1" type="color3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="plus_color3">
+    <plus name="plus1" type="color3">
       <input name="fg" type="color3" value="0.2000, 0.4000, 0.0" />
       <input name="bg" type="color3" value="0.3000, 0.3000, 1.0000" />
       <input name="mix" type="float" value="0.5000" />
     </plus>
     <output name="out" type="color3" nodename="plus1" />
   </nodegraph>
-  <nodegraph name="plus_color4" type="" xpos="9.19125" ypos="18.7399">
-    <plus name="plus1" type="color4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="plus_color4">
+    <plus name="plus1" type="color4">
       <input name="fg" type="color4" value="0.2000, 0.4000, 0.0000, 0.0000" />
       <input name="bg" type="color4" value="0.3000, 0.3000, 1.0000, 1.0" />
       <input name="mix" type="float" value="0.5000" />
     </plus>
     <output name="out" type="color4" nodename="plus1" />
   </nodegraph>
-  <nodegraph name="minus_float" type="" xpos="6.20862" ypos="20.0354">
-    <minus name="minus1" type="float" xpos="5.74483" ypos="4.42">
+  <nodegraph name="minus_float">
+    <minus name="minus1" type="float">
       <input name="fg" type="float" value="1.0000" />
       <input name="bg" type="float" value="1.0000" />
       <input name="mix" type="float" value="0.5000" />
     </minus>
     <output name="out" type="float" nodename="minus1" />
   </nodegraph>
-  <nodegraph name="minus_color3" type="" xpos="8.22864" ypos="20.0396">
-    <minus name="minus1" type="color3" xpos="5.75172" ypos="4.42">
+  <nodegraph name="minus_color3">
+    <minus name="minus1" type="color3">
       <input name="fg" type="color3" value="1.0000, 0.0, 0.0" />
       <input name="bg" type="color3" value="1.0000, 1.0000, 0.0" />
       <input name="mix" type="float" value="0.5000" />
     </minus>
     <output name="out" type="color3" nodename="minus1" />
   </nodegraph>
-  <nodegraph name="minus_color4" type="" xpos="9.20663" ypos="20.0253">
-    <minus name="minus1" type="color4" xpos="5.75172" ypos="4.42">
+  <nodegraph name="minus_color4">
+    <minus name="minus1" type="color4">
       <input name="fg" type="color4" value="1.0000, 0.0, 0.0, 0.000" />
       <input name="bg" type="color4" value="1.0000, 1.0000, 0.0, 1.0" />
       <input name="mix" type="float" value="0.5000" />
     </minus>
     <output name="out" type="color4" nodename="minus1" />
   </nodegraph>
-  <nodegraph name="difference_float" type="" xpos="6.21607" ypos="21.3854">
-    <difference name="difference1" type="float" xpos="5.75172" ypos="4.42">
+  <nodegraph name="difference_float">
+    <difference name="difference1" type="float">
       <input name="fg" type="float" value="1.0000" />
       <input name="bg" type="float" value="0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </difference>
     <output name="out" type="float" nodename="difference1" />
   </nodegraph>
-  <nodegraph name="difference_color3" type="" xpos="8.22972" ypos="21.3398">
-    <difference name="difference1" type="color3" xpos="5.75862" ypos="4.44">
+  <nodegraph name="difference_color3">
+    <difference name="difference1" type="color3">
       <input name="fg" type="color3" value="1.0000, 1.0000, 0.0" />
       <input name="bg" type="color3" value="0.5000, 0.0000, 0.0" />
       <input name="mix" type="float" value="0.5000" />
     </difference>
     <output name="out" type="color3" nodename="difference1" />
   </nodegraph>
-  <nodegraph name="difference_color4" type="" xpos="9.23654" ypos="21.3095">
-    <difference name="difference1" type="color4" xpos="5.75172" ypos="4.42">
+  <nodegraph name="difference_color4">
+    <difference name="difference1" type="color4">
       <input name="fg" type="color4" value="1.0000, 1.0000, 0.0, 0.0000" />
       <input name="bg" type="color4" value="0.5000, 0.0, 0.0, 1.0" />
       <input name="mix" type="float" value="0.5000" />
     </difference>
     <output name="out" type="color4" nodename="difference1" />
   </nodegraph>
-  <nodegraph name="burn_float" type="" xpos="6.20562" ypos="22.7021">
-    <burn name="burn1" type="float" xpos="5.75172" ypos="4.42">
+  <nodegraph name="burn_float">
+    <burn name="burn1" type="float">
       <input name="fg" type="float" value="0.5000" />
       <input name="bg" type="float" value="0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </burn>
     <output name="out" type="float" nodename="burn1" />
   </nodegraph>
-  <nodegraph name="burn_float_divzero" type="" xpos="6.20562" ypos="22.7021">
-    <burn name="burn1" type="float" xpos="5.75172" ypos="4.42">
+  <nodegraph name="burn_float_divzero">
+    <burn name="burn1" type="float">
       <input name="fg" type="float" value="0.0000" />
       <input name="bg" type="float" value="0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </burn>
     <output name="out" type="float" nodename="burn1" />
   </nodegraph>
-  <nodegraph name="burn_color3" type="" xpos="8.24017" ypos="22.6586">
-    <burn name="burn1" type="color3" xpos="5.75172" ypos="4.42">
+  <nodegraph name="burn_color3">
+    <burn name="burn1" type="color3">
       <input name="fg" type="color3" value="0.5000, 0.7500, 1.0000" />
       <input name="bg" type="color3" value="0.5000, 0.7500, 0.0000" />
       <input name="mix" type="float" value="0.5000" />
     </burn>
     <output name="out" type="color3" nodename="burn1" />
   </nodegraph>
-  <nodegraph name="burn_color4" type="" xpos="9.247" ypos="22.6485">
-    <burn name="burn1" type="color4" xpos="5.75172" ypos="4.42">
+  <nodegraph name="burn_color4">
+    <burn name="burn1" type="color4">
       <input name="fg" type="color4" value="0.5000, 0.7500, 1.0000, 1.0000" />
       <input name="bg" type="color4" value="0.5000, 0.7500, 0.0, 1.0" />
       <input name="mix" type="float" value="0.5000" />
     </burn>
     <output name="out" type="color4" nodename="burn1" />
   </nodegraph>
-  <nodegraph name="dodge_float" type="" xpos="6.21607" ypos="24.0124">
-    <dodge name="dodge1" type="float" xpos="5.75172" ypos="4.42">
+  <nodegraph name="dodge_float">
+    <dodge name="dodge1" type="float">
       <input name="fg" type="float" value="0.0000" />
       <input name="bg" type="float" value="0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </dodge>
     <output name="out" type="float" nodename="dodge1" />
   </nodegraph>
-  <nodegraph name="dodge_float_divzero" type="" xpos="6.21607" ypos="24.0124">
-    <dodge name="dodge1" type="float" xpos="5.75172" ypos="4.42">
+  <nodegraph name="dodge_float_divzero">
+    <dodge name="dodge1" type="float">
       <input name="fg" type="float" value="1.0000" />
       <input name="bg" type="float" value="0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </dodge>
     <output name="out" type="float" nodename="dodge1" />
   </nodegraph>
-  <nodegraph name="dodge_color3" type="" xpos="8.25062" ypos="24.0124">
-    <dodge name="dodge1" type="color3" xpos="5.75172" ypos="4.42">
+  <nodegraph name="dodge_color3">
+    <dodge name="dodge1" type="color3">
       <input name="fg" type="color3" value="0.0, 0.2000, 0.0" />
       <input name="bg" type="color3" value="0.5000, 0.8000, 0.0" />
       <input name="mix" type="float" value="0.5000" />
     </dodge>
     <output name="out" type="color3" nodename="dodge1" />
   </nodegraph>
-  <nodegraph name="dodge_color4" type="" xpos="9.26441" ypos="24.0023">
-    <dodge name="dodge1" type="color4" xpos="5.75172" ypos="4.42">
+  <nodegraph name="dodge_color4">
+    <dodge name="dodge1" type="color4">
       <input name="fg" type="color4" value="0.0, 0.2000, 0.0, 0.0" />
       <input name="bg" type="color4" value="0.5000, 0.8000, 0.0, 1.0" />
       <input name="mix" type="float" value="0.5000" />
     </dodge>
     <output name="out" type="color4" nodename="dodge1" />
   </nodegraph>
-  <nodegraph name="screen_float" type="" xpos="6.21955" ypos="25.2955">
-    <screen name="screen1" type="float" xpos="5" ypos="9.92">
+  <nodegraph name="screen_float">
+    <screen name="screen1" type="float">
       <input name="fg" type="float" value="0.5000" />
       <input name="bg" type="float" value="0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </screen>
     <output name="out" type="float" nodename="screen1" />
   </nodegraph>
-  <nodegraph name="screen_color3" type="" xpos="8.2541" ypos="25.2753">
-    <screen name="screen1" type="color3" xpos="5" ypos="9.92">
+  <nodegraph name="screen_color3">
+    <screen name="screen1" type="color3">
       <input name="fg" type="color3" value="0.5000, 0.0, 0.0000" />
       <input name="bg" type="color3" value="0.5000, 1.0000, 0.0" />
       <input name="mix" type="float" value="0.5000" />
     </screen>
     <output name="out" type="color3" nodename="screen1" />
   </nodegraph>
-  <nodegraph name="screen_color4" type="" xpos="9.2679" ypos="25.2753">
-    <screen name="screen1" type="color4" xpos="5" ypos="9.92">
+  <nodegraph name="screen_color4">
+    <screen name="screen1" type="color4">
       <input name="fg" type="color4" value="0.5000, 0.0, 0.0, 1.0" />
       <input name="bg" type="color4" value="0.5000, 1.0000, 0.0, 1.0000" />
       <input name="mix" type="float" value="0.5000" />
     </screen>
     <output name="out" type="color4" nodename="screen1" />
   </nodegraph>
-  <nodegraph name="overlay_float" type="" xpos="6.22133" ypos="26.5621">
-    <overlay name="overlay1" type="float" xpos="5" ypos="9.92">
+  <nodegraph name="overlay_float">
+    <overlay name="overlay1" type="float">
       <input name="fg" type="float" value="0.5000" />
       <input name="bg" type="float" value="0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </overlay>
     <output name="out" type="float" nodename="overlay1" />
   </nodegraph>
-  <nodegraph name="overlay_color3" type="" xpos="8.25148" ypos="26.5369">
-    <overlay name="overlay1" type="color3" xpos="5" ypos="9.92">
+  <nodegraph name="overlay_color3">
+    <overlay name="overlay1" type="color3">
       <input name="fg" type="color3" value="0.5000, 0.0, 0.0" />
       <input name="bg" type="color3" value="0.5000, 1.0000, 0.0" />
       <input name="mix" type="float" value="0.5000" />
     </overlay>
     <output name="out" type="color3" nodename="overlay1" />
   </nodegraph>
-  <nodegraph name="overlay_color4" type="" xpos="9.26875" ypos="26.5268">
-    <overlay name="overlay1" type="color4" xpos="5" ypos="9.92">
+  <nodegraph name="overlay_color4">
+    <overlay name="overlay1" type="color4">
       <input name="fg" type="color4" value="0.5000, 0.0, 0.0, 1.0" />
       <input name="bg" type="color4" value="0.5000, 1.0000, 0.0, 1.0000" />
       <input name="mix" type="float" value="0.5000" />
     </overlay>
     <output name="out" type="color4" nodename="overlay1" />
   </nodegraph>
-  <nodegraph name="disjointover_color4" type="" xpos="7.24117" ypos="27.9109">
-    <disjointover name="disjointover1" type="color4" xpos="5" ypos="9.92">
+  <nodegraph name="disjointover_color4">
+    <disjointover name="disjointover1" type="color4">
       <input name="fg" type="color4" value="0.5000, 1.0000, 0.0, 1.0" />
       <input name="bg" type="color4" value="0.5000, 1.0000, 1.0000, 1.0000" />
       <input name="mix" type="float" value="0.5000" />
     </disjointover>
     <output name="out" type="color4" nodename="disjointover1" />
   </nodegraph>
-  <nodegraph name="disjointover_color4_divzero" type="" xpos="7.24117" ypos="27.9109">
-    <disjointover name="disjointover1" type="color4" xpos="5" ypos="9.92">
+  <nodegraph name="disjointover_color4_divzero">
+    <disjointover name="disjointover1" type="color4">
       <input name="fg" type="color4" value="0.5000, 1.0000, 0.0, 2.0" />
       <input name="bg" type="color4" value="0.5000, 1.0000, 1.0000, 0.0000" />
       <input name="mix" type="float" value="0.5000" />
     </disjointover>
     <output name="out" type="color4" nodename="disjointover1" />
   </nodegraph>
-  <nodegraph name="mask_color4" type="" xpos="7.22892" ypos="29.2733">
-    <mask name="mask1" type="color4" xpos="5.0069" ypos="9.92">
+  <nodegraph name="mask_color4">
+    <mask name="mask1" type="color4">
       <input name="fg" type="color4" value="1.0000, 1.0000, 1.0000, 1.000" />
       <input name="bg" type="color4" value="0.5000, 0.7500, 0.0, 1.000" />
       <input name="mix" type="float" value="0.5000" />
     </mask>
     <output name="out" type="color4" nodename="mask1" />
   </nodegraph>
-  <nodegraph name="out_color4" type="" xpos="7.23492" ypos="33.1872">
-    <out name="out1" type="color4" xpos="5.0069" ypos="9.92">
+  <nodegraph name="out_color4">
+    <out name="out1" type="color4">
       <input name="fg" type="color4" value="1.0000, 1.0000, 1.0000, 1.0000" />
       <input name="bg" type="color4" value="1.0000, 1.0000, 0.0, 1.0000" />
       <input name="mix" type="float" value="0.5000" />
     </out>
     <output name="out" type="color4" nodename="out1" />
   </nodegraph>
-  <nodegraph name="over_color4" type="" xpos="7.23192" ypos="34.5142">
-    <over name="over1" type="color4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="over_color4">
+    <over name="over1" type="color4">
       <input name="fg" type="color4" value="1.0000, 1.0000, 1.0000, 0.5000" />
       <input name="bg" type="color4" value="1.0000, 1.0000, 0.0, 0.5000" />
       <input name="mix" type="float" value="0.5000" />
     </over>
     <output name="out" type="color4" nodename="over1" />
   </nodegraph>
-  <nodegraph name="inside_float" type="" xpos="6.20881" ypos="35.9986">
-    <inside name="inside1" type="float" xpos="5.0069" ypos="10.08">
+  <nodegraph name="inside_float">
+    <inside name="inside1" type="float">
       <input name="in" type="float" value="1.0000" />
       <input name="mask" type="float" value="0.5000" />
     </inside>
     <output name="out" type="float" nodename="inside1" />
   </nodegraph>
-  <nodegraph name="mix_float" type="" xpos="6.2028" ypos="38.5028">
-    <mix name="mix1" type="float" xpos="5.74483" ypos="4.42">
+  <nodegraph name="mix_float">
+    <mix name="mix1" type="float">
       <input name="fg" type="float" value="1.0000" />
       <input name="bg" type="float" value="0.0" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <output name="out" type="float" nodename="mix1" />
   </nodegraph>
-  <nodegraph name="inside_color3" type="" xpos="8.23952" ypos="35.9726">
-    <inside name="inside1" type="color3" xpos="5.0069" ypos="10.08">
+  <nodegraph name="inside_color3">
+    <inside name="inside1" type="color3">
       <input name="in" type="color3" value="0.5000, 0.8000, 0.0000" />
       <input name="mask" type="float" value="0.5000" />
     </inside>
     <output name="out" type="color3" nodename="inside1" />
   </nodegraph>
-  <nodegraph name="inside_color4" type="" xpos="9.27257" ypos="35.9812">
-    <inside name="inside1" type="color4" xpos="5.0069" ypos="10.08">
+  <nodegraph name="inside_color4">
+    <inside name="inside1" type="color4">
       <input name="in" type="color4" value="0.5000, 0.8000, 0.0, 2.0" />
       <input name="mask" type="float" value="0.5000" />
     </inside>
     <output name="out" type="color4" nodename="inside1" />
   </nodegraph>
-  <nodegraph name="mix_color3" type="" xpos="8.24848" ypos="38.4926">
-    <mix name="mix1" type="color3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="mix_color3">
+    <mix name="mix1" type="color3">
       <input name="fg" type="color3" value="1.0000, 0.0, 0.0" />
       <input name="bg" type="color3" value="0.0, 1.0000, 0.0" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <output name="out" type="color3" nodename="mix1" />
   </nodegraph>
-  <nodegraph name="mix_color4" type="" xpos="9.3072" ypos="38.484">
-    <mix name="mix1" type="color4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="mix_color4">
+    <mix name="mix1" type="color4">
       <input name="fg" type="color4" value="1.0000, 0.0, 0.0, 1.0" />
       <input name="bg" type="color4" value="0.0000, 1.0000, 0.0, 1.0" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <output name="out" type="color4" nodename="mix1" />
   </nodegraph>
-  <nodegraph name="mix_vector2" type="" xpos="7.20853" ypos="39.9542">
-    <mix name="mix1" type="vector2" xpos="5.74483" ypos="4.42">
+  <nodegraph name="mix_vector2">
+    <mix name="mix1" type="vector2">
       <input name="fg" type="vector2" value="1.0000, 0.0" />
       <input name="bg" type="vector2" value="0.0, 1.0000" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <output name="out" type="vector2" nodename="mix1" />
   </nodegraph>
-  <nodegraph name="mix_vector3" type="" xpos="8.25643" ypos="39.9378">
-    <mix name="mix1" type="vector3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="mix_vector3">
+    <mix name="mix1" type="vector3">
       <input name="fg" type="vector3" value="1.0000, 0.0, 0.0" />
       <input name="bg" type="vector3" value="0.0, 1.0000, 0.0" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <output name="out" type="vector3" nodename="mix1" />
   </nodegraph>
-  <nodegraph name="mix_vector4" type="" xpos="9.325" ypos="39.889">
-    <mix name="mix1" type="vector4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="mix_vector4">
+    <mix name="mix1" type="vector4">
       <input name="fg" type="vector4" value="1.0000, 0.0, 0.0, 1.0" />
       <input name="bg" type="vector4" value="0.0, 1.0000, 0.0, 1.0" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <output name="out" type="vector4" nodename="mix1" />
   </nodegraph>
-  <nodegraph name="premult_color4" type="" xpos="8.25474" ypos="41.4442">
-    <premult name="premult1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="premult_color4">
+    <premult name="premult1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.0, 0.5000, 0.5000" />
     </premult>
     <output name="out" type="color4" nodename="premult1" />
   </nodegraph>
-  <nodegraph name="unpremult_color4" type="" xpos="8.27269" ypos="42.9706">
-    <unpremult name="unpremult1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="unpremult_color4">
+    <unpremult name="unpremult1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.0, 0.5000, 0.5000" />
     </unpremult>
     <output name="out" type="color4" nodename="unpremult1" />
   </nodegraph>
-  <nodegraph name="in_color4" type="" xpos="7.23719" ypos="31.8966">
-    <in name="in1" type="color4" xpos="5.75172" ypos="4.42">
+  <nodegraph name="in_color4">
+    <in name="in1" type="color4">
       <input name="fg" type="color4" value="1.0000, 1.0000, 1.0000, 1.000" />
       <input name="bg" type="color4" value="1.0000, 1.0000, 0.0, 1.000" />
       <input name="mix" type="float" value="0.5000" />
     </in>
     <output name="out" type="color4" nodename="in1" />
   </nodegraph>
-  <nodegraph name="outside_float" type="" xpos="6.21034" ypos="37.29">
-    <outside name="outside1" type="float" xpos="5.75172" ypos="4.58">
+  <nodegraph name="outside_float">
+    <outside name="outside1" type="float">
       <input name="in" type="float" value="1.0000" />
       <input name="mask" type="float" value="0.5000" />
     </outside>
     <output name="out" type="float" nodename="outside1" />
   </nodegraph>
-  <nodegraph name="outside_color3" type="" xpos="8.23448" ypos="37.25">
-    <outside name="outside1" type="color3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="outside_color3">
+    <outside name="outside1" type="color3">
       <input name="in" type="color3" value="0.5000, 0.8000, 0.0" />
       <input name="mask" type="float" value="0.5000" />
     </outside>
     <output name="out" type="color3" nodename="outside1" />
   </nodegraph>
-  <nodegraph name="outside_color4" type="" xpos="9.27241" ypos="37.25">
-    <outside name="outside1" type="color4" xpos="5.75172" ypos="4.58">
+  <nodegraph name="outside_color4">
+    <outside name="outside1" type="color4">
       <input name="in" type="color4" value="0.5000, 0.8000, 0.0, 2.0" />
       <input name="mask" type="float" value="0.5000" />
     </outside>
     <output name="out" type="color4" nodename="outside1" />
   </nodegraph>
-  <nodegraph name="matte_color4" type="" xpos="7.22237" ypos="30.6262">
-    <matte name="matte1" type="color4" xpos="5.75172" ypos="4.42">
+  <nodegraph name="matte_color4">
+    <matte name="matte1" type="color4">
       <input name="fg" type="color4" value="1.0000, 1.0000, 1.0000, 1.0000" />
       <input name="bg" type="color4" value="0.5000, 0.7500, 0.0, 1.0000" />
       <input name="mix" type="float" value="0.5000" />

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_if_float.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_if_float.mtlx
@@ -4,8 +4,8 @@
   Basic conditional if* function tests each test is in a separate graph for each variation in input type.
   Tests are for floating point comparisons.
   -->
-  <nodegraph name="ifgreater_float" type="" xpos="6.23104" ypos="18.6971">
-    <ifgreater name="ifgreater1" type="float" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreater_float">
+    <ifgreater name="ifgreater1" type="float">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="float" value="1.0000" />
@@ -13,8 +13,8 @@
     </ifgreater>
     <output name="out" type="float" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color2" type="" xpos="7.22691" ypos="18.6969">
-    <ifgreater name="ifgreater1" type="vector2" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreater_color2">
+    <ifgreater name="ifgreater1" type="vector2">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector2" value="1.0000, 1.0" />
@@ -22,8 +22,8 @@
     </ifgreater>
     <output name="out" type="vector2" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color3" type="" xpos="8.2183" ypos="18.688">
-    <ifgreater name="ifgreater1" type="color3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreater_color3">
+    <ifgreater name="ifgreater1" type="color3">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
@@ -31,8 +31,8 @@
     </ifgreater>
     <output name="out" type="color3" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color4" type="" xpos="9.22746" ypos="18.6895">
-    <ifgreater name="ifgreater1" type="color4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreater_color4">
+    <ifgreater name="ifgreater1" type="color4">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -40,8 +40,8 @@
     </ifgreater>
     <output name="out" type="color4" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_vector2" type="" xpos="7.22554" ypos="20.0111">
-    <ifgreater name="ifgreater1" type="vector2" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreater_vector2">
+    <ifgreater name="ifgreater1" type="vector2">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
@@ -49,8 +49,8 @@
     </ifgreater>
     <output name="out" type="vector2" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_vector3" type="" xpos="8.23554" ypos="20.0067">
-    <ifgreater name="ifgreater1" type="vector3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreater_vector3">
+    <ifgreater name="ifgreater1" type="vector3">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector3" value="1.0000, 1.0000, 1.0000" />
@@ -58,8 +58,8 @@
     </ifgreater>
     <output name="out" type="vector3" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_vector4" type="" xpos="9.2447" ypos="19.9853">
-    <ifgreater name="ifgreater1" type="vector4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreater_vector4">
+    <ifgreater name="ifgreater1" type="vector4">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -67,8 +67,8 @@
     </ifgreater>
     <output name="out" type="vector4" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifequal_float" type="" xpos="6.23104" ypos="18.6971">
-    <ifequal name="ifequal1" type="float" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifequal_float">
+    <ifequal name="ifequal1" type="float">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.8000" />
       <input name="in1" type="float" value="1.0000" />
@@ -76,8 +76,8 @@
     </ifequal>
     <output name="out" type="float" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_color2" type="" xpos="7.22691" ypos="18.6969">
-    <ifequal name="ifequal1" type="vector2" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifequal_color2">
+    <ifequal name="ifequal1" type="vector2">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.8000" />
       <input name="in1" type="vector2" value="1.0000, 1.0" />
@@ -85,8 +85,8 @@
     </ifequal>
     <output name="out" type="vector2" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_color3" type="" xpos="8.2183" ypos="18.688">
-    <ifequal name="ifequal1" type="color3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifequal_color3">
+    <ifequal name="ifequal1" type="color3">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.8000" />
       <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
@@ -94,8 +94,8 @@
     </ifequal>
     <output name="out" type="color3" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_color4" type="" xpos="9.22746" ypos="18.6895">
-    <ifequal name="ifequal1" type="color4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifequal_color4">
+    <ifequal name="ifequal1" type="color4">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.8000" />
       <input name="in1" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -103,8 +103,8 @@
     </ifequal>
     <output name="out" type="color4" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_vector2" type="" xpos="7.22554" ypos="20.0111">
-    <ifequal name="ifequal1" type="vector2" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifequal_vector2">
+    <ifequal name="ifequal1" type="vector2">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.8000" />
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
@@ -112,8 +112,8 @@
     </ifequal>
     <output name="out" type="vector2" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_vector3" type="" xpos="8.23554" ypos="20.0067">
-    <ifequal name="ifequal1" type="vector3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifequal_vector3">
+    <ifequal name="ifequal1" type="vector3">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.8000" />
       <input name="in1" type="vector3" value="1.0000, 1.0000, 1.0000" />
@@ -121,8 +121,8 @@
     </ifequal>
     <output name="out" type="vector3" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_vector4" type="" xpos="9.2447" ypos="19.9853">
-    <ifequal name="ifequal1" type="vector4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifequal_vector4">
+    <ifequal name="ifequal1" type="vector4">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.8000" />
       <input name="in1" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -130,8 +130,8 @@
     </ifequal>
     <output name="out" type="vector4" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_float" type="" xpos="6.23104" ypos="18.6971">
-    <ifgreatereq name="ifgreatereq1" type="float" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_float">
+    <ifgreatereq name="ifgreatereq1" type="float">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="float" value="1.0000" />
@@ -139,8 +139,8 @@
     </ifgreatereq>
     <output name="out" type="float" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_color2" type="" xpos="7.22691" ypos="18.6969">
-    <ifgreatereq name="ifgreatereq1" type="vector2" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_color2">
+    <ifgreatereq name="ifgreatereq1" type="vector2">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector2" value="1.0000, 1.0" />
@@ -148,8 +148,8 @@
     </ifgreatereq>
     <output name="out" type="vector2" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_color3" type="" xpos="8.2183" ypos="18.688">
-    <ifgreatereq name="ifgreatereq1" type="color3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_color3">
+    <ifgreatereq name="ifgreatereq1" type="color3">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
@@ -157,8 +157,8 @@
     </ifgreatereq>
     <output name="out" type="color3" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_color4" type="" xpos="9.22746" ypos="18.6895">
-    <ifgreatereq name="ifgreatereq1" type="color4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_color4">
+    <ifgreatereq name="ifgreatereq1" type="color4">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -166,8 +166,8 @@
     </ifgreatereq>
     <output name="out" type="color4" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_vector2" type="" xpos="7.22554" ypos="20.0111">
-    <ifgreatereq name="ifgreatereq1" type="vector2" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_vector2">
+    <ifgreatereq name="ifgreatereq1" type="vector2">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
@@ -175,8 +175,8 @@
     </ifgreatereq>
     <output name="out" type="vector2" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_vector3" type="" xpos="8.23554" ypos="20.0067">
-    <ifgreatereq name="ifgreatereq1" type="vector3" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_vector3">
+    <ifgreatereq name="ifgreatereq1" type="vector3">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector3" value="1.0000, 1.0000, 1.0000" />
@@ -184,8 +184,8 @@
     </ifgreatereq>
     <output name="out" type="vector3" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_vector4" type="" xpos="9.2447" ypos="19.9853">
-    <ifgreatereq name="ifgreatereq1" type="vector4" xpos="5.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_vector4">
+    <ifgreatereq name="ifgreatereq1" type="vector4">
       <input name="value1" type="float" value="0.8000" />
       <input name="value2" type="float" value="0.6000" />
       <input name="in1" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0" />

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_if_int.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_if_int.mtlx
@@ -6,8 +6,8 @@
   -->
 
   <!-- greater int condition -->
-  <nodegraph name="ifgreater_float" type="" xpos="6.23104" ypos="18.6971">
-    <ifgreater name="ifgreater1" type="float" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreater_float">
+    <ifgreater name="ifgreater1" type="float">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="float" value="1.0000" />
@@ -15,8 +15,8 @@
     </ifgreater>
     <output name="out" type="float" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color2" type="" xpos="7.22691" ypos="18.6969">
-    <ifgreater name="ifgreater1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreater_color2">
+    <ifgreater name="ifgreater1" type="vector2">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector2" value="1.0000, 1.0" />
@@ -24,8 +24,8 @@
     </ifgreater>
     <output name="out" type="vector2" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color3" type="" xpos="8.2183" ypos="18.688">
-    <ifgreater name="ifgreater1" type="color3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreater_color3">
+    <ifgreater name="ifgreater1" type="color3">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
@@ -33,8 +33,8 @@
     </ifgreater>
     <output name="out" type="color3" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color4" type="" xpos="9.22746" ypos="18.6898">
-    <ifgreater name="ifgreater1" type="color4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreater_color4">
+    <ifgreater name="ifgreater1" type="color4">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -42,8 +42,8 @@
     </ifgreater>
     <output name="out" type="color4" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_vector2" type="" xpos="7.22884" ypos="20.0111">
-    <ifgreater name="ifgreater1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreater_vector2">
+    <ifgreater name="ifgreater1" type="vector2">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
@@ -51,8 +51,8 @@
     </ifgreater>
     <output name="out" type="vector2" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_vector3" type="" xpos="8.23884" ypos="20.0067">
-    <ifgreater name="ifgreater1" type="vector3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreater_vector3">
+    <ifgreater name="ifgreater1" type="vector3">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector3" value="1.0000, 1.0000, 1.0000" />
@@ -60,8 +60,8 @@
     </ifgreater>
     <output name="out" type="vector3" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_vector4" type="" xpos="9.2447" ypos="19.9883">
-    <ifgreater name="ifgreater1" type="vector4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreater_vector4">
+    <ifgreater name="ifgreater1" type="vector4">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -71,8 +71,8 @@
   </nodegraph>
 
   <!-- equal int condition -->
-  <nodegraph name="ifequal_float" type="" xpos="6.23104" ypos="18.6971">
-    <ifequal name="ifequal1" type="float" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequal_float">
+    <ifequal name="ifequal1" type="float">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="8" />
       <input name="in1" type="float" value="1.0000" />
@@ -80,8 +80,8 @@
     </ifequal>
     <output name="out" type="float" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_color2" type="" xpos="7.22691" ypos="18.6969">
-    <ifequal name="ifequal1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequal_color2">
+    <ifequal name="ifequal1" type="vector2">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="8" />
       <input name="in1" type="vector2" value="1.0000, 1.0" />
@@ -89,8 +89,8 @@
     </ifequal>
     <output name="out" type="vector2" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_color3" type="" xpos="8.2183" ypos="18.688">
-    <ifequal name="ifequal1" type="color3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequal_color3">
+    <ifequal name="ifequal1" type="color3">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="8" />
       <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
@@ -98,8 +98,8 @@
     </ifequal>
     <output name="out" type="color3" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_color4" type="" xpos="9.22746" ypos="18.6898">
-    <ifequal name="ifequal1" type="color4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequal_color4">
+    <ifequal name="ifequal1" type="color4">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="8" />
       <input name="in1" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -107,8 +107,8 @@
     </ifequal>
     <output name="out" type="color4" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_vector2" type="" xpos="7.22884" ypos="20.0111">
-    <ifequal name="ifequal1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequal_vector2">
+    <ifequal name="ifequal1" type="vector2">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="8" />
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
@@ -116,8 +116,8 @@
     </ifequal>
     <output name="out" type="vector2" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_vector3" type="" xpos="8.23884" ypos="20.0067">
-    <ifequal name="ifequal1" type="vector3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequal_vector3">
+    <ifequal name="ifequal1" type="vector3">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="8" />
       <input name="in1" type="vector3" value="1.0000, 1.0000, 1.0000" />
@@ -125,8 +125,8 @@
     </ifequal>
     <output name="out" type="vector3" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_vector4" type="" xpos="9.2447" ypos="19.9883">
-    <ifequal name="ifequal1" type="vector4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequal_vector4">
+    <ifequal name="ifequal1" type="vector4">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="8" />
       <input name="in1" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -136,8 +136,8 @@
   </nodegraph>
 
   <!-- equal boolean condition -->
-  <nodegraph name="ifequalB_float" type="" xpos="6.23104" ypos="18.6971">
-    <ifequal name="ifequal1" type="float" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequalB_float">
+    <ifequal name="ifequal1" type="float">
       <input name="value1" type="boolean" value="true" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="float" value="1.0000" />
@@ -145,8 +145,8 @@
     </ifequal>
     <output name="out" type="float" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequalB_color2" type="" xpos="7.22691" ypos="18.6969">
-    <ifequal name="ifequal1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequalB_color2">
+    <ifequal name="ifequal1" type="vector2">
       <input name="value1" type="boolean" value="true" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="vector2" value="1.0000, 1.0" />
@@ -154,8 +154,8 @@
     </ifequal>
     <output name="out" type="vector2" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequalB_color3" type="" xpos="8.2183" ypos="18.688">
-    <ifequal name="ifequal1" type="color3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequalB_color3">
+    <ifequal name="ifequal1" type="color3">
       <input name="value1" type="boolean" value="true" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
@@ -163,8 +163,8 @@
     </ifequal>
     <output name="out" type="color3" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequalB_color4" type="" xpos="9.22746" ypos="18.6898">
-    <ifequal name="ifequal1" type="color4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequalB_color4">
+    <ifequal name="ifequal1" type="color4">
       <input name="value1" type="boolean" value="true" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -172,8 +172,8 @@
     </ifequal>
     <output name="out" type="color4" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequalB_vector2" type="" xpos="7.22884" ypos="20.0111">
-    <ifequal name="ifequal1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequalB_vector2">
+    <ifequal name="ifequal1" type="vector2">
       <input name="value1" type="boolean" value="true" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
@@ -181,8 +181,8 @@
     </ifequal>
     <output name="out" type="vector2" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequalB_vector3" type="" xpos="8.23884" ypos="20.0067">
-    <ifequal name="ifequal1" type="vector3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequalB_vector3">
+    <ifequal name="ifequal1" type="vector3">
       <input name="value1" type="boolean" value="true" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="vector3" value="1.0000, 1.0000, 1.0000" />
@@ -190,8 +190,8 @@
     </ifequal>
     <output name="out" type="vector3" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequalB_vector4" type="" xpos="9.2447" ypos="19.9883">
-    <ifequal name="ifequal1" type="vector4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifequalB_vector4">
+    <ifequal name="ifequal1" type="vector4">
       <input name="value1" type="boolean" value="true" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -201,8 +201,8 @@
   </nodegraph>
 
   <!-- greatereq int condition -->
-  <nodegraph name="ifgreatereq_float" type="" xpos="6.23104" ypos="18.6971">
-    <ifgreatereq name="ifgreatereq1" type="float" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_float">
+    <ifgreatereq name="ifgreatereq1" type="float">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="float" value="1.0000" />
@@ -210,8 +210,8 @@
     </ifgreatereq>
     <output name="out" type="float" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_color2" type="" xpos="7.22691" ypos="18.6969">
-    <ifgreatereq name="ifgreatereq1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_color2">
+    <ifgreatereq name="ifgreatereq1" type="vector2">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector2" value="1.0000, 1.0" />
@@ -219,8 +219,8 @@
     </ifgreatereq>
     <output name="out" type="vector2" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_color3" type="" xpos="8.2183" ypos="18.688">
-    <ifgreatereq name="ifgreatereq1" type="color3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_color3">
+    <ifgreatereq name="ifgreatereq1" type="color3">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
@@ -228,8 +228,8 @@
     </ifgreatereq>
     <output name="out" type="color3" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_color4" type="" xpos="9.22746" ypos="18.6898">
-    <ifgreatereq name="ifgreatereq1" type="color4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_color4">
+    <ifgreatereq name="ifgreatereq1" type="color4">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
@@ -237,8 +237,8 @@
     </ifgreatereq>
     <output name="out" type="color4" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_vector2" type="" xpos="7.22884" ypos="20.0111">
-    <ifgreatereq name="ifgreatereq1" type="vector2" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_vector2">
+    <ifgreatereq name="ifgreatereq1" type="vector2">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
@@ -246,8 +246,8 @@
     </ifgreatereq>
     <output name="out" type="vector2" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_vector3" type="" xpos="8.23884" ypos="20.0067">
-    <ifgreatereq name="ifgreatereq1" type="vector3" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_vector3">
+    <ifgreatereq name="ifgreatereq1" type="vector3">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector3" value="1.0000, 1.0000, 1.0000" />
@@ -255,8 +255,8 @@
     </ifgreatereq>
     <output name="out" type="vector3" nodename="ifgreatereq1" />
   </nodegraph>
-  <nodegraph name="ifgreatereq_vector4" type="" xpos="9.2447" ypos="19.9883">
-    <ifgreatereq name="ifgreatereq1" type="vector4" xpos="8.74483" ypos="4.42">
+  <nodegraph name="ifgreatereq_vector4">
+    <ifgreatereq name="ifgreatereq1" type="vector4">
       <input name="value1" type="integer" value="8" />
       <input name="value2" type="integer" value="6" />
       <input name="in1" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0" />

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_switch.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_switch.mtlx
@@ -3,8 +3,8 @@
   <!--
   Basic switch conditional function tests each test is in a separate graph for each variation in input type.
   -->
-  <nodegraph name="switch_float" type="" xpos="6.26074" ypos="21.3283">
-    <switch name="switch1" type="float" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_float">
+    <switch name="switch1" type="float">
       <input name="in1" type="float" value="0.0000" />
       <input name="in2" type="float" value="0.3000" />
       <input name="in3" type="float" value="0.5000" />
@@ -14,8 +14,8 @@
     </switch>
     <output name="out" type="float" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_color2" type="" xpos="7.23526" ypos="21.2988">
-    <switch name="switch1" type="vector2" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_color2">
+    <switch name="switch1" type="vector2">
       <input name="in1" type="vector2" value="0.0, 0.0" />
       <input name="in2" type="vector2" value="0.3000, 0.3000" />
       <input name="in3" type="vector2" value="0.5000, 0.5000" />
@@ -25,8 +25,8 @@
     </switch>
     <output name="out" type="vector2" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_color3" type="" xpos="8.25501" ypos="21.2779">
-    <switch name="switch1" type="color3" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_color3">
+    <switch name="switch1" type="color3">
       <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
       <input name="in2" type="color3" value="0.3000, 0.3000, 0.3000" />
       <input name="in3" type="color3" value="0.5000, 0.5000, 0.5000" />
@@ -36,8 +36,8 @@
     </switch>
     <output name="out" type="color3" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_color4" type="" xpos="9.27533" ypos="21.2779">
-    <switch name="switch1" type="color4" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_color4">
+    <switch name="switch1" type="color4">
       <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0000" />
       <input name="in2" type="color4" value="0.3000, 0.3000, 0.3000, 0.5000" />
       <input name="in3" type="color4" value="0.5000, 0.5000, 0.5000, 0.5000" />
@@ -47,8 +47,8 @@
     </switch>
     <output name="out" type="color4" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_vector2" type="" xpos="7.25927" ypos="22.6088">
-    <switch name="switch1" type="vector2" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_vector2">
+    <switch name="switch1" type="vector2">
       <input name="in1" type="vector2" value="0.0, 0.0" />
       <input name="in2" type="vector2" value="0.3000, 0.3000" />
       <input name="in3" type="vector2" value="0.5000, 0.5000" />
@@ -58,8 +58,8 @@
     </switch>
     <output name="out" type="vector2" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_vector3" type="" xpos="8.2755" ypos="22.6088">
-    <switch name="switch1" type="vector3" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_vector3">
+    <switch name="switch1" type="vector3">
       <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="in2" type="vector3" value="0.3000, 0.3000, 0.3000" />
       <input name="in3" type="vector3" value="0.5000, 0.5000, 0.5000" />
@@ -69,8 +69,8 @@
     </switch>
     <output name="out" type="vector3" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_vector4" type="" xpos="9.29992" ypos="22.5969">
-    <switch name="switch1" type="vector4" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_vector4">
+    <switch name="switch1" type="vector4">
       <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
       <input name="in2" type="vector4" value="0.3000, 0.3000, 0.3000, 0.3000" />
       <input name="in3" type="vector4" value="0.5000, 0.5000, 0.5000, 0.5000" />
@@ -80,8 +80,8 @@
     </switch>
     <output name="out" type="vector4" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_floatI" type="" xpos="7.27129" ypos="23.9048">
-    <switch name="switch1" type="float" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_floatI">
+    <switch name="switch1" type="float">
       <input name="in1" type="float" value="0.0" />
       <input name="in2" type="float" value="0.3000" />
       <input name="in3" type="float" value="0.5000" />
@@ -91,8 +91,8 @@
     </switch>
     <output name="out" type="float" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_color2I" type="" xpos="8.29571" ypos="23.8875">
-    <switch name="switch1" type="vector2" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_color2I">
+    <switch name="switch1" type="vector2">
       <input name="in1" type="vector2" value="0.0000, 0.0000" />
       <input name="in2" type="vector2" value="0.3000, 0.3000" />
       <input name="in3" type="vector2" value="0.5000, 0.5000" />
@@ -102,8 +102,8 @@
     </switch>
     <output name="out" type="vector2" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_color3I" type="" xpos="9.31603" ypos="23.8875">
-    <switch name="switch1" type="color3" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_color3I">
+    <switch name="switch1" type="color3">
       <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
       <input name="in2" type="color3" value="0.3000, 0.3000, 0.3000" />
       <input name="in3" type="color3" value="0.5000, 0.5000, 0.5000" />
@@ -113,8 +113,8 @@
     </switch>
     <output name="out" type="color3" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="swicth_color4I" type="" xpos="7.29588" ypos="25.1828">
-    <switch name="switch1" type="color4" xpos="5.74483" ypos="4.12">
+  <nodegraph name="swicth_color4I">
+    <switch name="switch1" type="color4">
       <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
       <input name="in2" type="color4" value="0.3000, 0.3000, 0.3000, 0.3000" />
       <input name="in3" type="color4" value="0.5000, 0.5000, 0.5000, 0.5000" />
@@ -124,8 +124,8 @@
     </switch>
     <output name="out" type="color4" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_vector2I" type="" xpos="8.32439" ypos="25.1718">
-    <switch name="switch1" type="vector2" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_vector2I">
+    <switch name="switch1" type="vector2">
       <input name="in1" type="vector2" value="0.0, 0.0" />
       <input name="in2" type="vector2" value="0.3000, 0.3000" />
       <input name="in3" type="vector2" value="0.5000, 0.5000" />
@@ -135,8 +135,8 @@
     </switch>
     <output name="out" type="vector2" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_vector3I" type="" xpos="9.33242" ypos="25.1718">
-    <switch name="switch1" type="vector3" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_vector3I">
+    <switch name="switch1" type="vector3">
       <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="in2" type="vector3" value="0.3000, 0.3000, 0.3000" />
       <input name="in3" type="vector3" value="0.5000, 0.5000, 0.5000" />
@@ -146,8 +146,8 @@
     </switch>
     <output name="out" type="vector3" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_vector4I" type="" xpos="7.29338" ypos="26.4621">
-    <switch name="switch1" type="vector4" xpos="5.74483" ypos="4.12">
+  <nodegraph name="switch_vector4I">
+    <switch name="switch1" type="vector4">
       <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
       <input name="in2" type="vector4" value="0.3000, 0.3000, 0.3000, 0.3000" />
       <input name="in3" type="vector4" value="0.5000, 0.5000, 0.5000, 0.5000" />

--- a/resources/Materials/TestSuite/stdlib/convolution/blur.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/blur.mtlx
@@ -3,163 +3,122 @@
   <!---
      Blur unit test
   -->
-  <nodegraph name="blur_float" type="" xpos="8.42368" ypos="11.8375">
-    <image name="image1" type="float" xpos="4.26897" ypos="10.02">
+  <nodegraph name="blur_float">
+    <image name="image1" type="float">
       <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="default" type="float" value="0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" />
     </image>
-    <blur name="blur1" type="float" xpos="5.74789" ypos="9.48">
-      <input name="in" type="float" value="0.0" nodename="image1" />
+    <blur name="blur1" type="float">
+      <input name="in" type="float" nodename="image1" />
       <input name="size" type="float" value="0.4000" />
       <input name="filtertype" type="string" value="box" />
     </blur>
     <output name="out" type="float" nodename="blur1" />
   </nodegraph>
-  <nodegraph name="blur_color3" type="" xpos="8.38333" ypos="15.4672">
-    <image name="image2" type="color3" xpos="4.26514" ypos="10.02">
+  <nodegraph name="blur_color3">
+    <image name="image2" type="color3">
       <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" />
     </image>
-    <blur name="blur2" type="color3" xpos="5.75172" ypos="9.48">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="image2" />
+    <blur name="blur2" type="color3">
+      <input name="in" type="color3" nodename="image2" />
       <input name="size" type="float" value="0.1000" />
       <input name="filtertype" type="string" value="box" />
     </blur>
     <output name="out" type="color3" nodename="blur2" />
   </nodegraph>
-  <nodegraph name="blur_float_cellnoise" type="" xpos="6.95067" ypos="17.8001">
-    <cellnoise2d name="cellnoise2d1" type="float" xpos="5.75172" ypos="9.2">
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+  <nodegraph name="blur_float_cellnoise">
+    <cellnoise2d name="cellnoise2d1" type="float">
+      <input name="texcoord" type="vector2" nodename="multiply1" />
     </cellnoise2d>
-    <blur name="blur3" type="float" xpos="7.23448" ypos="9.2">
-      <input name="in" type="float" value="0.0" nodename="cellnoise2d1" />
+    <blur name="blur3" type="float">
+      <input name="in" type="float" nodename="cellnoise2d1" />
       <input name="size" type="float" value="0.7000" />
       <input name="filtertype" type="string" value="box" />
     </blur>
     <output name="out" type="float" nodename="blur3" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.78621" ypos="10.3">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.26897" ypos="9.76">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="100.0000, 100.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="blur_noise" type="" xpos="6.92883" ypos="15.5156">
-    <blur name="blur1" type="vector2" xpos="7.24668" ypos="8.96">
-      <input name="in" type="vector2" value="0.0, 1.0" nodename="noise2d1" />
+  <nodegraph name="blur_noise">
+    <blur name="blur1" type="vector2">
+      <input name="in" type="vector2" nodename="noise2d1" />
       <input name="size" type="float" value="0.1000" />
       <input name="filtertype" type="string" value="box" />
     </blur>
-    <noise2d name="noise2d1" type="vector2" xpos="5.82162" ypos="10.035">
+    <noise2d name="noise2d1" type="vector2">
       <input name="amplitude" type="vector2" value="1.0000, 2.0000" />
       <input name="pivot" type="float" value="0.4000" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
     </noise2d>
     <output name="out" type="vector2" nodename="blur1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.78621" ypos="10.58">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.26897" ypos="9.98694">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="50.0000, 50.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="blur_color2" type="" xpos="8.36983" ypos="14.1887">
-    <image name="image1" type="vector2" xpos="4.72893" ypos="14.7138">
+  <nodegraph name="blur_color2">
+    <image name="image1" type="vector2">
       <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="layer" type="string" value="" />
-      <input name="default" type="vector2" value="0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="vector2" nodename="blur1" />
-    <blur name="blur1" type="vector2" xpos="6.00592" ypos="14.0457">
-      <input name="in" type="vector2" value="0.0, 1.0" nodename="image1" />
+    <blur name="blur1" type="vector2">
+      <input name="in" type="vector2" nodename="image1" />
       <input name="size" type="float" value="1.0000" />
       <input name="filtertype" type="string" value="box" />
     </blur>
   </nodegraph>
-  <nodegraph name="blur_vector2" type="" xpos="8.44298" ypos="19.7465">
-    <tiledimage name="tiledimage1" type="vector2" xpos="4.36194" ypos="5.05426">
+  <nodegraph name="blur_vector2">
+    <tiledimage name="tiledimage1" type="vector2">
       <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="default" type="vector2" value="0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" />
       <input name="uvtiling" type="vector2" value="0.2000, 0.2000" />
-      <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </tiledimage>
     <output name="out" type="vector2" nodename="blur1" />
-    <blur name="blur1" type="vector2" xpos="5.62498" ypos="7.67688">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="tiledimage1" />
+    <blur name="blur1" type="vector2">
+      <input name="in" type="vector2" nodename="tiledimage1" />
       <input name="size" type="float" value="0.4000" />
       <input name="filtertype" type="string" value="gaussian" />
     </blur>
   </nodegraph>
-  <nodegraph name="blur_vector3" type="" xpos="8.44785" ypos="21.4295">
-    <tiledimage name="tiledimage1" type="vector3" xpos="4.82888" ypos="5.20368">
+  <nodegraph name="blur_vector3">
+    <tiledimage name="tiledimage1" type="vector3">
       <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" />
       <input name="uvtiling" type="vector2" value="0.1000, 0.1000" />
-      <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </tiledimage>
     <output name="out" type="vector3" nodename="blur1" />
-    <blur name="blur1" type="vector3" xpos="6.08171" ypos="7.48624">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="tiledimage1" />
+    <blur name="blur1" type="vector3">
+      <input name="in" type="vector3" nodename="tiledimage1" />
       <input name="size" type="float" value="0.1000" />
       <input name="filtertype" type="string" value="box" />
     </blur>
   </nodegraph>
-  <nodegraph name="blur_color4" type="" xpos="8.4381" ypos="17.7808">
-    <blur name="blur1" type="color4" xpos="6.57318" ypos="7.01756">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="tiledimage1" />
+  <nodegraph name="blur_color4">
+    <blur name="blur1" type="color4">
+      <input name="in" type="color4" nodename="tiledimage1" />
       <input name="size" type="float" value="0.3000" />
       <input name="filtertype" type="string" value="gaussian" />
     </blur>
-    <tiledimage name="tiledimage1" type="color4" xpos="5.38269" ypos="7.44224">
+    <tiledimage name="tiledimage1" type="color4">
       <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" />
       <input name="uvtiling" type="vector2" value="0.2000, 0.2000" />
-      <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </tiledimage>
     <output name="out" type="color4" nodename="blur1" />
   </nodegraph>
-  <nodegraph name="blur_vector4" type="" xpos="8.46248" ypos="23.2538">
-    <blur name="blur1" type="vector4" xpos="6.46253" ypos="8.25236">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="tiledimage1" />
+  <nodegraph name="blur_vector4">
+    <blur name="blur1" type="vector4">
+      <input name="in" type="vector4" nodename="tiledimage1" />
       <input name="size" type="float" value="0.3000" />
       <input name="filtertype" type="string" value="gaussian" />
     </blur>
-    <tiledimage name="tiledimage1" type="vector4" xpos="5.45428" ypos="6.50982">
+    <tiledimage name="tiledimage1" type="vector4">
       <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" />
       <input name="uvtiling" type="vector2" value="0.4000, 0.4000" />
-      <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </tiledimage>
     <output name="out" type="vector4" nodename="blur1" />
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="hton_unconnected_graph" xpos="-27.6471" ypos="304.882">
-    <heighttonormal name="heighttonormal1" type="vector3" xpos="-441.909" ypos="554.975">
+  <nodegraph name="hton_unconnected_graph">
+    <heighttonormal name="heighttonormal1" type="vector3">
       <input name="in" type="float" value="1" />
       <input name="scale" type="float" value="1" />
     </heighttonormal>
-    <normalmap name="normalmap" type="vector3" xpos="-60.5" ypos="176">
+    <normalmap name="normalmap" type="vector3">
       <input name="in" type="vector3" nodename="heighttonormal1" />
     </normalmap>
-    <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1" xpos="289.5" ypos="209">
+    <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1">
       <input name="normal" type="vector3" nodename="normalmap" />
     </standard_surface>
-    <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader" version="2.3" xpos="-123.25" ypos="564">
+    <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader" version="2.3">
       <input name="normal" type="vector3" nodename="heighttonormal1" />
     </UsdPreviewSurface>
     <output name="const_outHeightToNormal" type="vector3" nodename="heighttonormal1" />
@@ -19,24 +19,24 @@
     <output name="const_outStandardSurface" type="surfaceshader" nodename="standard_surface" />
     <output name="const_outUSDSurface" type="surfaceshader" nodename="UsdPreviewSurface" />
   </nodegraph>
-  <nodegraph name="hton_image_graph" xpos="-20.5886" ypos="1.76472">
+  <nodegraph name="hton_image_graph">
     <input name="file" type="filename" uniform="true" value="resources/Images/plain_heightmap.png" />
-    <heighttonormal name="heighttonormal1" type="vector3" xpos="620" ypos="112.591">
+    <heighttonormal name="heighttonormal1" type="vector3">
       <input name="in" type="float" nodename="tiledimage" />
       <input name="scale" type="float" value="0.2" />
     </heighttonormal>
-    <tiledimage name="tiledimage" type="float" xpos="315" ypos="138">
+    <tiledimage name="tiledimage" type="float">
       <input name="file" type="filename" uniform="true" interfacename="file" value="resources/Images/plain_heightmap.png" />
       <input name="uvtiling" type="vector2" value="10, 10" />
     </tiledimage>
-    <normalmap name="normalmap" type="vector3" xpos="925" ypos="137">
+    <normalmap name="normalmap" type="vector3">
       <input name="in" type="vector3" nodename="heighttonormal1" />
       <input name="scale" type="float" value="1" />
     </normalmap>
-    <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1" xpos="1345.52" ypos="403.639">
+    <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1">
       <input name="normal" type="vector3" nodename="normalmap" />
     </standard_surface>
-    <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader" version="2.3" xpos="893.447" ypos="531.913">
+    <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader" version="2.3">
       <input name="normal" type="vector3" nodename="heighttonormal1" />
     </UsdPreviewSurface>
     <output name="txt_outHeightToNormal" type="vector3" nodename="heighttonormal1" />

--- a/resources/Materials/TestSuite/stdlib/definition/definition_using_definitions.mtlx
+++ b/resources/Materials/TestSuite/stdlib/definition/definition_using_definitions.mtlx
@@ -199,7 +199,7 @@
       <input name="offset" type="vector2" nodename="total_offset" />
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
-      <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="rotate" type="float" nodename="rotation_angle_param" />
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
@@ -255,7 +255,7 @@
       <input name="offset" type="vector2" nodename="total_offset" />
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
-      <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="rotate" type="float" nodename="rotation_angle_param" />
     </place2d>
     <image name="b_image" type="vector3">
       <input name="file" type="filename" interfacename="file" />
@@ -312,7 +312,7 @@
       <input name="offset" type="vector2" nodename="total_offset" />
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
-      <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="rotate" type="float" nodename="rotation_angle_param" />
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />

--- a/resources/Materials/TestSuite/stdlib/geometric/geompropvalue.mtlx
+++ b/resources/Materials/TestSuite/stdlib/geometric/geompropvalue.mtlx
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <output name="geompropvalue_integer_out" type="vector4" nodename="switch1" xpos="12.4207" ypos="4.42" />
-  <switch name="switch1" type="vector4" xpos="5.74483" ypos="4.12">
+  <output name="geompropvalue_integer_out" type="vector4" nodename="switch1" />
+  <switch name="switch1" type="vector4">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 1.0" />
     <input name="in2" type="vector4" value="0.0, 1.0, 1.0, 1.0" />
     <input name="in3" type="vector4" value="1.0, 0.0, 1.0, 1.0" />
@@ -9,53 +9,53 @@
     <input name="in5" type="vector4" value="0.0, 1.0, 0.0, 1.0" />
     <input name="which" type="integer" nodename="geompropvalue_integer" />
   </switch>
-  <geompropvalue name="geompropvalue_integer" type="integer" xpos="9.00908" ypos="16.4387">
+  <geompropvalue name="geompropvalue_integer" type="integer">
     <input name="geomprop" type="string" value="geompropvalue_integer" />
   </geompropvalue>
-  <output name="geompropvalue_boolean_out" type="color3" nodename="switch2" xpos="12.4886" ypos="11.0706" />
-  <ifequal name="switch2" type="color3" xpos="5.74483" ypos="4.58">
+  <output name="geompropvalue_boolean_out" type="color3" nodename="switch2" />
+  <ifequal name="switch2" type="color3">
     <input name="in1" type="color3" value="1.0000, 1.0000, 1.0000" />
     <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
     <input name="value1" type="boolean" nodename="geompropvalue_boolean" />
     <input name="value2" type="boolean" value="true" />
   </ifequal>
-  <geompropvalue name="geompropvalue_boolean" type="boolean" xpos="9.15917" ypos="14.1093">
+  <geompropvalue name="geompropvalue_boolean" type="boolean">
     <input name="geomprop" type="string" value="geompropvalue_bool" />
   </geompropvalue>
-  <output name="geompropvalue_string_out" type="color3" nodename="swizzle1" xpos="12.4636" ypos="6.70438" />
-  <swizzle name="swizzle1" type="color3" xpos="5.74483" ypos="4.74">
+  <output name="geompropvalue_string_out" type="color3" nodename="swizzle1" />
+  <swizzle name="swizzle1" type="color3">
     <input name="in" type="color3" value="0.5, 0.5, 0.5" />
     <input name="channels" type="string" nodename="geompropvalue_string" />
   </swizzle>
-  <geompropvalue name="geompropvalue_string" type="string" xpos="9.07912" ypos="3.95942">
+  <geompropvalue name="geompropvalue_string" type="string">
     <input name="geomprop" type="string" value="geompropvalue_string" />
   </geompropvalue>
-  <output name="geompropvalue_float_out" type="float" nodename="geompropvalue_float" xpos="12.4759" ypos="8.82" />
-  <geompropvalue name="geompropvalue_float" type="float" xpos="8.98436" ypos="6.29386">
+  <output name="geompropvalue_float_out" type="float" nodename="geompropvalue_float" />
+  <geompropvalue name="geompropvalue_float" type="float">
     <input name="geomprop" type="string" value="geompropvalue_float" />
   </geompropvalue>
-  <output name="geompropvalue_color2_out" type="vector2" nodename="geompropvalue_color2" xpos="12.5241" ypos="22.02" />
-  <geompropvalue name="geompropvalue_color2" type="vector2" xpos="9.06207" ypos="8.8">
+  <output name="geompropvalue_color2_out" type="vector2" nodename="geompropvalue_color2" />
+  <geompropvalue name="geompropvalue_color2" type="vector2">
     <input name="geomprop" type="string" value="geompropvalue_color2" />
   </geompropvalue>
-  <output name="geompropvalue_color3_out" type="color3" nodename="geompropvalue_color3" xpos="12.5241" ypos="19.82" />
-  <geompropvalue name="geompropvalue_color3" type="color3" xpos="9.06207" ypos="8.8">
+  <output name="geompropvalue_color3_out" type="color3" nodename="geompropvalue_color3" />
+  <geompropvalue name="geompropvalue_color3" type="color3">
     <input name="geomprop" type="string" value="geompropvalue_color3" />
   </geompropvalue>
-  <output name="geompropvalue_color4_out" type="color4" nodename="geompropvalue_color4" xpos="12.5241" ypos="24.22" />
-  <geompropvalue name="geompropvalue_color4" type="color4" xpos="9.14353" ypos="11.1117">
+  <output name="geompropvalue_color4_out" type="color4" nodename="geompropvalue_color4" />
+  <geompropvalue name="geompropvalue_color4" type="color4">
     <input name="geomprop" type="string" value="geompropvalue_color4" />
   </geompropvalue>
-  <output name="geompropvalue_vector2_out" type="vector2" nodename="geompropvalue_vector2" xpos="12.5034" ypos="17.62" />
-  <geompropvalue name="geompropvalue_vector2" type="vector2" xpos="9.1327" ypos="23.9284">
+  <output name="geompropvalue_vector2_out" type="vector2" nodename="geompropvalue_vector2" />
+  <geompropvalue name="geompropvalue_vector2" type="vector2">
     <input name="geomprop" type="string" value="geompropvalue_vector2" />
   </geompropvalue>
-  <output name="geompropvalue_vector3_out" type="vector3" nodename="geompropvalue_vector3" xpos="12.5093" ypos="13.22" />
-  <geompropvalue name="geompropvalue_vector3" type="vector3" xpos="9.1327" ypos="21.1948">
+  <output name="geompropvalue_vector3_out" type="vector3" nodename="geompropvalue_vector3" />
+  <geompropvalue name="geompropvalue_vector3" type="vector3">
     <input name="geomprop" type="string" value="geompropvalue_vector3" />
   </geompropvalue>
-  <output name="geompropvalue_vector4_out" type="vector4" nodename="geompropvalue_vector4" xpos="12.5034" ypos="15.42" />
-  <geompropvalue name="geompropvalue_vector4" type="vector4" xpos="9.22581" ypos="18.5962">
+  <output name="geompropvalue_vector4_out" type="vector4" nodename="geompropvalue_vector4" />
+  <geompropvalue name="geompropvalue_vector4" type="vector4">
     <input name="geomprop" type="string" value="geompropvalue_vector4" />
   </geompropvalue>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/math/math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math.mtlx
@@ -1,323 +1,323 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="ln_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <ln name="ln1" type="float" xpos="5.74483" ypos="4.74">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="ln_nodegraph">
+    <ln name="ln1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </ln>
-    <constant name="constant1" type="float" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="1.5000" />
     </constant>
     <output name="out" type="float" nodename="ln1" />
   </nodegraph>
-  <nodegraph name="ln_vector2_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <ln name="ln1" type="vector2" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="ln_vector2_nodegraph">
+    <ln name="ln1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </ln>
-    <constant name="constant1" type="vector2" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.5, 1.5" />
     </constant>
     <output name="out" type="vector2" nodename="ln1" />
   </nodegraph>
-  <nodegraph name="ln_vector3_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <ln name="ln1" type="vector3" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="ln_vector3_nodegraph">
+    <ln name="ln1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </ln>
-    <constant name="constant1" type="vector3" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.5, 1.5, 1.5" />
     </constant>
     <output name="out" type="vector3" nodename="ln1" />
   </nodegraph>
-  <nodegraph name="ln_vector4_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <ln name="ln1" type="vector4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="ln_vector4_nodegraph">
+    <ln name="ln1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </ln>
-    <constant name="constant1" type="vector4" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.5, 1.5, 1.5, 1.0" />
     </constant>
     <output name="out" type="vector4" nodename="ln1" />
   </nodegraph>
-  <nodegraph name="exp_nodegraph" type="" xpos="5.8768" ypos="16.0483">
-    <exp name="exp1" type="float" xpos="5.74483" ypos="4.74">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="exp_nodegraph">
+    <exp name="exp1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </exp>
-    <constant name="constant1" type="float" xpos="4.63706" ypos="5.0147">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="-1.0000" />
     </constant>
     <output name="out" type="float" nodename="exp1" />
   </nodegraph>
-  <nodegraph name="exp_vector2_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <exp name="exp1" type="vector2" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="exp_vector2_nodegraph">
+    <exp name="exp1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </exp>
-    <constant name="constant1" type="vector2" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.5, 1.5" />
     </constant>
     <output name="out" type="vector2" nodename="exp1" />
   </nodegraph>
-  <nodegraph name="exp_vector3_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <exp name="exp1" type="vector3" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="exp_vector3_nodegraph">
+    <exp name="exp1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </exp>
-    <constant name="constant1" type="vector3" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.5, 1.5, 1.5" />
     </constant>
     <output name="out" type="vector3" nodename="exp1" />
   </nodegraph>
-  <nodegraph name="exp_vector4_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <exp name="exp1" type="vector4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="exp_vector4_nodegraph">
+    <exp name="exp1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </exp>
-    <constant name="constant1" type="vector4" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.5, 1.5, 1.5, 1.0" />
     </constant>
     <output name="out" type="vector4" nodename="exp1" />
   </nodegraph>
-  <nodegraph name="sqrt_nodegraph" type="" xpos="5.85492" ypos="17.4359">
-    <sqrt name="sqrt1" type="float" xpos="5.74483" ypos="4.74">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="sqrt_nodegraph">
+    <sqrt name="sqrt1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </sqrt>
     <output name="out" type="float" nodename="sqrt1" />
-    <constant name="constant1" type="float" xpos="4.56729" ypos="4.92132">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.2500" />
     </constant>
   </nodegraph>
-  <nodegraph name="sqrt_vector2_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <sqrt name="sqrt1" type="vector2" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="sqrt_vector2_nodegraph">
+    <sqrt name="sqrt1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </sqrt>
-    <constant name="constant1" type="vector2" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.5, 1.5" />
     </constant>
     <output name="out" type="vector2" nodename="sqrt1" />
   </nodegraph>
-  <nodegraph name="sqrt_vector3_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <sqrt name="sqrt1" type="vector3" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="sqrt_vector3_nodegraph">
+    <sqrt name="sqrt1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </sqrt>
-    <constant name="constant1" type="vector3" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.5, 1.5, 1.5" />
     </constant>
     <output name="out" type="vector3" nodename="sqrt1" />
   </nodegraph>
-  <nodegraph name="sqrt_vector4_nodegraph" type="" xpos="5.88123" ypos="14.6822">
-    <sqrt name="sqrt1" type="vector4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="sqrt_vector4_nodegraph">
+    <sqrt name="sqrt1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </sqrt>
-    <constant name="constant1" type="vector4" xpos="4.64779" ypos="5.0614">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.5, 1.5, 1.5, 1.0" />
     </constant>
     <output name="out" type="vector4" nodename="sqrt1" />
   </nodegraph>
-  <nodegraph name="ceil_float_nodegraph" type="" xpos="5.85517" ypos="18.7675">
-    <ceil name="ceil1" type="float" xpos="5.74483" ypos="4.74">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="ceil_float_nodegraph">
+    <ceil name="ceil1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </ceil>
-    <constant name="constant1" type="float" xpos="4.67999" ypos="4.99914">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
     <output name="out" type="float" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="floor_float_nodegraph" type="" xpos="5.86524" ypos="21.3863">
-    <floor name="floor1" type="float" xpos="5.74483" ypos="10.24">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="floor_float_nodegraph">
+    <floor name="floor1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </floor>
-    <constant name="constant1" type="float" xpos="4.26207" ypos="10.54">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
     <output name="out" type="float" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="ceil_vector2_nodegraph" type="" xpos="6.85754" ypos="18.8117">
-    <ceil name="ceil1" type="vector2" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="ceil_vector2_nodegraph">
+    <ceil name="ceil1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </ceil>
-    <constant name="constant1" type="vector2" xpos="4.72025" ypos="5.06918">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="-0.5000, 0.5000" />
     </constant>
     <output name="out" type="vector2" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="ceil_vector3_nodegraph" type="" xpos="7.82105" ypos="18.7959">
-    <constant name="constant1" type="vector3" xpos="5.74483" ypos="4.9">
+  <nodegraph name="ceil_vector3_nodegraph">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="-0.5000, 0.5000, 0.0000" />
     </constant>
     <output name="out" type="vector3" nodename="ceil1" />
-    <ceil name="ceil1" type="vector3" xpos="6.77989" ypos="4.50184">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+    <ceil name="ceil1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </ceil>
   </nodegraph>
-  <nodegraph name="ceil_vector4_nodegraph" type="" xpos="8.77251" ypos="18.7891">
-    <ceil name="ceil1" type="vector4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="ceil_vector4_nodegraph">
+    <ceil name="ceil1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </ceil>
-    <constant name="constant1" type="vector4" xpos="4.7283" ypos="5.0225">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="-0.5000, 0.5000, 0.0, 1.0" />
     </constant>
     <output name="out" type="vector4" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="ceil_color2_nodegraph" type="" xpos="6.87414" ypos="20.1078">
-    <constant name="constant1" type="vector2" xpos="5.74483" ypos="4.9">
+  <nodegraph name="ceil_color2_nodegraph">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="-0.5000, 0.5000" />
     </constant>
-    <ceil name="ceil1" type="vector2" xpos="6.8195" ypos="4.55544">
-      <input name="in" type="vector2" value="0.0, 1.0" nodename="constant1" />
+    <ceil name="ceil1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </ceil>
     <output name="out" type="vector2" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="ceil_color3_nodegraph" type="" xpos="7.84719" ypos="20.0864">
-    <constant name="constant1" type="color3" xpos="5.74483" ypos="4.9">
+  <nodegraph name="ceil_color3_nodegraph">
+    <constant name="constant1" type="color3">
       <input name="value" type="color3" value="-0.5000, 0.5000, 0.0" />
     </constant>
-    <ceil name="ceil1" type="color3" xpos="6.83007" ypos="4.60904">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="constant1" />
+    <ceil name="ceil1" type="color3">
+      <input name="in" type="color3" nodename="constant1" />
     </ceil>
     <output name="out" type="color3" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="ceil_color4_nodegraph" type="" xpos="8.8104" ypos="20.065">
-    <constant name="constant1" type="color4" xpos="5.74483" ypos="4.9">
+  <nodegraph name="ceil_color4_nodegraph">
+    <constant name="constant1" type="color4">
       <input name="value" type="color4" value="-0.5000, 0.5000, 0.0, 1.0" />
     </constant>
-    <ceil name="ceil1" type="color4" xpos="6.85383" ypos="4.57842">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+    <ceil name="ceil1" type="color4">
+      <input name="in" type="color4" nodename="constant1" />
     </ceil>
     <output name="out" type="color4" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="floor_vector2_nodegraph" type="" xpos="6.86381" ypos="21.3922">
-    <floor name="floor1" type="vector2" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="floor_vector2_nodegraph">
+    <floor name="floor1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </floor>
-    <constant name="constant1" type="vector2" xpos="4.65852" ypos="5.03028">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="0.5000, 1.5000" />
     </constant>
     <output name="out" type="vector2" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="floor_vector3_nodegraph" type="" xpos="7.8344" ypos="21.3851">
-    <floor name="floor1" type="vector3" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="floor_vector3_nodegraph">
+    <floor name="floor1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </floor>
-    <constant name="constant1" type="vector3" xpos="4.71488" ypos="5.03806">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="0.5000, 1.5000, 0.0" />
     </constant>
     <output name="out" type="vector3" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="floor_vector4_nodegraph" type="" xpos="8.81239" ypos="21.3636">
-    <floor name="floor1" type="vector4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="floor_vector4_nodegraph">
+    <floor name="floor1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </floor>
-    <constant name="constant1" type="vector4" xpos="4.74172" ypos="5.0225">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="0.5000, 1.5000, 0.0, 1.0" />
     </constant>
     <output name="out" type="vector4" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="floor_color2_nodegraph" type="" xpos="6.86285" ypos="22.7221">
-    <constant name="constant1" type="vector2" xpos="5.74483" ypos="4.9">
+  <nodegraph name="floor_color2_nodegraph">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="0.5000, 1.5000" />
     </constant>
-    <floor name="floor1" type="vector2" xpos="6.88816" ypos="4.57842">
-      <input name="in" type="vector2" value="0.0, 1.0" nodename="constant1" />
+    <floor name="floor1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </floor>
     <output name="out" type="vector2" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="floor_color3_nodegraph" type="" xpos="7.82606" ypos="22.7293">
-    <constant name="constant1" type="color3" xpos="5.74483" ypos="4.9">
+  <nodegraph name="floor_color3_nodegraph">
+    <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.5000, 1.5000, 0.0" />
     </constant>
-    <floor name="floor1" type="color3" xpos="6.79838" ypos="4.58608">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="constant1" />
+    <floor name="floor1" type="color3">
+      <input name="in" type="color3" nodename="constant1" />
     </floor>
     <output name="out" type="color3" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="floor_color4_nodegraph" type="" xpos="8.81636" ypos="22.7079">
-    <constant name="constant1" type="color4" xpos="5.74483" ypos="4.9">
+  <nodegraph name="floor_color4_nodegraph">
+    <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.5000, 1.5000, 0.0, 1.0" />
     </constant>
-    <floor name="floor1" type="color4" xpos="6.84855" ypos="4.58608">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+    <floor name="floor1" type="color4">
+      <input name="in" type="color4" nodename="constant1" />
     </floor>
     <output name="out" type="color4" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="sign_float" type="" xpos="5.84964" ypos="24.0275">
-    <constant name="constant1" type="float" xpos="5.74483" ypos="4.9">
+  <nodegraph name="sign_float">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="1.0000" />
     </constant>
-    <sign name="sign1" type="float" xpos="6.90928" ypos="4.80814">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+    <sign name="sign1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </sign>
     <output name="out" type="float" nodename="sign1" />
   </nodegraph>
-  <nodegraph name="sign_color2" type="" xpos="6.87392" ypos="24.0472">
-    <constant name="constant1" type="vector2" xpos="5.74483" ypos="4.9">
+  <nodegraph name="sign_color2">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="0.0, 1.0" />
     </constant>
-    <sign name="sign1" type="vector2" xpos="6.93041" ypos="5.6275">
-      <input name="in" type="vector2" value="0.0, 1.0" nodename="constant1" />
+    <sign name="sign1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </sign>
     <output name="out" type="vector2" nodename="sign1" />
   </nodegraph>
-  <nodegraph name="sign_color3" type="" xpos="7.85216" ypos="24.0357">
-    <constant name="constant1" type="color3" xpos="5.20088" ypos="6.50044">
+  <nodegraph name="sign_color3">
+    <constant name="constant1" type="color3">
       <input name="value" type="color3" value="-0.5000, 0.0, 0.5000" />
     </constant>
-    <sign name="sign1" type="color3" xpos="6.34949" ypos="6.36264">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="constant1" />
+    <sign name="sign1" type="color3">
+      <input name="in" type="color3" nodename="constant1" />
     </sign>
     <output name="out" type="color3" nodename="remap1" />
-    <remap name="remap1" type="color3" xpos="7.6809" ypos="6.4775">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="sign1" />
+    <remap name="remap1" type="color3">
+      <input name="in" type="color3" nodename="sign1" />
       <input name="inlow" type="float" value="-1.0000" />
       <input name="inhigh" type="float" value="1.0" />
       <input name="outlow" type="float" value="0.0" />
       <input name="outhigh" type="float" value="1.0" />
     </remap>
   </nodegraph>
-  <nodegraph name="sign_color4" type="" xpos="8.81793" ypos="24.0195">
-    <sign name="sign1" type="color4" xpos="6.676" ypos="7.51822">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="sign_color4">
+    <sign name="sign1" type="color4">
+      <input name="in" type="color4" nodename="constant1" />
     </sign>
-    <constant name="constant1" type="color4" xpos="6.67876" ypos="5.75136">
+    <constant name="constant1" type="color4">
       <input name="value" type="color4" value="-0.5000, 0.0, 0.5000, 1.0" />
     </constant>
     <output name="out" type="color4" nodename="remap2" />
-    <remap name="remap2" type="color4" xpos="6.71728" ypos="9.94476">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="sign1" />
+    <remap name="remap2" type="color4">
+      <input name="in" type="color4" nodename="sign1" />
       <input name="inlow" type="float" value="-1.0000" />
       <input name="inhigh" type="float" value="1.0" />
       <input name="outlow" type="float" value="0.0" />
       <input name="outhigh" type="float" value="1.0" />
     </remap>
   </nodegraph>
-  <nodegraph name="sign_vector2" type="" xpos="6.88323" ypos="25.3534">
-    <constant name="constant1" type="vector2" xpos="5.74483" ypos="4.9">
+  <nodegraph name="sign_vector2">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="0.0, 1.0000" />
     </constant>
-    <sign name="sign1" type="vector2" xpos="6.2069" ypos="8.3">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+    <sign name="sign1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </sign>
     <output name="out" type="vector2" nodename="sign1" />
   </nodegraph>
-  <nodegraph name="sign_vector3" type="" xpos="7.86294" ypos="25.321">
-    <constant name="constant1" type="vector3" xpos="5.74483" ypos="4.9">
+  <nodegraph name="sign_vector3">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="-0.5000, 0.0, 0.5000" />
     </constant>
-    <remap name="remap1" type="vector3" xpos="6.2069" ypos="8.3">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="sign1" />
+    <remap name="remap1" type="vector3">
+      <input name="in" type="vector3" nodename="sign1" />
       <input name="inlow" type="float" value="-1.0000" />
       <input name="inhigh" type="float" value="1.0" />
       <input name="outlow" type="float" value="0.0" />
       <input name="outhigh" type="float" value="1.0" />
     </remap>
-    <sign name="sign1" type="vector3" xpos="7.02703" ypos="5.49704">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+    <sign name="sign1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </sign>
     <output name="out" type="vector3" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="sign_vector4" type="" xpos="8.8315" ypos="25.3048">
-    <constant name="constant1" type="vector4" xpos="5.74483" ypos="4.9">
+  <nodegraph name="sign_vector4">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="-0.5000, 0.0, 0.5000, 1.0" />
     </constant>
-    <sign name="sign1" type="vector4" xpos="5.75536" ypos="6.56938">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+    <sign name="sign1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </sign>
-    <remap name="remap1" type="vector4" xpos="5.81452" ypos="8.63666">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="sign1" />
+    <remap name="remap1" type="vector4">
+      <input name="in" type="vector4" nodename="sign1" />
       <input name="inlow" type="float" value="-1.0000" />
       <input name="inhigh" type="float" value="1.0" />
       <input name="outlow" type="float" value="0.0" />
@@ -325,420 +325,420 @@
     </remap>
     <output name="out" type="vector4" nodename="remap1" />
   </nodegraph>
-  <nodegraph name="absval_float" type="" xpos="5.86539" ypos="26.6098">
-    <absval name="absval1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="absval_float">
+    <absval name="absval1" type="float">
       <input name="in" type="float" value="-0.5000" />
     </absval>
     <output name="out" type="float" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="absval_color2" type="" xpos="6.88909" ypos="26.6401">
-    <absval name="absval1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="absval_color2">
+    <absval name="absval1" type="vector2">
       <input name="in" type="vector2" value="-0.5000, -0.2500" />
     </absval>
     <output name="out" type="vector2" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="absval_color3" type="" xpos="7.89772" ypos="26.621">
-    <absval name="absval1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="absval_color3">
+    <absval name="absval1" type="color3">
       <input name="in" type="color3" value="-0.5000, -0.2500, 0.5000" />
     </absval>
     <output name="out" type="color3" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="absval_color4" type="" xpos="8.88479" ypos="26.6054">
-    <absval name="absval1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="absval_color4">
+    <absval name="absval1" type="color4">
       <input name="in" type="color4" value="-0.5000, -0.2500, 0.5000, -1.0000" />
     </absval>
     <output name="out" type="color4" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="absval_vector2" type="" xpos="6.89519" ypos="27.9595">
-    <absval name="absval1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="absval_vector2">
+    <absval name="absval1" type="vector2">
       <input name="in" type="vector2" value="-0.5000, -0.2500" />
     </absval>
     <output name="out" type="vector2" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="absval_vector3" type="" xpos="7.90381" ypos="27.8999">
-    <absval name="absval1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="absval_vector3">
+    <absval name="absval1" type="vector3">
       <input name="in" type="vector3" value="-0.5000, -0.2500, 0.5000" />
     </absval>
     <output name="out" type="vector3" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="absval_vector4" type="" xpos="8.90707" ypos="27.8764">
-    <absval name="absval1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="absval_vector4">
+    <absval name="absval1" type="vector4">
       <input name="in" type="vector4" value="-0.5000, -0.2500, 0.5000, -1.0000" />
     </absval>
     <output name="out" type="vector4" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="invert_float" type="" xpos="5.90796" ypos="29.4446">
-    <invert name="invert1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="invert_float">
+    <invert name="invert1" type="float">
       <input name="in" type="float" value="0.5000" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <output name="out" type="float" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_vector2" type="" xpos="6.92069" ypos="32.23">
-    <invert name="invert1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="invert_vector2">
+    <invert name="invert1" type="vector2">
       <input name="in" type="vector2" value="0.5000, 0.5000" />
       <input name="amount" type="vector2" value="1.0, 0.5000" />
     </invert>
     <output name="out" type="vector2" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_vector2FA" type="" xpos="7.98966" ypos="32.23">
-    <invert name="invert1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="invert_vector2FA">
+    <invert name="invert1" type="vector2">
       <input name="in" type="vector2" value="0.5000, 1.0000" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <output name="out" type="vector2" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_vector3" type="" xpos="9.03793" ypos="32.21">
-    <invert name="invert1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="invert_vector3">
+    <invert name="invert1" type="vector3">
       <input name="in" type="vector3" value="0.5000, 0.5000, 0.0" />
       <input name="amount" type="vector3" value="1.0, 0.5000, 0.0000" />
     </invert>
     <output name="out" type="vector3" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_vector3FA" type="" xpos="6.92557" ypos="33.54">
-    <invert name="invert1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="invert_vector3FA">
+    <invert name="invert1" type="vector3">
       <input name="in" type="vector3" value="0.5000, 1.0000, 0.0" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <output name="out" type="vector3" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_vector4" type="" xpos="8.00345" ypos="33.53">
-    <invert name="invert1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="invert_vector4">
+    <invert name="invert1" type="vector4">
       <input name="in" type="vector4" value="0.5000, 0.5000, 0.0, 1.0" />
       <input name="amount" type="vector4" value="1.0, 0.5000, 0.0000, 2.0000" />
     </invert>
     <output name="out" type="vector4" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_vector4FA" type="" xpos="9.05517" ypos="33.53">
-    <invert name="invert1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="invert_vector4FA">
+    <invert name="invert1" type="vector4">
       <input name="in" type="vector4" value="0.5000, 1.0000, 0.0, 0.2500" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <output name="out" type="vector4" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_color2" type="" xpos="6.91379" ypos="29.43">
-    <invert name="invert1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="invert_color2">
+    <invert name="invert1" type="vector2">
       <input name="in" type="vector2" value="0.5000, 0.5000" />
       <input name="amount" type="vector2" value="1.0, 0.5000" />
     </invert>
     <output name="out" type="vector2" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_color2FA" type="" xpos="7.95862" ypos="29.41">
-    <invert name="invert1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="invert_color2FA">
+    <invert name="invert1" type="vector2">
       <input name="in" type="vector2" value="0.5000, 1.0" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <output name="out" type="vector2" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_color3" type="" xpos="8.98276" ypos="29.38">
-    <invert name="invert1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="invert_color3">
+    <invert name="invert1" type="color3">
       <input name="in" type="color3" value="0.5000, 0.5000, 0.0" />
       <input name="amount" type="color3" value="1.0, 0.5000, 0.0000" />
     </invert>
     <output name="out" type="color3" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_color3FA" type="" xpos="6.91379" ypos="30.86">
-    <invert name="invert1" type="color3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="invert_color3FA">
+    <invert name="invert1" type="color3">
       <input name="in" type="color3" value="0.5000, 1.0000, 0.0" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <output name="out" type="color3" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_color4" type="" xpos="7.98621" ypos="30.83">
-    <invert name="invert1" type="color4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="invert_color4">
+    <invert name="invert1" type="color4">
       <input name="in" type="color4" value="0.5000, 0.5000, 0.0, 1.0000" />
       <input name="amount" type="color4" value="1.0, 0.5000, 0.0000, 2.0000" />
     </invert>
     <output name="out" type="color4" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_color4FA" type="" xpos="9.02069" ypos="30.8">
-    <invert name="invert1" type="color4" xpos="5.74751" ypos="4.74778">
+  <nodegraph name="invert_color4FA">
+    <invert name="invert1" type="color4">
       <input name="in" type="color4" value="0.5000, 1.0000, 0.0, 0.2500" />
       <input name="amount" type="float" value="1.0" />
     </invert>
     <output name="out" type="color4" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="clamp_float" type="" xpos="5.91053" ypos="34.9718">
-    <clamp name="clamp1" type="float" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_float">
+    <clamp name="clamp1" type="float">
       <input name="in" type="float" value="1.0000" />
       <input name="low" type="float" value="0.0" />
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="float" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_color2" type="" xpos="6.91511" ypos="34.928">
-    <clamp name="clamp1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_color2">
+    <clamp name="clamp1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.0000" />
       <input name="low" type="vector2" value="0.0000, 0.5000" />
       <input name="high" type="vector2" value="0.5000, 1.0" />
     </clamp>
     <output name="out" type="vector2" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_color2FA" type="" xpos="8.01722" ypos="34.8856">
-    <clamp name="clamp1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_color2FA">
+    <clamp name="clamp1" type="vector2">
       <input name="in" type="vector2" value="0.0, 1.0" />
       <input name="low" type="float" value="0.5000" />
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="vector2" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_color3" type="" xpos="9.06081" ypos="34.8574">
-    <clamp name="clamp1" type="color3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_color3">
+    <clamp name="clamp1" type="color3">
       <input name="in" type="color3" value="1.0000, 0.0, 1.0000" />
       <input name="low" type="color3" value="0.0, 0.5000, 0.0" />
       <input name="high" type="color3" value="0.5000, 1.0, 0.0000" />
     </clamp>
     <output name="out" type="color3" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_color3FA" type="" xpos="6.92487" ypos="36.4272">
-    <clamp name="clamp1" type="color3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_color3FA">
+    <clamp name="clamp1" type="color3">
       <input name="in" type="color3" value="1.0000, 0.0, 0.5000" />
       <input name="low" type="float" value="0.5000" />
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="color3" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_color4" type="" xpos="8.0221" ypos="36.4356">
-    <clamp name="clamp1" type="color4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_color4">
+    <clamp name="clamp1" type="color4">
       <input name="in" type="color4" value="0.0, 0.0, 0.0, 2.0000" />
       <input name="low" type="color4" value="0.5000, 0.0, 0.5000, 0.0" />
       <input name="high" type="color4" value="1.0, 0.5000, 0.5000, 1.0" />
     </clamp>
     <output name="out" type="color4" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_color4FA" type="" xpos="9.06081" ypos="36.399">
-    <clamp name="clamp1" type="color4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_color4FA">
+    <clamp name="clamp1" type="color4">
       <input name="in" type="color4" value="1.0000, 0.0000, 0.5000, 2.0000" />
       <input name="low" type="float" value="0.5000" />
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="color4" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_vector2" type="" xpos="6.93462" ypos="37.7694">
-    <clamp name="clamp1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_vector2">
+    <clamp name="clamp1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.0" />
       <input name="low" type="vector2" value="0.0, 0.5000" />
       <input name="high" type="vector2" value="0.5000, 1.0" />
     </clamp>
     <output name="out" type="vector2" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_vector2FA" type="" xpos="8.01471" ypos="37.749">
-    <clamp name="clamp1" type="vector2" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_vector2FA">
+    <clamp name="clamp1" type="vector2">
       <input name="in" type="vector2" value="0.0000, 1.0000" />
       <input name="low" type="float" value="0.5000" />
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="vector2" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_vector3" type="" xpos="9.07781" ypos="37.7206">
-    <clamp name="clamp1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_vector3">
+    <clamp name="clamp1" type="vector3">
       <input name="in" type="vector3" value="1.0000, 0.0, 1.0000" />
       <input name="low" type="vector3" value="0.0, 0.5000, 0.0" />
       <input name="high" type="vector3" value="0.5000, 1.0, 0.0000" />
     </clamp>
     <output name="out" type="vector3" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_vector3FA" type="" xpos="6.92925" ypos="39.0924">
-    <clamp name="clamp1" type="vector3" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_vector3FA">
+    <clamp name="clamp1" type="vector3">
       <input name="in" type="vector3" value="1.0000, 0.0, 0.5000" />
       <input name="low" type="float" value="0.5000" />
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="vector3" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_vector4" type="" xpos="8.01673" ypos="39.05">
-    <clamp name="clamp1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_vector4">
+    <clamp name="clamp1" type="vector4">
       <input name="in" type="vector4" value="0.0, 0.0, 0.0, 2.0000" />
       <input name="low" type="vector4" value="0.5000, 0.0, 0.5000, 0.0" />
       <input name="high" type="vector4" value="1.0, 0.5000, 0.5000, 1.0" />
     </clamp>
     <output name="out" type="vector4" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="clamp_vector4FA" type="" xpos="9.08958" ypos="39.05">
-    <clamp name="clamp1" type="vector4" xpos="5.75172" ypos="4.74">
+  <nodegraph name="clamp_vector4FA">
+    <clamp name="clamp1" type="vector4">
       <input name="in" type="vector4" value="1.0000, 0.0, 0.5000, 2.0000" />
       <input name="low" type="float" value="0.5000" />
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="vector4" nodename="clamp1" />
   </nodegraph>
-  <nodegraph name="min_float" type="" xpos="5.91206" ypos="40.5066">
-    <min name="min1" type="float" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_float">
+    <min name="min1" type="float">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
     </min>
     <output name="out" type="float" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_color2" type="" xpos="6.94033" ypos="40.4716">
-    <min name="min1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_color2">
+    <min name="min1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0" />
       <input name="in2" type="vector2" value="1.0000, 0.5000" />
     </min>
     <output name="out" type="vector2" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_color2FA" type="" xpos="8.01806" ypos="40.4434">
-    <min name="min1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_color2FA">
+    <min name="min1" type="vector2">
       <input name="in1" type="vector2" value="0.0, 1.0" />
       <input name="in2" type="float" value="0.5000" />
     </min>
     <output name="out" type="vector2" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_color3" type="" xpos="9.09091" ypos="40.4008">
-    <min name="min1" type="color3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_color3">
+    <min name="min1" type="color3">
       <input name="in1" type="color3" value="0.5000, 1.0000, 0.5000" />
       <input name="in2" type="color3" value="1.0000, 0.5000, 0.5000" />
     </min>
     <output name="out" type="color3" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_color3FA" type="" xpos="6.94033" ypos="41.9">
-    <min name="min1" type="color3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_color3FA">
+    <min name="min1" type="color3">
       <input name="in1" type="color3" value="0.5000, 1.0000, 0.0" />
       <input name="in2" type="float" value="0.5000" />
     </min>
     <output name="out" type="color3" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_color4" type="" xpos="8.03757" ypos="41.8772">
-    <min name="min1" type="color4" xpos="5.74483" ypos="4.56">
+  <nodegraph name="min_color4">
+    <min name="min1" type="color4">
       <input name="in1" type="color4" value="0.5000, 1.0000, 0.5000, 1.0000" />
       <input name="in2" type="color4" value="1.0000, 0.5000, 0.5000, 2.0000" />
     </min>
     <output name="out" type="color4" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_color4FA" type="" xpos="9.10555" ypos="41.849">
-    <min name="min1" type="color4" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_color4FA">
+    <min name="min1" type="color4">
       <input name="in1" type="color4" value="0.5000, 1.0000, 0.0, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </min>
     <output name="out" type="color4" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_vector2" type="" xpos="6.95984" ypos="43.2916">
-    <min name="min1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_vector2">
+    <min name="min1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0000" />
       <input name="in2" type="vector2" value="1.0000, 0.5000" />
     </min>
     <output name="out" type="vector2" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_vector2FA" type="" xpos="8.03269" ypos="43.2576">
-    <min name="min1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_vector2FA">
+    <min name="min1" type="vector2">
       <input name="in1" type="vector2" value="0.0, 1.0000" />
       <input name="in2" type="float" value="0.5000" />
     </min>
     <output name="out" type="vector2" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_vector3" type="" xpos="9.11042" ypos="43.2434">
-    <min name="min1" type="vector3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_vector3">
+    <min name="min1" type="vector3">
       <input name="in1" type="vector3" value="0.5000, 1.0000, 0.5000" />
       <input name="in2" type="vector3" value="1.0000, 0.5000, 0.5000" />
     </min>
     <output name="out" type="vector3" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_vector3FA" type="" xpos="6.95984" ypos="44.7848">
-    <min name="min1" type="vector3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_vector3FA">
+    <min name="min1" type="vector3">
       <input name="in1" type="vector3" value="0.5000, 1.0000, 0.0" />
       <input name="in2" type="float" value="0.5000" />
     </min>
     <output name="out" type="vector3" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_vector4" type="" xpos="8.04732" ypos="44.733">
-    <min name="min1" type="vector4" xpos="5.75172" ypos="4.58">
+  <nodegraph name="min_vector4">
+    <min name="min1" type="vector4">
       <input name="in1" type="vector4" value="0.5000, 1.0000, 0.5000, 1.0" />
       <input name="in2" type="vector4" value="1.0000, 0.5000, 0.5000, 2.0000" />
     </min>
     <output name="out" type="vector4" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_vector4FA" type="" xpos="9.1153" ypos="44.6904">
-    <min name="min1" type="vector4" xpos="6.2069" ypos="6.9">
+  <nodegraph name="min_vector4FA">
+    <min name="min1" type="vector4">
       <input name="in1" type="vector4" value="0.5000, 1.0000, 0.0, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </min>
     <output name="out" type="vector4" nodename="min1" />
   </nodegraph>
-  <nodegraph name="max_float" type="" xpos="5.90718" ypos="46.121">
-    <max name="max1" type="float" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_float">
+    <max name="max1" type="float">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="1.0000" />
     </max>
     <output name="out" type="float" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_color2" type="" xpos="6.96959" ypos="46.1144">
-    <max name="max1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_color2">
+    <max name="max1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0" />
       <input name="in2" type="vector2" value="1.0000, 0.5000" />
     </max>
     <output name="out" type="vector2" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_color2FA" type="" xpos="8.04245" ypos="46.1144">
-    <max name="max1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_color2FA">
+    <max name="max1" type="vector2">
       <input name="in1" type="vector2" value="0.0, 1.0" />
       <input name="in2" type="float" value="0.5000" />
     </max>
     <output name="out" type="vector2" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_color3" type="" xpos="9.11041" ypos="46.086">
-    <max name="max1" type="color3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_color3">
+    <max name="max1" type="color3">
       <input name="in1" type="color3" value="0.5000, 1.0000, 0.5000" />
       <input name="in2" type="color3" value="1.0000, 0.5000, 0.5000" />
     </max>
     <output name="out" type="color3" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_color3FA" type="" xpos="6.96959" ypos="47.4438">
-    <max name="max1" type="color3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_color3FA">
+    <max name="max1" type="color3">
       <input name="in1" type="color3" value="0.5000, 1.0000, 0.0" />
       <input name="in2" type="float" value="0.5000" />
     </max>
     <output name="out" type="color3" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_color4" type="" xpos="8.06196" ypos="47.435">
-    <max name="max1" type="color4" xpos="5.74483" ypos="4.56">
+  <nodegraph name="max_color4">
+    <max name="max1" type="color4">
       <input name="in1" type="color4" value="0.5000, 1.0000, 0.5000, 1.0000" />
       <input name="in2" type="color4" value="1.0000, 0.5000, 0.5000, 0.2500" />
     </max>
     <output name="out" type="color4" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_color4FA" type="" xpos="9.14457" ypos="47.4352">
-    <max name="max1" type="color4" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_color4FA">
+    <max name="max1" type="color4">
       <input name="in1" type="color4" value="0.5000, 1.0000, 0.0, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </max>
     <output name="out" type="color4" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_vector2" type="" xpos="6.95497" ypos="48.7646">
-    <max name="max1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_vector2">
+    <max name="max1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0000" />
       <input name="in2" type="vector2" value="1.0000, 0.5000" />
     </max>
     <output name="out" type="vector2" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_vector2FA" type="" xpos="8.05708" ypos="48.773">
-    <max name="max1" type="vector2" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_vector2FA">
+    <max name="max1" type="vector2">
       <input name="in1" type="vector2" value="0.0, 1.0000" />
       <input name="in2" type="float" value="0.5000" />
     </max>
     <output name="out" type="vector2" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_vector3" type="" xpos="9.16406" ypos="48.8012">
-    <max name="max1" type="vector3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_vector3">
+    <max name="max1" type="vector3">
       <input name="in1" type="vector3" value="0.5000, 1.0000, 0.5000" />
       <input name="in2" type="vector3" value="1.0000, 0.5000, 0.5000" />
     </max>
     <output name="out" type="vector3" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_vector3FA" type="" xpos="6.95009" ypos="50.1022">
-    <max name="max1" type="vector3" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_vector3FA">
+    <max name="max1" type="vector3">
       <input name="in1" type="vector3" value="0.5000, 1.0000, 0.0" />
       <input name="in2" type="float" value="0.5000" />
     </max>
     <output name="out" type="vector3" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_vector4" type="" xpos="8.05219" ypos="50.0788">
-    <max name="max1" type="vector4" xpos="5.75172" ypos="4.58">
+  <nodegraph name="max_vector4">
+    <max name="max1" type="vector4">
       <input name="in1" type="vector4" value="0.5000, 1.0000, 0.5000, 1.0" />
       <input name="in2" type="vector4" value="1.0000, 0.5000, 0.5000, 0.2500" />
     </max>
     <output name="out" type="vector4" nodename="max1" />
   </nodegraph>
-  <nodegraph name="max_vector4FA" type="" xpos="9.14944" ypos="50.121">
-    <max name="max1" type="vector4" xpos="6.2069" ypos="6.9">
+  <nodegraph name="max_vector4FA">
+    <max name="max1" type="vector4">
       <input name="in1" type="vector4" value="0.5000, 1.0000, 0.0, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </max>

--- a/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
@@ -1,546 +1,546 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="add_float" type="" xpos="5.02395" ypos="14.1393">
-    <add name="add1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_float">
+    <add name="add1" type="float">
       <input name="in1" type="float" value="0.2000" />
       <input name="in2" type="float" value="0.3000" />
     </add>
     <output name="out" type="float" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_color2" type="" xpos="6.02691" ypos="14.1379">
-    <add name="add1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_color2">
+    <add name="add1" type="vector2">
       <input name="in1" type="vector2" value="0.2000, 0.0000" />
       <input name="in2" type="vector2" value="0.3000, 1.0" />
     </add>
     <output name="out" type="vector2" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_color2FA" type="" xpos="7.02041" ypos="14.1422">
-    <add name="add1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_color2FA">
+    <add name="add1" type="vector2">
       <input name="in1" type="vector2" value="0.2000, 0.4500" />
       <input name="in2" type="float" value="0.3000" />
     </add>
     <output name="out" type="vector2" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_color3" type="" xpos="7.9931" ypos="14.134">
-    <add name="add1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_color3">
+    <add name="add1" type="color3">
       <input name="in1" type="color3" value="0.2000, 0.3000, 0.0" />
       <input name="in2" type="color3" value="0.3000, 0.4500, 1.0000" />
     </add>
     <output name="out" type="color3" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_color3FA" type="" xpos="6.02823" ypos="15.4764">
-    <add name="add1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_color3FA">
+    <add name="add1" type="color3">
       <input name="in1" type="color3" value="0.2000, 0.4500, 0.7000" />
       <input name="in2" type="float" value="0.3000" />
     </add>
     <output name="out" type="color3" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_color4" type="" xpos="7.0246" ypos="15.4507">
-    <add name="add1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_color4">
+    <add name="add1" type="color4">
       <input name="in1" type="color4" value="0.2000, 0.3000, 0.0, 1.0" />
       <input name="in2" type="color4" value="0.3000, 0.4500, 1.0000, 0.0000" />
     </add>
     <output name="out" type="color4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_color4FA" type="" xpos="8.01401" ypos="15.4406">
-    <add name="add1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_color4FA">
+    <add name="add1" type="color4">
       <input name="in1" type="color4" value="0.2000, 0.4500, -0.3000, 0.7000" />
       <input name="in2" type="float" value="0.3000" />
     </add>
     <output name="out" type="color4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_vector2" type="" xpos="6.03395" ypos="16.8269">
-    <add name="add1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_vector2">
+    <add name="add1" type="vector2">
       <input name="in1" type="vector2" value="0.2000, 0.0" />
       <input name="in2" type="vector2" value="0.3000, 1.0000" />
     </add>
     <output name="out" type="vector2" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_vector2FA" type="" xpos="7.04426" ypos="16.7908">
-    <add name="add1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_vector2FA">
+    <add name="add1" type="vector2">
       <input name="in1" type="vector2" value="0.2000, 0.4500" />
       <input name="in2" type="float" value="0.3000" />
     </add>
     <output name="out" type="vector2" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_vector3" type="" xpos="8.03715" ypos="16.7706">
-    <add name="add1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_vector3">
+    <add name="add1" type="vector3">
       <input name="in1" type="vector3" value="0.2000, 0.3000, 0.0" />
       <input name="in2" type="vector3" value="0.3000, 0.4500, 1.0000" />
     </add>
     <output name="out" type="vector3" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_vector3FA" type="" xpos="6.03587" ypos="18.1192">
-    <add name="add1" type="vector3" xpos="6.2069" ypos="7.06">
+  <nodegraph name="add_vector3FA">
+    <add name="add1" type="vector3">
       <input name="in1" type="vector3" value="0.2000, 0.4500, 0.7000" />
       <input name="in2" type="float" value="0.3000" />
     </add>
     <output name="out" type="vector3" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_vector4" type="" xpos="7.04531" ypos="18.0959">
-    <add name="add1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_vector4">
+    <add name="add1" type="vector4">
       <input name="in1" type="vector4" value="0.2000, 0.3000, 0.0, 1.0" />
       <input name="in2" type="vector4" value="0.3000, 0.4500, 1.0000, 0.0000" />
     </add>
     <output name="out" type="vector4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_vector4FA" type="" xpos="8.04169" ypos="18.0757">
-    <add name="add1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="add_vector4FA">
+    <add name="add1" type="vector4">
       <input name="in1" type="vector4" value="0.2000, 0.4500, -0.3000, 0.7000" />
       <input name="in2" type="float" value="0.3000" />
     </add>
     <output name="out" type="vector4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="subtract_float" type="" xpos="5.07157" ypos="19.439">
-    <subtract name="subtract1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_float">
+    <subtract name="subtract1" type="float">
       <input name="in1" type="float" value="1.0000" />
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="float" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_color2" type="" xpos="6.05052" ypos="19.4188">
-    <subtract name="subtract1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_color2">
+    <subtract name="subtract1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 1.0" />
       <input name="in2" type="vector2" value="0.5000, 0.0000" />
     </subtract>
     <output name="out" type="vector2" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_color2FA" type="" xpos="7.04341" ypos="19.3986">
-    <subtract name="subtract1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_color2FA">
+    <subtract name="subtract1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="vector2" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_color3" type="" xpos="8.05372" ypos="19.3682">
-    <subtract name="subtract1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_color3">
+    <subtract name="subtract1" type="color3">
       <input name="in1" type="color3" value="1.0000, 1.0000, 0.0" />
       <input name="in2" type="color3" value="0.5000, 0.0, 0.0" />
     </subtract>
     <output name="out" type="color3" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_color3FA" type="" xpos="6.06124" ypos="20.679">
-    <subtract name="subtract1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_color3FA">
+    <subtract name="subtract1" type="color3">
       <input name="in1" type="color3" value="1.0000, 0.5000, 0.7500" />
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="color3" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_color4" type="" xpos="7.05413" ypos="20.6891">
-    <subtract name="subtract1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_color4">
+    <subtract name="subtract1" type="color4">
       <input name="in1" type="color4" value="1.0000, 1.0000, 0.0, 0.7500" />
       <input name="in2" type="color4" value="0.5000, 0.0, 0.0, 0.2500" />
     </subtract>
     <output name="out" type="color4" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_color4FA" type="" xpos="8.06792" ypos="20.6891">
-    <subtract name="subtract1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_color4FA">
+    <subtract name="subtract1" type="color4">
       <input name="in1" type="color4" value="1.0000, 0.5000, 0.7500, 1.5000" />
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="color4" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_vector2" type="" xpos="6.04341" ypos="21.9735">
-    <subtract name="subtract1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_vector2">
+    <subtract name="subtract1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
       <input name="in2" type="vector2" value="0.5000, 0.0" />
     </subtract>
     <output name="out" type="vector2" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_vector2FA" type="" xpos="7.05023" ypos="21.9735">
-    <subtract name="subtract1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_vector2FA">
+    <subtract name="subtract1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="vector2" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_vector3" type="" xpos="8.05706" ypos="21.933">
-    <subtract name="subtract1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_vector3">
+    <subtract name="subtract1" type="vector3">
       <input name="in1" type="vector3" value="1.0000, 1.0000, 0.0" />
       <input name="in2" type="vector3" value="0.5000, 0.0, 0.0" />
     </subtract>
     <output name="out" type="vector3" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_vector3FA" type="" xpos="6.03589" ypos="23.3157">
-    <subtract name="subtract1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_vector3FA">
+    <subtract name="subtract1" type="vector3">
       <input name="in1" type="vector3" value="1.0000, 0.5000, 0.7500" />
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="vector3" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_vector4" type="" xpos="7.05665" ypos="23.2955">
-    <subtract name="subtract1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_vector4">
+    <subtract name="subtract1" type="vector4">
       <input name="in1" type="vector4" value="1.0000, 1.0000, 0.0, 0.7500" />
       <input name="in2" type="vector4" value="0.5000, 0.0, 0.0, 0.2500" />
     </subtract>
     <output name="out" type="vector4" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="subtract_vector4FA" type="" xpos="8.06697" ypos="23.2651">
-    <subtract name="subtract1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="subtract_vector4FA">
+    <subtract name="subtract1" type="vector4">
       <input name="in1" type="vector4" value="1.0000, 0.5000, 0.7500, 1.5000" />
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="vector4" nodename="subtract1" />
   </nodegraph>
-  <nodegraph name="multiply_float" type="" xpos="5.05794" ypos="24.6626">
-    <multiply name="multiply1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_float">
+    <multiply name="multiply1" type="float">
       <input name="in1" type="float" value="1.0000" />
       <input name="in2" type="float" value="0.5000" />
     </multiply>
     <output name="out" type="float" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_color2" type="" xpos="6.03546" ypos="24.6125">
-    <multiply name="multiply1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_color2">
+    <multiply name="multiply1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 0.5000" />
       <input name="in2" type="vector2" value="0.5000, 0.5000" />
     </multiply>
     <output name="out" type="vector2" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_color2FA" type="" xpos="7.06811" ypos="24.6065">
-    <multiply name="multiply1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_color2FA">
+    <multiply name="multiply1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </multiply>
     <output name="out" type="vector2" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_color3" type="" xpos="8.07842" ypos="24.5762">
-    <multiply name="multiply1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_color3">
+    <multiply name="multiply1" type="color3">
       <input name="in1" type="color3" value="1.0000, 0.5000, 0.0000" />
       <input name="in2" type="color3" value="0.5000, 0.5000, 1.0000" />
     </multiply>
     <output name="out" type="color3" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_color3FA" type="" xpos="6.03499" ypos="25.9535">
-    <multiply name="multiply1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_color3FA">
+    <multiply name="multiply1" type="color3">
       <input name="in1" type="color3" value="1.0000, 0.5000, 0.0" />
       <input name="in2" type="float" value="0.5000" />
     </multiply>
     <output name="out" type="color3" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_color4" type="" xpos="7.05227" ypos="25.938">
-    <multiply name="multiply1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_color4">
+    <multiply name="multiply1" type="color4">
       <input name="in1" type="color4" value="1.0000, 0.5000, 0.0, 1.0" />
       <input name="in2" type="color4" value="0.5000, 0.5000, 1.0000, 1.0" />
     </multiply>
     <output name="out" type="color4" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_color4FA" type="" xpos="8.0765" ypos="25.9077">
-    <multiply name="multiply1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_color4FA">
+    <multiply name="multiply1" type="color4">
       <input name="in1" type="color4" value="1.0000, 0.5000, 0.0, 2.0000" />
       <input name="in2" type="float" value="0.5000" />
     </multiply>
     <output name="out" type="color4" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_vector2" type="" xpos="6.02454" ypos="27.2664">
-    <multiply name="multiply1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_vector2">
+    <multiply name="multiply1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 0.5000" />
       <input name="in2" type="vector2" value="0.5000, 0.5000" />
     </multiply>
     <output name="out" type="vector2" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_vector2FA" type="" xpos="7.03978" ypos="27.2646">
-    <multiply name="multiply1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_vector2FA">
+    <multiply name="multiply1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 0.5000" />
       <input name="in2" type="float" value="0.5000" />
     </multiply>
     <output name="out" type="vector2" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_vector3" type="" xpos="8.06954" ypos="27.22">
-    <multiply name="multiply1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_vector3">
+    <multiply name="multiply1" type="vector3">
       <input name="in1" type="vector3" value="1.0000, 0.5000, 0.0" />
       <input name="in2" type="vector3" value="0.5000, 0.5000, 1.0000" />
     </multiply>
     <output name="out" type="vector3" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_vector3FA" type="" xpos="6.02454" ypos="28.5614">
-    <multiply name="multiply1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_vector3FA">
+    <multiply name="multiply1" type="vector3">
       <input name="in1" type="vector3" value="1.0000, 0.5000, 0.0" />
       <input name="in2" type="float" value="0.5000" />
     </multiply>
     <output name="out" type="vector3" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_vector4" type="" xpos="7.03983" ypos="28.5426">
-    <multiply name="multiply1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_vector4">
+    <multiply name="multiply1" type="vector4">
       <input name="in1" type="vector4" value="1.0000, 0.5000, 0.0, 1.0" />
       <input name="in2" type="vector4" value="0.5000, 0.5000, 1.0000, 1.0" />
     </multiply>
     <output name="out" type="vector4" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_vector4FA" type="" xpos="8.06407" ypos="28.5123">
-    <multiply name="multiply1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="multiply_vector4FA">
+    <multiply name="multiply1" type="vector4">
       <input name="in1" type="vector4" value="1.0000, 0.5000, 0.0, 2.0000" />
       <input name="in2" type="float" value="0.5000" />
     </multiply>
     <output name="out" type="vector4" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="divide_float" type="" xpos="5.05023" ypos="29.9199">
-    <divide name="divide1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_float">
+    <divide name="divide1" type="float">
       <input name="in1" type="float" value="1.0000" />
       <input name="in2" type="float" value="2.0000" />
     </divide>
     <output name="out" type="float" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_color2" type="" xpos="6.03615" ypos="29.8753">
-    <divide name="divide1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_color2">
+    <divide name="divide1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 1.0" />
       <input name="in2" type="vector2" value="2.0000, 4.0000" />
     </divide>
     <output name="out" type="vector2" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_color2FA" type="" xpos="7.03601" ypos="29.8795">
-    <divide name="divide1" type="vector2" xpos="5.74483" ypos="4.6">
+  <nodegraph name="divide_color2FA">
+    <divide name="divide1" type="vector2">
       <input name="in1" type="vector2" value="2.0000, 1.0" />
       <input name="in2" type="float" value="4.0000" />
     </divide>
     <output name="out" type="vector2" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_color3" type="" xpos="8.05676" ypos="29.8391">
-    <divide name="divide1" type="color3" xpos="5" ypos="10.08">
+  <nodegraph name="divide_color3">
+    <divide name="divide1" type="color3">
       <input name="in1" type="color3" value="1.0000, 1.0000, 0.0" />
       <input name="in2" type="color3" value="2.0000, 4.0000, 1.0000" />
     </divide>
     <output name="out" type="color3" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_color3FA" type="" xpos="6.01907" ypos="31.2391">
-    <divide name="divide1" type="color3" xpos="5" ypos="10.08">
+  <nodegraph name="divide_color3FA">
+    <divide name="divide1" type="color3">
       <input name="in1" type="color3" value="2.0000, 1.0000, 0.0" />
       <input name="in2" type="float" value="4.0000" />
     </divide>
     <output name="out" type="color3" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_color4" type="" xpos="7.03286" ypos="31.2332">
-    <divide name="divide1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_color4">
+    <divide name="divide1" type="color4">
       <input name="in1" type="color4" value="1.0000, 1.0000, 0.0, 1.0" />
       <input name="in2" type="color4" value="2.0000, 4.0000, 1.0000, 1.0" />
     </divide>
     <output name="out" type="color4" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_color4FA" type="" xpos="8.07103" ypos="31.1238">
-    <divide name="divide1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_color4FA">
+    <divide name="divide1" type="color4">
       <input name="in1" type="color4" value="2.0000, 1.0000, 0.0, 4.0000" />
       <input name="in2" type="float" value="4.0000" />
     </divide>
     <output name="out" type="color4" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_vector2" type="" xpos="6.01328" ypos="32.589">
-    <divide name="divide1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_vector2">
+    <divide name="divide1" type="vector2">
       <input name="in1" type="vector2" value="1.0000, 1.0000" />
       <input name="in2" type="vector2" value="2.0000, 4.0000" />
     </divide>
     <output name="out" type="vector2" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_vector2FA" type="" xpos="7.02328" ypos="32.5604">
-    <divide name="divide1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_vector2FA">
+    <divide name="divide1" type="vector2">
       <input name="in1" type="vector2" value="2.0000, 1.0000" />
       <input name="in2" type="float" value="4.0000" />
     </divide>
     <output name="out" type="vector2" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_vector3" type="" xpos="8.05793" ypos="32.5318">
-    <divide name="divide1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_vector3">
+    <divide name="divide1" type="vector3">
       <input name="in1" type="vector3" value="1.0000, 1.0000, 0.0" />
       <input name="in2" type="vector3" value="2.0000, 4.0000, 1.0000" />
     </divide>
     <output name="out" type="vector3" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_vector3FA" type="" xpos="6.01172" ypos="33.8648">
-    <divide name="divide1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_vector3FA">
+    <divide name="divide1" type="vector3">
       <input name="in1" type="vector3" value="2.0000, 1.0000, 0.0" />
       <input name="in2" type="float" value="4.0000" />
     </divide>
     <output name="out" type="vector3" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_vector4" type="" xpos="7.03159" ypos="33.8218">
-    <divide name="divide1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_vector4">
+    <divide name="divide1" type="vector4">
       <input name="in1" type="vector4" value="1.0000, 1.0000, 0.0, 1.0" />
       <input name="in2" type="vector4" value="2.0000, 4.0000, 1.0000, 1.0" />
     </divide>
     <output name="out" type="vector4" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="divide_vector4FA" type="" xpos="8.07887" ypos="33.7786">
-    <divide name="divide1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="divide_vector4FA">
+    <divide name="divide1" type="vector4">
       <input name="in1" type="vector4" value="2.0000, 1.0000, 0.0, 4.0000" />
       <input name="in2" type="float" value="4.0000" />
     </divide>
     <output name="out" type="vector4" nodename="divide1" />
   </nodegraph>
-  <nodegraph name="modulo_float" type="" xpos="5.01618" ypos="35.249">
-    <modulo name="modulo1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_float">
+    <modulo name="modulo1" type="float">
       <input name="in1" type="float" value="1.5000" />
       <input name="in2" type="float" value="1.0000" />
     </modulo>
     <output name="out" type="float" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_color2" type="" xpos="6.05718" ypos="35.3146">
-    <modulo name="modulo1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_color2">
+    <modulo name="modulo1" type="vector2">
       <input name="in1" type="vector2" value="1.5000, 1.0" />
       <input name="in2" type="vector2" value="1.0000, 1.0000" />
     </modulo>
     <output name="out" type="vector2" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_color2FA" type="" xpos="7.06583" ypos="35.2972">
-    <modulo name="modulo1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_color2FA">
+    <modulo name="modulo1" type="vector2">
       <input name="in1" type="vector2" value="1.5000, 1.0" />
       <input name="in2" type="float" value="1.0000" />
     </modulo>
     <output name="out" type="vector2" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_color3" type="" xpos="8.10143" ypos="35.2346">
-    <modulo name="modulo1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_color3">
+    <modulo name="modulo1" type="color3">
       <input name="in1" type="color3" value="1.5000, 1.0000, 0.0" />
       <input name="in2" type="color3" value="1.0000, 1.0000, 1.0000" />
     </modulo>
     <output name="out" type="color3" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_color3FA" type="" xpos="6.06813" ypos="36.723">
-    <modulo name="modulo1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_color3FA">
+    <modulo name="modulo1" type="color3">
       <input name="in1" type="color3" value="1.5000, 1.0000, 0.0" />
       <input name="in2" type="float" value="1.0000" />
     </modulo>
     <output name="out" type="color3" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_color4" type="" xpos="7.11453" ypos="36.7074">
-    <modulo name="modulo1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_color4">
+    <modulo name="modulo1" type="color4">
       <input name="in1" type="color4" value="1.5000, 1.0000, 0.0, 0.5000" />
       <input name="in2" type="color4" value="1.0000, 1.0000, 1.0000, 1.0" />
     </modulo>
     <output name="out" type="color4" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_color4FA" type="" xpos="8.11778" ypos="36.6916">
-    <modulo name="modulo1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_color4FA">
+    <modulo name="modulo1" type="color4">
       <input name="in1" type="color4" value="1.5000, 1.0000, 0.0, 0.2500" />
       <input name="in2" type="float" value="1.0000" />
     </modulo>
     <output name="out" type="color4" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_vector2" type="" xpos="6.08582" ypos="38.1308">
-    <modulo name="modulo1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_vector2">
+    <modulo name="modulo1" type="vector2">
       <input name="in1" type="vector2" value="1.5000, 1.0000" />
       <input name="in2" type="vector2" value="1.0000, 1.0000" />
     </modulo>
     <output name="out" type="vector2" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_vector2FA" type="" xpos="7.12143" ypos="38.115">
-    <modulo name="modulo1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_vector2FA">
+    <modulo name="modulo1" type="vector2">
       <input name="in1" type="vector2" value="1.5000, 1.0000" />
       <input name="in2" type="float" value="1.0000" />
     </modulo>
     <output name="out" type="vector2" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_vector3" type="" xpos="8.14085" ypos="38.0838">
-    <modulo name="modulo1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_vector3">
+    <modulo name="modulo1" type="vector3">
       <input name="in1" type="vector3" value="1.5000, 1.0000, 0.0" />
       <input name="in2" type="vector3" value="1.0000, 1.0000, 1.0000" />
     </modulo>
     <output name="out" type="vector3" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_vector3FA" type="" xpos="6.09961" ypos="39.5072">
-    <modulo name="modulo1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_vector3FA">
+    <modulo name="modulo1" type="vector3">
       <input name="in1" type="vector3" value="1.5000, 1.0000, 0.0" />
       <input name="in2" type="float" value="1.0000" />
     </modulo>
     <output name="out" type="vector3" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_vector4" type="" xpos="7.12443" ypos="39.476">
-    <modulo name="modulo1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_vector4">
+    <modulo name="modulo1" type="vector4">
       <input name="in1" type="vector4" value="1.5000, 1.0000, 0.0, 0.2500" />
       <input name="in2" type="vector4" value="1.0000, 1.0000, 1.0000, 1.0000" />
     </modulo>
     <output name="out" type="vector4" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_vector4FA" type="" xpos="8.16543" ypos="39.4446">
-    <modulo name="modulo1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="modulo_vector4FA">
+    <modulo name="modulo1" type="vector4">
       <input name="in1" type="vector4" value="1.5000, 1.0000, 0.0, 0.2500" />
       <input name="in2" type="float" value="1.0000" />
     </modulo>
     <output name="out" type="vector4" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="power_float" type="" xpos="5.0745" ypos="40.7844">
-    <power name="power1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_float">
+    <power name="power1" type="float">
       <input name="in1" type="float" value="0.5000" />
       <input name="in2" type="float" value="2.0000" />
     </power>
     <output name="out" type="float" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_color2" type="" xpos="6.10347" ypos="40.7878">
-    <power name="power1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_color2">
+    <power name="power1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0" />
       <input name="in2" type="vector2" value="2.0000, 1.0" />
     </power>
     <output name="out" type="vector2" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_color2FA" type="" xpos="7.13288" ypos="40.7668">
-    <power name="power1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_color2FA">
+    <power name="power1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0000" />
       <input name="in2" type="float" value="2.0000" />
     </power>
     <output name="out" type="vector2" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_color3" type="" xpos="8.17625" ypos="40.7566">
-    <power name="power1" type="color3" xpos="5.74483" ypos="4.56">
+  <nodegraph name="power_color3">
+    <power name="power1" type="color3">
       <input name="in1" type="color3" value="0.5000, 1.0000, 1.0000" />
       <input name="in2" type="color3" value="2.0000, 1.0000, 0.0" />
     </power>
     <output name="out" type="color3" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_color3FA" type="" xpos="6.11045" ypos="42.1414">
-    <power name="power1" type="color3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_color3FA">
+    <power name="power1" type="color3">
       <input name="in1" type="color3" value="0.5000, 1.0000, 0.0000" />
       <input name="in2" type="float" value="2.0000" />
     </power>
     <output name="out" type="color3" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_color4" type="" xpos="7.13986" ypos="42.0842">
-    <power name="power1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_color4">
+    <power name="power1" type="color4">
       <input name="in1" type="color4" value="0.5000, 1.0000, 1.0000, 1.0000" />
       <input name="in2" type="color4" value="2.0000, 1.0000, 0.0000, 3.0000" />
     </power>
     <output name="out" type="color4" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_color4FA" type="" xpos="8.18323" ypos="42.054">
-    <power name="power1" type="color4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_color4FA">
+    <power name="power1" type="color4">
       <input name="in1" type="color4" value="0.5000, 1.0000, 0.0, 1.0000" />
       <input name="in2" type="float" value="2.0000" />
     </power>
     <output name="out" type="color4" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_vector2" type="" xpos="6.09998" ypos="43.4606">
-    <power name="power1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_vector2">
+    <power name="power1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0000" />
       <input name="in2" type="vector2" value="2.0000, 1.0000" />
     </power>
     <output name="out" type="vector2" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_vector2FA" type="" xpos="7.1467" ypos="43.4286">
-    <power name="power1" type="vector2" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_vector2FA">
+    <power name="power1" type="vector2">
       <input name="in1" type="vector2" value="0.5000, 1.0000" />
       <input name="in2" type="float" value="2.0000" />
     </power>
     <output name="out" type="vector2" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_vector3" type="" xpos="8.20053" ypos="43.3982">
-    <power name="power1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_vector3">
+    <power name="power1" type="vector3">
       <input name="in1" type="vector3" value="0.5000, 1.0000, 1.0000" />
       <input name="in2" type="vector3" value="2.0000, 1.0000, 0.0" />
     </power>
     <output name="out" type="vector3" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_vector3FA" type="" xpos="6.09765" ypos="44.8046">
-    <power name="power1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_vector3FA">
+    <power name="power1" type="vector3">
       <input name="in1" type="vector3" value="0.5000, 1.0000, 0.0" />
       <input name="in2" type="float" value="2.0000" />
     </power>
     <output name="out" type="vector3" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_vector4" type="" xpos="7.15425" ypos="44.7904">
-    <power name="power1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_vector4">
+    <power name="power1" type="vector4">
       <input name="in1" type="vector4" value="0.5000, 1.0000, 1.0000, 1.0" />
       <input name="in2" type="vector4" value="2.0000, 1.0000, 0.0, 3.0000" />
     </power>
     <output name="out" type="vector4" nodename="power1" />
   </nodegraph>
-  <nodegraph name="power_vector4FA" type="" xpos="8.22205" ypos="44.76">
-    <power name="power1" type="vector4" xpos="5.74483" ypos="4.58">
+  <nodegraph name="power_vector4FA">
+    <power name="power1" type="vector4">
       <input name="in1" type="vector4" value="0.5000, 1.0000, 0.0, 1.0000" />
       <input name="in2" type="float" value="2.0000" />
     </power>

--- a/resources/Materials/TestSuite/stdlib/math/transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/transform.mtlx
@@ -3,11 +3,11 @@
   <!-- point space transform -->
   <nodegraph name="tf_point_vector3">
     <transformpoint name="transformpoint1" type="vector3">
-      <input name="in" type="vector3" value="1.0, 0.5, 0.0" nodename="position1" />
+      <input name="in" type="vector3" nodename="position1" />
       <input name="fromspace" type="string" value="object" />
       <input name="tospace" type="string" value="world" />
     </transformpoint>
-    <position name="position1" type="vector3" xpos="4.29468" ypos="7.25674">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
     <output name="out" type="vector3" nodename="transformpoint1" />
@@ -15,65 +15,65 @@
   <!-- vector space transform -->
   <nodegraph name="tf_vector_vector3">
     <transformvector name="transformvector1" type="vector3">
-      <input name="in" type="vector3" value="1.0, 0.5, 0.0" nodename="normal1" />
+      <input name="in" type="vector3" nodename="normal1" />
       <input name="fromspace" type="string" value="object" />
       <input name="tospace" type="string" value="world" />
     </transformvector>
-    <normal name="normal1" type="vector3" xpos="4.77303" ypos="13.4329">
+    <normal name="normal1" type="vector3">
       <input name="space" type="string" value="object" />
     </normal>
     <output name="out" type="vector3" nodename="transformvector1" />
   </nodegraph>
   <!-- normal space transform -->
-  <nodegraph name="tf_normal_vector3" xpos="6.83448" ypos="23.3">
+  <nodegraph name="tf_normal_vector3">
     <transformnormal name="transformnormal1" type="vector3">
-      <input name="in" type="vector3" value="1.0, 0.5, 0.0" nodename="normal1" />
+      <input name="in" type="vector3" nodename="normal1" />
       <input name="fromspace" type="string" value="object" />
       <input name="tospace" type="string" value="world" />
     </transformnormal>
-    <normal name="normal1" type="vector3" xpos="3.855" ypos="10.3157">
+    <normal name="normal1" type="vector3">
       <input name="space" type="string" value="object" />
     </normal>
     <output name="out" type="vector3" nodename="transformnormal1" />
   </nodegraph>
   <!-- vector/matrix transform -->
   <nodegraph name="tf_matrix3_vector2">
-    <transformmatrix name="transformpoint2M3" type="vector2" xpos="5.12832" ypos="10.7513">
-      <input name="in" type="vector2" value="1.0, 0.5" nodename="texcoord1" />
+    <transformmatrix name="transformpoint2M3" type="vector2">
+      <input name="in" type="vector2" nodename="texcoord1" />
       <input name="mat" type="matrix33" value="0.5, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 1.0" />
     </transformmatrix>
     <output name="out" type="vector2" nodename="transformpoint2M3" />
-    <texcoord name="texcoord1" type="vector2" xpos="4.05281" ypos="11.1126">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
   </nodegraph>
   <nodegraph name="tf_matrix3_vector3">
     <transformmatrix name="transformpoint1" type="vector3">
-      <input name="in" type="vector3" value="1.0, 0.5, 0.0" nodename="position1" />
+      <input name="in" type="vector3" nodename="position1" />
       <input name="mat" type="matrix33" value="0.5, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0" />
     </transformmatrix>
-    <position name="position1" type="vector3" xpos="4.29468" ypos="7.25674">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
     <output name="out" type="vector3" nodename="transformpoint1" />
   </nodegraph>
-  <nodegraph name="tf_matrix4_vector3" xpos="6.93103" ypos="29.02">
+  <nodegraph name="tf_matrix4_vector3">
     <output name="out" type="vector3" nodename="transformpoint3M4" />
-    <transformmatrix name="transformpoint3M4" type="vector3" xpos="5.1253" ypos="10.5662">
-      <input name="in" type="vector3" value="1.0, 0.5, 0.0" nodename="position1" />
+    <transformmatrix name="transformpoint3M4" type="vector3">
+      <input name="in" type="vector3" nodename="position1" />
       <input name="mat" type="matrix44" value="0.5, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 1.0" />
     </transformmatrix>
-    <position name="position1" type="vector3" xpos="4.29468" ypos="7.25674">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
   </nodegraph>
-  <nodegraph name="tf_matrix4_vector4" xpos="6.77241" ypos="0.411679">
-    <transformmatrix name="transformvector1" type="vector4" xpos="5.73505" ypos="11.4101">
+  <nodegraph name="tf_matrix4_vector4">
+    <transformmatrix name="transformvector1" type="vector4">
       <input name="in" type="vector4" nodename="normal1" channels="xyz0" />
       <input name="mat" type="matrix44" value="0.5, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0" />
     </transformmatrix>
     <output name="out" type="vector4" nodename="transformvector1" channels="xyz1" />
-    <normal name="normal1" type="vector3" xpos="4.77303" ypos="13.4329">
+    <normal name="normal1" type="vector3">
       <input name="space" type="string" value="object" />
     </normal>
   </nodegraph>
@@ -165,8 +165,8 @@
     <output name="N_out_vec3" type="vector3" nodename="N_convtov3" />
   </nodegraph>
   <!-- place2d -->
-  <nodegraph name="place2d_vector2" xpos="6.93103" ypos="26.16">
-    <texcoord name="texcoord1" type="vector2" xpos="4.05281" ypos="11.1126">
+  <nodegraph name="place2d_vector2">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
     <place2d name="place2d1_1" type="vector2">

--- a/resources/Materials/TestSuite/stdlib/math/trig.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/trig.mtlx
@@ -1,214 +1,214 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="sin_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <sin name="sin1" type="float" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="sin_nodegraph">
+    <sin name="sin1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </sin>
-    <constant name="constant1" type="float" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="1.0000" />
     </constant>
     <output name="sin_out" type="float" nodename="sin1" />
   </nodegraph>
-  <nodegraph name="sin_vector2_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <sin name="sin1" type="vector2" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="sin_vector2_nodegraph">
+    <sin name="sin1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </sin>
-    <constant name="constant1" type="vector2" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.0000, 1.0" />
     </constant>
     <output name="sin_out" type="vector2" nodename="sin1" />
   </nodegraph>
-  <nodegraph name="sin_vector3_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <sin name="sin1" type="vector3" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="sin_vector3_nodegraph">
+    <sin name="sin1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </sin>
-    <constant name="constant1" type="vector3" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.0, 1.0, 1.0" />
     </constant>
     <output name="sin_out" type="vector3" nodename="sin1" />
   </nodegraph>
-  <nodegraph name="sin_vector4_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <sin name="sin1" type="vector4" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="sin_vector4_nodegraph">
+    <sin name="sin1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </sin>
-    <constant name="constant1" type="vector4" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     </constant>
     <output name="sin_out" type="vector4" nodename="sin1" />
   </nodegraph>
-  <nodegraph name="cos_nodegraph" type="" xpos="5.61327" ypos="15.3983">
-    <cos name="cos1" type="float" xpos="5.75172" ypos="10.24">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="cos_nodegraph">
+    <cos name="cos1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </cos>
-    <constant name="constant1" type="float" xpos="4.26897" ypos="10.54">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="1.0000" />
     </constant>
     <output name="cos_out" type="float" nodename="cos1" />
   </nodegraph>
-  <nodegraph name="cos_vector2_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <cos name="cos1" type="vector2" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="cos_vector2_nodegraph">
+    <cos name="cos1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </cos>
-    <constant name="constant1" type="vector2" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.0000, 1.0" />
     </constant>
     <output name="cos_out" type="vector2" nodename="cos1" />
   </nodegraph>
-  <nodegraph name="cos_vector3_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <cos name="cos1" type="vector3" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="cos_vector3_nodegraph">
+    <cos name="cos1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </cos>
-    <constant name="constant1" type="vector3" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.0, 1.0, 1.0" />
     </constant>
     <output name="cos_out" type="vector3" nodename="cos1" />
   </nodegraph>
-  <nodegraph name="cos_vector4_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <cos name="cos1" type="vector4" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="cos_vector4_nodegraph">
+    <cos name="cos1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </cos>
-    <constant name="constant1" type="vector4" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     </constant>
     <output name="cos_out" type="vector4" nodename="cos1" />
   </nodegraph>
-  <nodegraph name="tan_nodegraph" type="" xpos="5.63544" ypos="16.6298">
-    <constant name="constant1" type="float" xpos="4.26897" ypos="10.54">
+  <nodegraph name="tan_nodegraph">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
-    <tan name="tan1" type="float" xpos="5.75172" ypos="10.24">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+    <tan name="tan1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </tan>
     <output name="tan_out" type="float" nodename="tan1" />
   </nodegraph>
-  <nodegraph name="tan_vector2_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <tan name="tan1" type="vector2" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="tan_vector2_nodegraph">
+    <tan name="tan1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </tan>
-    <constant name="constant1" type="vector2" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.0000, 1.0" />
     </constant>
     <output name="tan_out" type="vector2" nodename="tan1" />
   </nodegraph>
-  <nodegraph name="tan_vector3_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <tan name="tan1" type="vector3" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="tan_vector3_nodegraph">
+    <tan name="tan1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </tan>
-    <constant name="constant1" type="vector3" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.0, 1.0, 1.0" />
     </constant>
     <output name="tan_out" type="vector3" nodename="tan1" />
   </nodegraph>
-  <nodegraph name="tan_vector4_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <tan name="tan1" type="vector4" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="tan_vector4_nodegraph">
+    <tan name="tan1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </tan>
-    <constant name="constant1" type="vector4" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     </constant>
     <output name="tan_out" type="vector4" nodename="tan1" />
   </nodegraph>
-  <nodegraph name="asin_nodegraph" type="" xpos="5.64463" ypos="17.8931">
-    <asin name="asin1" type="float" xpos="5.75172" ypos="10.24">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="asin_nodegraph">
+    <asin name="asin1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </asin>
-    <constant name="constant1" type="float" xpos="4.26897" ypos="10.54">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
     <output name="asin_out" type="float" nodename="asin1" />
   </nodegraph>
-  <nodegraph name="asin_vector2_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <asin name="asin1" type="vector2" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="asin_vector2_nodegraph">
+    <asin name="asin1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </asin>
-    <constant name="constant1" type="vector2" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.0000, 1.0" />
     </constant>
     <output name="asin_out" type="vector2" nodename="asin1" />
   </nodegraph>
-  <nodegraph name="asin_vector3_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <asin name="asin1" type="vector3" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="asin_vector3_nodegraph">
+    <asin name="asin1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </asin>
-    <constant name="constant1" type="vector3" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.0, 1.0, 1.0" />
     </constant>
     <output name="asin_out" type="vector3" nodename="asin1" />
   </nodegraph>
-  <nodegraph name="asin_vector4_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <asin name="asin1" type="vector4" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="asin_vector4_nodegraph">
+    <asin name="asin1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </asin>
-    <constant name="constant1" type="vector4" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     </constant>
     <output name="asin_out" type="vector4" nodename="asin1" />
   </nodegraph>
-  <nodegraph name="acos_nodegraph" type="" xpos="5.64463" ypos="19.1375">
-    <acos name="acos1" type="float" xpos="5.75172" ypos="10.24">
-      <input name="in" type="float" value="0.0" nodename="constant1" />
+  <nodegraph name="acos_nodegraph">
+    <acos name="acos1" type="float">
+      <input name="in" type="float" nodename="constant1" />
     </acos>
-    <constant name="constant1" type="float" xpos="4.26897" ypos="10.54">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.8000" />
     </constant>
     <output name="acos_out" type="float" nodename="acos1" />
   </nodegraph>
-  <nodegraph name="acos_vector2_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <acos name="acos1" type="vector2" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="acos_vector2_nodegraph">
+    <acos name="acos1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
     </acos>
-    <constant name="constant1" type="vector2" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="1.0000, 1.0" />
     </constant>
     <output name="acos_out" type="vector2" nodename="acos1" />
   </nodegraph>
-  <nodegraph name="acos_vector3_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <acos name="acos1" type="vector3" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="acos_vector3_nodegraph">
+    <acos name="acos1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
     </acos>
-    <constant name="constant1" type="vector3" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="1.0, 1.0, 1.0" />
     </constant>
     <output name="acos_out" type="vector3" nodename="acos1" />
   </nodegraph>
-  <nodegraph name="acos_vector4_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <acos name="acos1" type="vector4" xpos="4.03625" ypos="12.8689">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="acos_vector4_nodegraph">
+    <acos name="acos1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
     </acos>
-    <constant name="constant1" type="vector4" xpos="2.71937" ypos="13.0341">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     </constant>
     <output name="acos_out" type="vector4" nodename="acos1" />
   </nodegraph>
-  <nodegraph name="atan_nodegraph" type="" xpos="5.65399" ypos="20.3234">
-    <constant name="constant1" type="float" xpos="4.26207" ypos="9.5">
+  <nodegraph name="atan_nodegraph">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
-    <constant name="constant2" type="float" xpos="4.26207" ypos="11.28">
+    <constant name="constant2" type="float">
       <input name="value" type="float" value="1.0000" />
     </constant>
-    <atan2 name="atan21" type="float" xpos="5.74171" ypos="9.92">
-      <input name="in1" type="float" value="0.0" nodename="constant1" />
-      <input name="in2" type="float" value="0.0" nodename="constant2" />
+    <atan2 name="atan21" type="float">
+      <input name="in1" type="float" nodename="constant1" />
+      <input name="in2" type="float" nodename="constant2" />
     </atan2>
     <output name="atan2_out" type="float" nodename="atan21" />
   </nodegraph>
-  <nodegraph name="atan_vector2_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <atan2 name="atan21" type="vector2" xpos="4.03625" ypos="12.8689">
+  <nodegraph name="atan_vector2_nodegraph">
+    <atan2 name="atan21" type="vector2">
       <input name="in1" type="vector2" value="0.5, 0.5" />
       <input name="in2" type="vector2" value="1.0, 1.0" />
     </atan2>
     <output name="atan_out" type="vector2" nodename="atan21" />
   </nodegraph>
-  <nodegraph name="atan_vector3_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <atan2 name="atan21" type="vector3" xpos="4.03625" ypos="12.8689">
+  <nodegraph name="atan_vector3_nodegraph">
+    <atan2 name="atan21" type="vector3">
       <input name="in1" type="vector3" value="0.5, 0.5, 0.5" />
       <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
     </atan2>
     <output name="atan_out" type="vector3" nodename="atan21" />
   </nodegraph>
-  <nodegraph name="atan_vector4_nodegraph" type="" xpos="5.6201" ypos="14.0821">
-    <atan2 name="atan21" type="vector4" xpos="4.03625" ypos="12.8689">
+  <nodegraph name="atan_vector4_nodegraph">
+    <atan2 name="atan21" type="vector4">
       <input name="in1" type="vector4" value="0.5, 0.5, 0.5, 0.5" />
       <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     </atan2>

--- a/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
@@ -1,132 +1,132 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="normalize_vector2" type="" xpos="6.21379" ypos="18.74">
-    <normalize name="normalize1" type="vector2" xpos="5.74483" ypos="4.74">
+  <nodegraph name="normalize_vector2">
+    <normalize name="normalize1" type="vector2">
       <input name="in" type="vector2" value="1.0000, 0.5000" />
     </normalize>
     <output name="out" type="vector2" nodename="normalize1" />
   </nodegraph>
-  <nodegraph name="normalize_vector3" type="" xpos="7.21444" ypos="18.7234">
-    <normalize name="normalize1" type="vector3" xpos="5.74483" ypos="4.74">
+  <nodegraph name="normalize_vector3">
+    <normalize name="normalize1" type="vector3">
       <input name="in" type="vector3" value="1.0000, 0.5000, 0.0" />
     </normalize>
     <output name="out" type="vector3" nodename="normalize1" />
   </nodegraph>
-  <nodegraph name="normalize_vector4" type="" xpos="8.21433" ypos="18.7019">
-    <normalize name="normalize1" type="vector4" xpos="5.74483" ypos="4.74">
+  <nodegraph name="normalize_vector4">
+    <normalize name="normalize1" type="vector4">
       <input name="in" type="vector4" value="1.0000, 0.5000, 0.0, 0.7500" />
     </normalize>
     <output name="out" type="vector4" nodename="normalize1" />
   </nodegraph>
-  <nodegraph name="magnitude_vector2" type="" xpos="6.21402" ypos="19.9893">
-    <magnitude name="magnitude1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="magnitude_vector2">
+    <magnitude name="magnitude1" type="float">
       <input name="in" type="vector2" value="1.0000, 0.5000" />
     </magnitude>
     <output name="out" type="float" nodename="magnitude1" />
   </nodegraph>
-  <nodegraph name="magnitude_vector3" type="" xpos="7.2191" ypos="19.9964">
-    <magnitude name="magnitude1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="magnitude_vector3">
+    <magnitude name="magnitude1" type="float">
       <input name="in" type="vector3" value="1.0000, 0.5000, 0.0" />
     </magnitude>
     <output name="out" type="float" nodename="magnitude1" />
   </nodegraph>
-  <nodegraph name="magnitude_vector4" type="" xpos="8.21926" ypos="19.975">
-    <magnitude name="magnitude1" type="float" xpos="5.74483" ypos="4.74">
+  <nodegraph name="magnitude_vector4">
+    <magnitude name="magnitude1" type="float">
       <input name="in" type="vector4" value="1.0000, 0.5000, 0.0, 0.7500" />
     </magnitude>
     <output name="out" type="float" nodename="magnitude1" />
   </nodegraph>
-  <nodegraph name="dotproduct_vector2" type="" xpos="6.22542" ypos="21.2711">
+  <nodegraph name="dotproduct_vector2">
     <output name="out" type="float" nodename="dotproduct1" />
-    <dotproduct name="dotproduct1" type="float" xpos="5.84999" ypos="5.4547">
+    <dotproduct name="dotproduct1" type="float">
       <input name="in1" type="vector2" value="1.0000, 0.5000" />
       <input name="in2" type="vector2" value="0.5000, 1.0000" />
     </dotproduct>
   </nodegraph>
-  <nodegraph name="dotproduct_vector3" type="" xpos="7.22804" ypos="21.2682">
-    <dotproduct name="dotproduct1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="dotproduct_vector3">
+    <dotproduct name="dotproduct1" type="float">
       <input name="in1" type="vector3" value="1.0000, 0.5000, 0.0" />
       <input name="in2" type="vector3" value="0.5000, 1.0000, 1.0000" />
     </dotproduct>
     <output name="out" type="float" nodename="dotproduct1" />
   </nodegraph>
-  <nodegraph name="dotproduct_vector4" type="" xpos="8.22574" ypos="21.261">
-    <dotproduct name="dotproduct1" type="float" xpos="5.74483" ypos="4.58">
+  <nodegraph name="dotproduct_vector4">
+    <dotproduct name="dotproduct1" type="float">
       <input name="in1" type="vector4" value="1.0000, 0.5000, 0.0, 1.0000" />
       <input name="in2" type="vector4" value="0.5000, 1.0000, 1.0000, 1.0000" />
     </dotproduct>
     <output name="out" type="float" nodename="dotproduct1" />
   </nodegraph>
-  <nodegraph name="crossproduct_vector3" type="" xpos="6.23281" ypos="22.5398">
-    <crossproduct name="crossproduct1" type="vector3" xpos="5.74483" ypos="4.58">
+  <nodegraph name="crossproduct_vector3">
+    <crossproduct name="crossproduct1" type="vector3">
       <input name="in1" type="vector3" value="1.0000, 1.0000, 0.0" />
       <input name="in2" type="vector3" value="0.0, 1.0000, 1.0000" />
     </crossproduct>
     <output name="out" type="vector3" nodename="crossproduct1" />
   </nodegraph>
-  <nodegraph name="rotate_vector2" type="" xpos="6.24941" ypos="23.8081">
-    <position name="position1" type="vector3" xpos="3.04828" ypos="6.34">
+  <nodegraph name="rotate_vector2">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
     <output name="out" type="vector2" nodename="rotate1" />
-    <rotate2d name="rotate1" type="vector2" xpos="5.62998" ypos="7.07692">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="swizzle1" />
+    <rotate2d name="rotate1" type="vector2">
+      <input name="in" type="vector2" nodename="swizzle1" />
       <input name="amount" type="float" value="1.5708" unittype="angle" unit="radian" />
     </rotate2d>
-    <swizzle name="swizzle1" type="vector2" xpos="4.31739" ypos="5.3662">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <swizzle name="swizzle1" type="vector2">
+      <input name="in" type="vector3" nodename="position1" />
       <input name="channels" type="string" value="xy" />
     </swizzle>
   </nodegraph>
-  <nodegraph name="rotate_vector3" type="" xpos="7.24435" ypos="23.808">
-    <position name="position1" type="vector3" xpos="3.53793" ypos="5.42">
+  <nodegraph name="rotate_vector3">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <rotate3d name="rotate1" type="vector3" xpos="5.19248" ypos="5.306">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <rotate3d name="rotate1" type="vector3">
+      <input name="in" type="vector3" nodename="position1" />
       <input name="amount" type="float" value="180.0000" unittype="angle" unit="degree" />
       <input name="axis" type="vector3" value="0.0, 1.0000, 1.0000" />
     </rotate3d>
     <output name="out" type="vector3" nodename="rotate1" />
   </nodegraph>
-  <nodegraph name="determinant_matrix33" type="" xpos="6.26251" ypos="25.1022">
-    <determinant name="determinant1" type="float" xpos="5.74835" ypos="6.41022">
+  <nodegraph name="determinant_matrix33">
+    <determinant name="determinant1" type="float">
       <input name="in" type="matrix33" value="1.0,0.0,0.5, 0.0,1.0,0.0, 1.0,0.0,1.0" />
     </determinant>
     <output name="out" type="float" nodename="determinant1" />
   </nodegraph>
-  <nodegraph name="determinant_matrix44" type="" xpos="7.26465" ypos="25.0919">
-    <determinant name="determinant1" type="float" xpos="5.75172" ypos="6.42">
+  <nodegraph name="determinant_matrix44">
+    <determinant name="determinant1" type="float">
       <input name="in" type="matrix44" value="1.0,0.0,0.0,1.0, 0.0,1.0,1.0,0.0, 0.0,0.5.0,1.0,0.0, 1.0,0.0,0.0,1.0" />
     </determinant>
     <output name="out" type="float" nodename="determinant1" />
   </nodegraph>
-  <nodegraph name="transpose_matrix33" type="" xpos="6.27714" ypos="26.3972">
-    <transpose name="transpose1" type="matrix33" xpos="5.02637" ypos="8.34744">
+  <nodegraph name="transpose_matrix33">
+    <transpose name="transpose1" type="matrix33">
       <input name="in" type="matrix33" value="1.0,1.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
     </transpose>
-    <position name="position1" type="vector3" xpos="4.87243" ypos="6.7323">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <transformmatrix name="transformvector1" type="vector3" xpos="6.25413" ypos="7.13256">
+    <transformmatrix name="transformvector1" type="vector3">
       <input name="in" type="vector3" nodename="position1" />
       <input name="mat" type="matrix33" nodename="transpose1" />
     </transformmatrix>
     <output name="out" type="vector3" nodename="transformvector1" />
   </nodegraph>
-  <nodegraph name="transpose_matrix44" type="" xpos="7.2764" ypos="26.383">
-    <position name="position1" type="vector3" xpos="3.41379" ypos="6.94">
+  <nodegraph name="transpose_matrix44">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <swizzle name="swizzle1" type="vector4" xpos="4.61194" ypos="6.66496">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <swizzle name="swizzle1" type="vector4">
+      <input name="in" type="vector3" nodename="position1" />
       <input name="channels" type="string" value="xyz1" />
     </swizzle>
-    <transformmatrix name="transformvector1" type="vector4" xpos="5.83715" ypos="6.95826">
+    <transformmatrix name="transformvector1" type="vector4">
       <input name="in" type="vector4" nodename="swizzle1" />
       <input name="mat" type="matrix44" nodename="transpose1" />
     </transformmatrix>
-    <transpose name="transpose1" type="matrix44" xpos="4.7123" ypos="8.70598">
+    <transpose name="transpose1" type="matrix44">
       <input name="in" type="matrix44" value="1.0,1.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
     </transpose>
     <output name="out" type="vector4" nodename="transformvector1" />

--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/cascade_nodegraphs.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/cascade_nodegraphs.mtlx
@@ -1,44 +1,42 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="upstream3" xpos="10" ypos="153">
+  <nodegraph name="upstream3">
     <input name="file" type="filename" uniform="true" value="resources/Images/cloth.png" />
     <input name="file1" type="filename" uniform="true" value="resources/Images/grid.png" />
-    <image name="upstream_image" type="color3" xpos="10" ypos="8.86024">
+    <image name="upstream_image" type="color3">
       <input name="file" type="filename" uniform="true" interfacename="file" value="resources/Images/cloth.png" />
-      <input name="frameoffset" type="integer" uniform="true" value="0" />
     </image>
-    <image name="upstream_image1" type="color3" xpos="19.1695" ypos="421">
+    <image name="upstream_image1" type="color3">
       <input name="file" type="filename" uniform="true" interfacename="file1" value="resources/Images/grid.png" />
-      <input name="frameoffset" type="integer" uniform="true" value="0" />
     </image>
     <output name="out" type="color3" nodename="upstream_image" />
     <output name="out1" type="color3" nodename="upstream_image1" />
   </nodegraph>
-  <nodegraph name="upstream2" xpos="315" ypos="82">
+  <nodegraph name="upstream2">
     <input name="upstream2_in1" type="color3" nodegraph="upstream3" output="out" value="0, 1, 0" />
     <input name="upstream2_in2" type="color3" nodegraph="upstream3" output="out1" value="0, 1, 0" />
-    <multiply name="multiply_by_image" type="color3" xpos="333.028" ypos="-27.8587">
+    <multiply name="multiply_by_image" type="color3">
       <input name="in1" type="color3" interfacename="upstream2_in1" value="0, 1, 0" />
       <input name="in2" type="color3" nodename="image" />
     </multiply>
-    <multiply name="make_red" type="color3" xpos="361.069" ypos="248.883">
+    <multiply name="make_red" type="color3">
       <input name="in1" type="color3" interfacename="upstream2_in2" value="0, 1, 0" />
       <input name="in2" type="color3" value="1, 0.1, 0.1" />
     </multiply>
-    <image name="image" type="color3" xpos="-30.4805" ypos="-249.603">
+    <image name="image" type="color3">
       <input name="file" type="filename" uniform="true" value="resources/Images/grid.png" />
     </image>
     <output name="upstream2_out1" type="color3" nodename="multiply_by_image" />
     <output name="upstream2_out2" type="color3" nodename="make_red" />
   </nodegraph>
-  <nodegraph name="upstream1" xpos="620" ypos="10">
+  <nodegraph name="upstream1">
     <input name="upstream1_in1" type="color3" nodegraph="upstream2" output="upstream2_out1" value="0, 1, 0" />
     <input name="upstream1_in2" type="color3" nodegraph="upstream2" output="upstream2_out2" value="0, 1, 0" />
-    <multiply name="make_yellow" type="color3" xpos="-77.0636" ypos="-139.845">
+    <multiply name="make_yellow" type="color3">
       <input name="in1" type="color3" interfacename="upstream1_in1" value="0, 1, 0" />
       <input name="in2" type="color3" value="1, 1, 0" />
     </multiply>
-    <multiply name="remove_red" type="color3" xpos="-75.6416" ypos="242.103">
+    <multiply name="remove_red" type="color3">
       <input name="in1" type="color3" interfacename="upstream1_in2" value="0, 1, 0" />
       <input name="in2" type="color3" value="0, 1, 1" />
     </multiply>
@@ -47,17 +45,17 @@
   </nodegraph>
   <output name="top_upstream1_out1" type="color3" nodename="upstream1" output="upstream1_out1" />
   <output name="top_upstream1_out2" type="color3" nodename="upstream1" output="upstream1_out2" />
-  <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1" xpos="949.876" ypos="-189.576">
+  <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1">
     <input name="base_color" type="color3" nodegraph="upstream1" output="upstream1_out1" />
   </standard_surface>
-  <standard_surface name="standard_surface1" type="surfaceshader" version="1.0.1" xpos="940.476" ypos="307.63">
+  <standard_surface name="standard_surface1" type="surfaceshader" version="1.0.1">
     <input name="base_color" type="color3" nodegraph="upstream1" output="upstream1_out2" />
   </standard_surface>
-  <surfacematerial name="surfacematerial" type="material" xpos="1303.4" ypos="-234.282">
+  <surfacematerial name="surfacematerial" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="standard_surface" />
     <input name="displacementshader" type="displacementshader" value="" />
   </surfacematerial>
-  <surfacematerial name="surfacematerial1" type="material" xpos="1325.2" ypos="245.001">
+  <surfacematerial name="surfacematerial1" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="standard_surface1" />
     <input name="displacementshader" type="displacementshader" value="" />
   </surfacematerial>

--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx
@@ -50,7 +50,7 @@
   <nodegraph name="NG_upstream_graph" nodedef="ND_upstream_graph">
     <input name="nd_file" type="filename" uniform="true" value="resources/Images/grid.png" />
     <input name="nd_file2" type="filename" uniform="true" value="resources/Images/cloth.png" />
-    <image name="image" type="color3" xpos="-79" ypos="-448.596">
+    <image name="image" type="color3">
       <input name="file" type="filename" uniform="true" interfacename="nd_file" value="resources/Images/grid.png" />
     </image>
     <image name="image2" type="color3">

--- a/resources/Materials/TestSuite/stdlib/noise/noise.mtlx
+++ b/resources/Materials/TestSuite/stdlib/noise/noise.mtlx
@@ -10,121 +10,121 @@
   - worleynoise2d
   - worleynoise3d
   -->
-  <nodegraph name="cellnoise3d_object" type="" xpos="5.28754" ypos="14.9465">
-    <cellnoise3d name="cellnoise3d1" type="float" xpos="6.48276" ypos="9.94">
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+  <nodegraph name="cellnoise3d_object">
+    <cellnoise3d name="cellnoise3d1" type="float">
+      <input name="position" type="vector3" nodename="multiply1" />
     </cellnoise3d>
     <output name="out" type="float" nodename="cellnoise3d1" />
-    <position name="position1" type="vector3" xpos="3.51724" ypos="10.54">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <multiply name="multiply1" type="vector3" xpos="5" ypos="10.24">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <multiply name="multiply1" type="vector3">
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="fractal3d_object" type="" xpos="5.29008" ypos="16.1884">
-    <fractal3d name="fractal3d1" type="float" xpos="6.48276" ypos="9.92">
+  <nodegraph name="fractal3d_object">
+    <fractal3d name="fractal3d1" type="float">
       <input name="amplitude" type="float" value="10.0000" />
       <input name="octaves" type="integer" value="2" />
       <input name="lacunarity" type="float" value="2.0000" />
       <input name="diminish" type="float" value="0.5000" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+      <input name="position" type="vector3" nodename="multiply1" />
     </fractal3d>
     <output name="out" type="float" nodename="fractal3d1" />
-    <position name="position1" type="vector3" xpos="3.51724" ypos="10.54">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <multiply name="multiply1" type="vector3" xpos="5" ypos="10.24">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <multiply name="multiply1" type="vector3">
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="noise3d_object" type="" xpos="5.28762" ypos="18.6787">
-    <noise3d name="noise3d1" type="float" xpos="6.48276" ypos="9.92">
+  <nodegraph name="noise3d_object">
+    <noise3d name="noise3d1" type="float">
       <input name="amplitude" type="float" value="10.0000" />
       <input name="pivot" type="float" value="0.0000" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+      <input name="position" type="vector3" nodename="multiply1" />
     </noise3d>
-    <position name="position1" type="vector3" xpos="3.51724" ypos="10.54">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <multiply name="multiply1" type="vector3" xpos="5" ypos="10.24">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <multiply name="multiply1" type="vector3">
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
     <output name="out" type="float" nodename="noise3d1" />
   </nodegraph>
-  <nodegraph name="noise2d" type="" xpos="5.29254" ypos="17.4241">
-    <noise2d name="noise2d1" type="float" xpos="6.48276" ypos="9.92">
+  <nodegraph name="noise2d">
+    <noise2d name="noise2d1" type="float">
       <input name="amplitude" type="float" value="10.0000" />
       <input name="pivot" type="float" value="0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
     </noise2d>
     <output name="out" type="float" nodename="noise2d1" />
-    <texcoord name="texcoord1" type="vector2" xpos="3.51724" ypos="10.58">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="5" ypos="10.26">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="100.0000, 100.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="cellnoise2d" type="" xpos="5.28582" ypos="13.671">
-    <cellnoise2d name="cellnoise2d1" type="float" xpos="6.48276" ypos="9.94">
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+  <nodegraph name="cellnoise2d">
+    <cellnoise2d name="cellnoise2d1" type="float">
+      <input name="texcoord" type="vector2" nodename="multiply1" />
     </cellnoise2d>
-    <texcoord name="texcoord1" type="vector2" xpos="3.51724" ypos="10.54">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="5" ypos="10.24">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="100.0000, 100.0000" />
     </multiply>
     <output name="out" type="float" nodename="cellnoise2d1" />
   </nodegraph>
-  <nodegraph name="cellnoise3d_world" type="" xpos="6.34143" ypos="14.9552">
-    <position name="position1" type="vector3" xpos="2.03448" ypos="7.18">
+  <nodegraph name="cellnoise3d_world">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="world" />
     </position>
-    <cellnoise3d name="cellnoise3d1" type="float" xpos="4.96857" ypos="7.23722">
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+    <cellnoise3d name="cellnoise3d1" type="float">
+      <input name="position" type="vector3" nodename="multiply1" />
     </cellnoise3d>
-    <multiply name="multiply1" type="vector3" xpos="3.45628" ypos="7.0425">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <multiply name="multiply1" type="vector3">
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
     <output name="out" type="float" nodename="cellnoise3d1" />
   </nodegraph>
-  <nodegraph name="fractal3d_world" type="" xpos="6.35007" ypos="16.1687">
-    <position name="position1" type="vector3" xpos="2.76552" ypos="8.98">
+  <nodegraph name="fractal3d_world">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="world" />
     </position>
-    <multiply name="multiply1" type="vector3" xpos="4.42552" ypos="9.0089">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <multiply name="multiply1" type="vector3">
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
-    <fractal3d name="fractal3d1" type="float" xpos="5.96324" ypos="9.07604">
+    <fractal3d name="fractal3d1" type="float">
       <input name="amplitude" type="float" value="10.0000" />
       <input name="octaves" type="integer" value="2" />
       <input name="lacunarity" type="float" value="2.0" />
       <input name="diminish" type="float" value="0.5" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+      <input name="position" type="vector3" nodename="multiply1" />
     </fractal3d>
     <output name="out" type="float" nodename="fractal3d1" />
   </nodegraph>
-  <nodegraph name="noise3d_world" type="" xpos="6.35007" ypos="18.6762">
-    <position name="position1" type="vector3" xpos="1.81379" ypos="7.76">
+  <nodegraph name="noise3d_world">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="world" />
     </position>
-    <multiply name="multiply1" type="vector3" xpos="3.52872" ypos="7.39866">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <multiply name="multiply1" type="vector3">
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="20.0000, 20.0000, 20.0000" />
     </multiply>
-    <noise3d name="noise3d1" type="float" xpos="5.27098" ypos="7.53098">
+    <noise3d name="noise3d1" type="float">
       <input name="amplitude" type="float" value="10.0000" />
       <input name="pivot" type="float" value="0.0" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+      <input name="position" type="vector3" nodename="multiply1" />
     </noise3d>
     <output name="out" type="float" nodename="noise3d1" />
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/noise/procedural.mtlx
+++ b/resources/Materials/TestSuite/stdlib/noise/procedural.mtlx
@@ -1,106 +1,106 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="nodegraph1" type="" xpos="7.14697" ypos="11.4475">
-    <cellnoise3d name="cellnoise3d1" type="float" xpos="4.5505" ypos="4.1665">
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply1" />
+  <nodegraph name="nodegraph1">
+    <cellnoise3d name="cellnoise3d1" type="float">
+      <input name="position" type="vector3" nodename="multiply1" />
     </cellnoise3d>
     <output name="out" type="color3" nodename="ifgreater1" />
-    <position name="position1" type="vector3" xpos="2.97476" ypos="1.83258">
+    <position name="position1" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <multiply name="multiply1" type="vector3" xpos="3.14625" ypos="3.6056">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
+    <multiply name="multiply1" type="vector3">
+      <input name="in1" type="vector3" nodename="position1" />
       <input name="in2" type="vector3" value="1.0000, 1.0000, 1.0000" />
     </multiply>
-    <ifgreater name="ifgreater2" type="color3" xpos="5.97002" ypos="8.61048">
+    <ifgreater name="ifgreater2" type="color3">
       <input name="value1" type="float" value="0.4400" />
-      <input name="value2" type="float" value="0.0" nodename="cellnoise3d1" />
-      <input name="in1" type="color3" value="0.0, 1.0000, 0.0" nodename="noise3d1" />
-      <input name="in2" type="color3" value="0.0, 0.0000, 1.0000" nodename="ifgreater3" />
+      <input name="value2" type="float" nodename="cellnoise3d1" />
+      <input name="in1" type="color3" nodename="noise3d1" />
+      <input name="in2" type="color3" nodename="ifgreater3" />
     </ifgreater>
-    <ifgreater name="ifgreater1" type="color3" xpos="5.95711" ypos="5.76366">
+    <ifgreater name="ifgreater1" type="color3">
       <input name="value1" type="float" value="0.3700" />
-      <input name="value2" type="float" value="0.0" nodename="cellnoise3d1" />
-      <input name="in1" type="color3" value="1.0000, 0.0, 0.0" nodename="mix1" />
-      <input name="in2" type="color3" value="0.0, 0.0, 0.0" nodename="ifgreater2" />
+      <input name="value2" type="float" nodename="cellnoise3d1" />
+      <input name="in1" type="color3" nodename="mix1" />
+      <input name="in2" type="color3" nodename="ifgreater2" />
     </ifgreater>
-    <ifgreater name="ifgreater3" type="color3" xpos="6.01609" ypos="12.2133">
+    <ifgreater name="ifgreater3" type="color3">
       <input name="value1" type="float" value="0.6800" />
-      <input name="value2" type="float" value="0.0" nodename="cellnoise3d1" />
-      <input name="in1" type="color3" value="0.0, 0.0, 1.0000" nodename="convert1" />
-      <input name="in2" type="color3" value="0.0, 0.0, 0.0" nodename="fractal3d1" />
+      <input name="value2" type="float" nodename="cellnoise3d1" />
+      <input name="in1" type="color3" nodename="convert1" />
+      <input name="in2" type="color3" nodename="fractal3d1" />
     </ifgreater>
-    <fractal3d name="fractal3d1" type="color3" xpos="4.45249" ypos="15.9225">
+    <fractal3d name="fractal3d1" type="color3">
       <input name="amplitude" type="vector3" value="2.0000, 2.0000, 1.0000" />
       <input name="octaves" type="integer" value="3" />
       <input name="lacunarity" type="float" value="2.0" />
       <input name="diminish" type="float" value="0.5" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply2" />
+      <input name="position" type="vector3" nodename="multiply2" />
     </fractal3d>
-    <position name="position2" type="vector3" xpos="2.33754" ypos="15.8045">
+    <position name="position2" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <multiply name="multiply2" type="vector3" xpos="3.34061" ypos="15.478">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position2" />
+    <multiply name="multiply2" type="vector3">
+      <input name="in1" type="vector3" nodename="position2" />
       <input name="in2" type="vector3" value="3.0000, 0.0000, 0.0000" />
     </multiply>
-    <noise3d name="noise3d1" type="color3" xpos="4.41623" ypos="11.4751">
+    <noise3d name="noise3d1" type="color3">
       <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
       <input name="pivot" type="float" value="0.0" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" nodename="multiply3" />
+      <input name="position" type="vector3" nodename="multiply3" />
     </noise3d>
-    <position name="position3" type="vector3" xpos="2.27049" ypos="11.2296">
+    <position name="position3" type="vector3">
       <input name="space" type="string" value="object" />
     </position>
-    <multiply name="multiply3" type="vector3" xpos="3.30537" ypos="11.2024">
-      <input name="in1" type="vector3" value="0.0, 0.0, 0.0" nodename="position3" />
+    <multiply name="multiply3" type="vector3">
+      <input name="in1" type="vector3" nodename="position3" />
       <input name="in2" type="vector3" value="2.0000, 2.0000, 2.0000" />
     </multiply>
-    <ramptb name="ramptb1" type="color3" xpos="3.19306" ypos="5.66478">
+    <ramptb name="ramptb1" type="color3">
       <input name="valuet" type="color3" value="1.0000, 0.0, 0.0" />
       <input name="valueb" type="color3" value="1.0000, 1.0000, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply4" />
+      <input name="texcoord" type="vector2" nodename="multiply4" />
     </ramptb>
-    <texcoord name="texcoord1" type="vector2" xpos="0.696786" ypos="4.9712">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply4" type="vector2" xpos="1.9959" ypos="5.44648">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply4" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="1.0000, 1.0000" />
     </multiply>
-    <ramptb name="ramptb2" type="color3" xpos="3.2132" ypos="7.19774">
+    <ramptb name="ramptb2" type="color3">
       <input name="valuet" type="color3" value="1.0000, 0.2000, 0.2000" />
       <input name="valueb" type="color3" value="1.0000, 1.0000, 0.2000" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="invert1" />
+      <input name="texcoord" type="vector2" nodename="invert1" />
     </ramptb>
-    <invert name="invert1" type="vector2" xpos="2.11326" ypos="7.71854">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="multiply4" />
+    <invert name="invert1" type="vector2">
+      <input name="in" type="vector2" nodename="multiply4" />
       <input name="amount" type="vector2" value="1.0, 1.0" />
     </invert>
-    <mix name="mix1" type="color3" xpos="4.52024" ypos="6.59818">
-      <input name="fg" type="color3" value="0.0, 0.0, 0.0" nodename="ramptb1" />
-      <input name="bg" type="color3" value="0.0, 0.0, 0.0" nodename="ramptb2" />
-      <input name="mix" type="float" value="0.5600" nodename="sin1" />
+    <mix name="mix1" type="color3">
+      <input name="fg" type="color3" nodename="ramptb1" />
+      <input name="bg" type="color3" nodename="ramptb2" />
+      <input name="mix" type="float" nodename="sin1" />
     </mix>
-    <swizzle name="swizzle1" type="float" xpos="0.913317" ypos="6.98328">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <swizzle name="swizzle1" type="float">
+      <input name="in" type="vector2" nodename="texcoord1" />
       <input name="channels" type="string" value="y" />
     </swizzle>
-    <sin name="sin1" type="float" xpos="3.19075" ypos="9.25918">
-      <input name="in" type="float" value="0.0" nodename="multiply5" />
+    <sin name="sin1" type="float">
+      <input name="in" type="float" nodename="multiply5" />
     </sin>
-    <multiply name="multiply5" type="float" xpos="1.4099" ypos="9.29448">
-      <input name="in1" type="float" value="0.0" nodename="swizzle1" />
+    <multiply name="multiply5" type="float">
+      <input name="in1" type="float" nodename="swizzle1" />
       <input name="in2" type="float" value="30.0000" />
     </multiply>
-    <cellnoise2d name="cellnoise2d1" type="float" xpos="3.6397" ypos="13.4553">
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply6" />
+    <cellnoise2d name="cellnoise2d1" type="float">
+      <input name="texcoord" type="vector2" nodename="multiply6" />
     </cellnoise2d>
-    <convert name="convert1" type="color3" xpos="4.77081" ypos="13.4516">
-      <input name="in" type="float" value="0.0" nodename="cellnoise2d1" />
+    <convert name="convert1" type="color3">
+      <input name="in" type="float" nodename="cellnoise2d1" />
     </convert>
-    <multiply name="multiply6" type="vector2" xpos="2.5005" ypos="13.364">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply6" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="50.0000, 50.0000" />
     </multiply>
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/noise/shared_function.mtlx
+++ b/resources/Materials/TestSuite/stdlib/noise/shared_function.mtlx
@@ -4,7 +4,7 @@
       Test using noise2d for both color3 and vector3 in the same graph,
       since these share the same node implementation for GLSL.
   -->
-  <nodegraph name="shared_function_test" type="">
+  <nodegraph name="shared_function_test">
     <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>

--- a/resources/Materials/TestSuite/stdlib/organization/organization.mtlx
+++ b/resources/Materials/TestSuite/stdlib/organization/organization.mtlx
@@ -1,77 +1,77 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="dot_float" type="" xpos="4.58053" ypos="13.8678">
-    <dot name="dot1" type="float" xpos="5.74483" ypos="4.74">
-      <input name="in" type="float" value="0.5000" nodename="constant1" />
+  <nodegraph name="dot_float">
+    <dot name="dot1" type="float">
+      <input name="in" type="float" nodename="constant1" />
       <input name="note" type="string" value="" />
     </dot>
     <output name="out" type="float" nodename="dot1" />
-    <constant name="constant1" type="float" xpos="4.37389" ypos="4.87278">
+    <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
     </constant>
   </nodegraph>
-  <nodegraph name="dot_color2" type="" xpos="5.63784" ypos="13.8481">
-    <dot name="dot1" type="vector2" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector2" value="0.0, 1.0" nodename="constant1" />
+  <nodegraph name="dot_color2">
+    <dot name="dot1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
       <input name="note" type="string" value="" />
     </dot>
     <output name="out" type="vector2" nodename="dot1" />
-    <constant name="constant1" type="vector2" xpos="4.46234" ypos="4.8856">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="0.5000, 1.0" />
     </constant>
   </nodegraph>
-  <nodegraph name="dot_color3" type="" xpos="6.67495" ypos="13.8481">
-    <dot name="dot1" type="color3" xpos="5.79581" ypos="4.74">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="dot_color3">
+    <dot name="dot1" type="color3">
+      <input name="in" type="color3" nodename="constant1" />
       <input name="note" type="string" value="" />
     </dot>
-    <constant name="constant1" type="color3" xpos="4.70414" ypos="5.03028">
+    <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.0000, 0.5000, 1.0000" />
     </constant>
     <output name="out" type="color3" nodename="dot1" />
   </nodegraph>
-  <nodegraph name="dot_color4" type="" xpos="7.71945" ypos="13.8338">
-    <dot name="dot1" type="color4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="dot_color4">
+    <dot name="dot1" type="color4">
+      <input name="in" type="color4" nodename="constant1" />
       <input name="note" type="string" value="" />
     </dot>
-    <constant name="constant1" type="color4" xpos="4.67194" ypos="5.05362">
+    <constant name="constant1" type="color4">
       <input name="value" type="color4" value="0.0, 0.2500, 0.5000, 1.0" />
     </constant>
     <output name="out" type="color4" nodename="dot1" />
   </nodegraph>
-  <nodegraph name="dot_vector2" type="" xpos="5.66248" ypos="14.9482">
-    <dot name="dot1" type="vector2" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector2" value="0.0, 0.0" nodename="constant1" />
+  <nodegraph name="dot_vector2">
+    <dot name="dot1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
       <input name="note" type="string" value="" />
     </dot>
-    <constant name="constant1" type="vector2" xpos="4.70683" ypos="5.05362">
+    <constant name="constant1" type="vector2">
       <input name="value" type="vector2" value="0.5000, 1.0000" />
     </constant>
     <output name="out" type="vector2" nodename="dot1" />
   </nodegraph>
-  <nodegraph name="dot_vector3" type="" xpos="6.68973" ypos="14.9167">
-    <dot name="dot1" type="vector3" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="constant1" />
+  <nodegraph name="dot_vector3">
+    <dot name="dot1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
       <input name="note" type="string" value="" />
     </dot>
-    <constant name="constant1" type="vector3" xpos="4.64243" ypos="4.91354">
+    <constant name="constant1" type="vector3">
       <input name="value" type="vector3" value="0.0, 0.5000, 1.0000" />
     </constant>
     <output name="out" type="vector3" nodename="dot1" />
   </nodegraph>
-  <nodegraph name="dot_vector4" type="" xpos="7.73177" ypos="14.9096">
-    <dot name="dot1" type="vector4" xpos="5.74483" ypos="4.74">
-      <input name="in" type="vector4" value="0.0, 0.0, 0.0, 1.0" nodename="constant1" />
+  <nodegraph name="dot_vector4">
+    <dot name="dot1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
       <input name="note" type="string" value="" />
     </dot>
-    <constant name="constant1" type="vector4" xpos="4.65048" ypos="4.96802">
+    <constant name="constant1" type="vector4">
       <input name="value" type="vector4" value="0.0, 0.2500, 0.5000, 1.0" />
     </constant>
     <output name="out" type="vector4" nodename="dot1" />
   </nodegraph>
   <!--
-  <nodegraph name="dot_matrix33" type="">
+  <nodegraph name="dot_matrix33">
     <dot name="dot1" type="matrix33">
       <input name="in" type="matrix33" nodename="constant1" />
       <input name="note" type="string" value="" uniform="true" />
@@ -86,7 +86,7 @@
     <output name="out" type="vector3" nodename="transformvector1"/>
   </nodegraph>
   -->
-  <nodegraph name="dot_matrix44" type="">
+  <nodegraph name="dot_matrix44">
     <dot name="dot1" type="matrix44">
       <input name="in" type="matrix44" nodename="constant1" />
       <input name="note" type="string" value="" />

--- a/resources/Materials/TestSuite/stdlib/texture/image_addressing.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image_addressing.mtlx
@@ -1,160 +1,120 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="uclamp" type="" xpos="8.43448" ypos="4.84">
-    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+  <nodegraph name="uclamp">
+    <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="layer" type="string" value="" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
       <input name="uaddressmode" type="string" value="clamp" />
-      <input name="vaddressmode" type="string" value="periodic" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="2.0000, 2.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="vclamp" type="" xpos="8.43448" ypos="4.84">
-    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+  <nodegraph name="vclamp">
+    <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="layer" type="string" value="" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
-      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
       <input name="vaddressmode" type="string" value="clamp" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="2.0000, 2.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="uborder_color" type="" xpos="8.43448" ypos="4.84">
-    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+  <nodegraph name="uborder_color">
+    <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="layer" type="string" value="" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
       <input name="uaddressmode" type="string" value="constant" />
-      <input name="vaddressmode" type="string" value="periodic" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="2.0000, 2.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="vborder_color" type="" xpos="8.43448" ypos="4.84">
-    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+  <nodegraph name="vborder_color">
+    <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="layer" type="string" value="" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
-      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
       <input name="vaddressmode" type="string" value="constant" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="2.0000, 2.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="uv_decal_black" type="" xpos="8.43448" ypos="4.84">
-    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+  <nodegraph name="uv_decal_black">
+    <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="layer" type="string" value="" />
-      <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="add1" />
+      <input name="texcoord" type="vector2" nodename="add1" />
       <input name="uaddressmode" type="string" value="constant" />
       <input name="vaddressmode" type="string" value="constant" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="2.0000, 2.0000" />
     </multiply>
-    <add name="add1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <add name="add1" type="vector2">
+      <input name="in1" type="vector2" nodename="multiply1" />
       <input name="in2" type="vector2" value="-0.5000, -0.5000" />
     </add>
   </nodegraph>
-  <nodegraph name="vmirror" type="" xpos="8.43448" ypos="4.84">
-    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+  <nodegraph name="vmirror">
+    <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="layer" type="string" value="" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
       <input name="uaddressmode" type="string" value="clamp" />
       <input name="vaddressmode" type="string" value="mirror" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="2.0000, 2.0000" />
     </multiply>
   </nodegraph>
-  <nodegraph name="umirror" type="" xpos="8.43448" ypos="4.84">
-    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+  <nodegraph name="umirror">
+    <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="layer" type="string" value="" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <input name="texcoord" type="vector2" nodename="multiply1" />
       <input name="uaddressmode" type="string" value="mirror" />
       <input name="vaddressmode" type="string" value="clamp" />
-      <input name="filtertype" type="string" value="linear" />
-      <input name="framerange" type="string" value="" />
-      <input name="frameoffset" type="integer" value="0" />
-      <input name="frameendaction" type="string" value="constant" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
-    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+    <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" value="0" />
     </texcoord>
-    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
-      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
       <input name="in2" type="vector2" value="2.0000, 2.0000" />
     </multiply>
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/texture/noise.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/noise.mtlx
@@ -13,7 +13,7 @@
     <input name="index" type="integer" value="0" />
   </texcoord>
   <multiply name="multiply1" type="vector2">
-    <input name="in1" type="vector2" value="0.0, 1.0" nodename="texcoord1" />
+    <input name="in1" type="vector2" nodename="texcoord1" />
     <input name="in2" type="vector2" value="16.0000, 16.0000" />
   </multiply>
 
@@ -22,79 +22,79 @@
   <noise2d name="noise2d_1" type="float">
     <input name="amplitude" type="float" value="1.0000" />
     <input name="pivot" type="float" value="0.4000" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_2_output" type="vector2" nodename="noise2d_2" />
   <noise2d name="noise2d_2" type="vector2">
     <input name="amplitude" type="vector2" value="1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_2FA_output" type="vector2" nodename="noise2d_2FA" />
   <noise2d name="noise2d_2FA" type="vector2">
     <input name="amplitude" type="float" value="1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_3_output" type="color3" nodename="noise2d_3" />
   <noise2d name="noise2d_3" type="color3">
     <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_3FA_output" type="color3" nodename="noise2d_3FA" />
   <noise2d name="noise2d_3FA" type="color3">
     <input name="amplitude" type="float" value="1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_4_output" type="color4" nodename="noise2d_4" />
   <noise2d name="noise2d_4" type="color4">
     <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_4FA_output" type="color4" nodename="noise2d_4FA" />
   <noise2d name="noise2d_4FA" type="color4">
     <input name="amplitude" type="float" value="1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_2v_output" type="vector2" nodename="noise2d_2v" />
   <noise2d name="noise2d_2v" type="vector2">
     <input name="amplitude" type="vector2" value="1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_2FAv_output" type="vector2" nodename="noise2d_2FAv" />
   <noise2d name="noise2d_2FAv" type="vector2">
     <input name="amplitude" type="float" value="1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_3v_output" type="vector3" nodename="noise2d_3v" />
   <noise2d name="noise2d_3v" type="vector3">
     <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_3FAv_output" type="vector3" nodename="noise2d_3FAv" />
   <noise2d name="noise2d_3FAv" type="vector3">
     <input name="amplitude" type="float" value="1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_4v_output" type="vector4" nodename="noise2d_4v" />
   <noise2d name="noise2d_4v" type="vector4">
     <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
   <output name="noise2d_4FAv_output" type="vector4" nodename="noise2d_4FAv" />
   <noise2d name="noise2d_4FAv" type="vector4">
     <input name="amplitude" type="float" value="1.0" />
     <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </noise2d>
 
   <!-- 3D Perlin noise -->
@@ -221,7 +221,7 @@
   <!-- Cell noise 2D and 3D -->
   <output name="cellnoise2d_1_output" type="float" nodename="cellnoise2d_1" />
   <cellnoise2d name="cellnoise2d_1" type="float">
-    <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+    <input name="texcoord" type="vector2" nodename="multiply1" />
   </cellnoise2d>
   <output name="cellnoise3d_1_output" type="float" nodename="cellnoise3d_1" />
   <cellnoise3d name="cellnoise3d_1" type="float" />

--- a/resources/Materials/TestSuite/stdlib/units/texture_units.mtlx
+++ b/resources/Materials/TestSuite/stdlib/units/texture_units.mtlx
@@ -17,8 +17,6 @@
     </place2d>
     <image name="base_color_image" type="color3">
       <input name="file" type="filename" value="grid.png" colorspace="srgb_texture" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
       <input name="texcoord" type="vector2" nodename="a_place2d" />
     </image>
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/upgrade/1_36_to_1_37.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/1_36_to_1_37.mtlx
@@ -36,7 +36,7 @@ Upgrade path test from 1.36 to 1.37
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="amount" type="float" value="1.5708" unittype="angle" unit="radian" />
   </rotate>
-  <rotate name="rotate2" type="vector3" xpos="5.19248" ypos="5.306">
+  <rotate name="rotate2" type="vector3">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
     <input name="amount" type="float" value="180.0000" unittype="angle" unit="degree" />
     <parameter name="axis" type="vector3" value="0.0, 1.0000, 1.0000" />

--- a/resources/Materials/TestSuite/stdlib/upgrade/1_38_parameter_to_input.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/1_38_parameter_to_input.mtlx
@@ -21,14 +21,6 @@
     </ramp4>
     <image name="image" type="color3">
       <input name="file" type="filename" nodename="constant3" />
-      <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-      <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default Color" uniform="true" />
-      <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-      <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
-      <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
-      <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
-      <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
-      <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
     </image>
     <splitlr name="splitlr" type="color3">
       <input name="valuel" type="color3" nodename="image" />


### PR DESCRIPTION
- Remove value attributes that are overridden by node connections.
- Remove explicit assignments of default values.
- Remove legacy xpos and ypos attributes with screen-space coordinates.