### PR TITLE
Improvements to convolution render tests

### DIFF
--- a/resources/Materials/TestSuite/stdlib/convolution/blur.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/blur.mtlx
@@ -3,123 +3,86 @@
   <!---
      Blur unit test
   -->
+  <nodegraph name="blur_color3">
+    <image name="image1" type="color3">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+    </image>
+    <blur name="blur_color3" type="color3">
+      <input name="in" type="color3" nodename="image1" />
+      <input name="size" type="float" value="0.5" />
+      <input name="filtertype" type="string" value="gaussian" />
+    </blur>
+    <output name="blur_color3_out" type="color3" nodename="blur_color3" />
+  </nodegraph>
+  <nodegraph name="blur_color4">
+    <tiledimage name="tiledimage1" type="color4">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+    </tiledimage>
+    <blur name="blur_color4" type="color4">
+      <input name="in" type="color4" nodename="tiledimage1" />
+      <input name="size" type="float" value="0.5" />
+      <input name="filtertype" type="string" value="gaussian" />
+    </blur>
+    <output name="blur_color4_out" type="color4" nodename="blur_color4" />
+  </nodegraph>
   <nodegraph name="blur_float">
     <image name="image1" type="float">
-      <input name="file" type="filename" value="resources/Images/marble.png" />
+      <input name="file" type="filename" value="resources/Images/grid.png" />
     </image>
-    <blur name="blur1" type="float">
+    <blur name="blur_float" type="float">
       <input name="in" type="float" nodename="image1" />
-      <input name="size" type="float" value="0.4000" />
+      <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="box" />
     </blur>
-    <output name="out" type="float" nodename="blur1" />
-  </nodegraph>
-  <nodegraph name="blur_color3">
-    <image name="image2" type="color3">
-      <input name="file" type="filename" value="resources/Images/marble.png" />
-    </image>
-    <blur name="blur2" type="color3">
-      <input name="in" type="color3" nodename="image2" />
-      <input name="size" type="float" value="0.1000" />
-      <input name="filtertype" type="string" value="box" />
-    </blur>
-    <output name="out" type="color3" nodename="blur2" />
-  </nodegraph>
-  <nodegraph name="blur_float_cellnoise">
-    <cellnoise2d name="cellnoise2d1" type="float">
-      <input name="texcoord" type="vector2" nodename="multiply1" />
-    </cellnoise2d>
-    <blur name="blur3" type="float">
-      <input name="in" type="float" nodename="cellnoise2d1" />
-      <input name="size" type="float" value="0.7000" />
-      <input name="filtertype" type="string" value="box" />
-    </blur>
-    <output name="out" type="float" nodename="blur3" />
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" value="0" />
-    </texcoord>
-    <multiply name="multiply1" type="vector2">
-      <input name="in1" type="vector2" nodename="texcoord1" />
-      <input name="in2" type="vector2" value="100.0000, 100.0000" />
-    </multiply>
-  </nodegraph>
-  <nodegraph name="blur_noise">
-    <blur name="blur1" type="vector2">
-      <input name="in" type="vector2" nodename="noise2d1" />
-      <input name="size" type="float" value="0.1000" />
-      <input name="filtertype" type="string" value="box" />
-    </blur>
-    <noise2d name="noise2d1" type="vector2">
-      <input name="amplitude" type="vector2" value="1.0000, 2.0000" />
-      <input name="pivot" type="float" value="0.4000" />
-      <input name="texcoord" type="vector2" nodename="multiply1" />
-    </noise2d>
-    <output name="out" type="vector2" nodename="blur1" />
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" value="0" />
-    </texcoord>
-    <multiply name="multiply1" type="vector2">
-      <input name="in1" type="vector2" nodename="texcoord1" />
-      <input name="in2" type="vector2" value="50.0000, 50.0000" />
-    </multiply>
-  </nodegraph>
-  <nodegraph name="blur_color2">
-    <image name="image1" type="vector2">
-      <input name="file" type="filename" value="resources/Images/marble.png" />
-    </image>
-    <output name="out" type="vector2" nodename="blur1" />
-    <blur name="blur1" type="vector2">
-      <input name="in" type="vector2" nodename="image1" />
-      <input name="size" type="float" value="1.0000" />
-      <input name="filtertype" type="string" value="box" />
-    </blur>
+    <output name="blur_float_out" type="float" nodename="blur_float" />
   </nodegraph>
   <nodegraph name="blur_vector2">
     <tiledimage name="tiledimage1" type="vector2">
-      <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="uvtiling" type="vector2" value="0.2000, 0.2000" />
+      <input name="file" type="filename" value="resources/Images/grid.png" />
     </tiledimage>
-    <output name="out" type="vector2" nodename="blur1" />
-    <blur name="blur1" type="vector2">
+    <blur name="blur_vector2" type="vector2">
       <input name="in" type="vector2" nodename="tiledimage1" />
-      <input name="size" type="float" value="0.4000" />
-      <input name="filtertype" type="string" value="gaussian" />
+      <input name="size" type="float" value="0.5" />
+      <input name="filtertype" type="string" value="box" />
     </blur>
+    <output name="blur_vector2_out" type="vector2" nodename="blur_vector2" />
   </nodegraph>
   <nodegraph name="blur_vector3">
     <tiledimage name="tiledimage1" type="vector3">
-      <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="uvtiling" type="vector2" value="0.1000, 0.1000" />
+      <input name="file" type="filename" value="resources/Images/grid.png" />
     </tiledimage>
-    <output name="out" type="vector3" nodename="blur1" />
-    <blur name="blur1" type="vector3">
+    <blur name="blur_vector3" type="vector3">
       <input name="in" type="vector3" nodename="tiledimage1" />
-      <input name="size" type="float" value="0.1000" />
+      <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="box" />
     </blur>
-  </nodegraph>
-  <nodegraph name="blur_color4">
-    <blur name="blur1" type="color4">
-      <input name="in" type="color4" nodename="tiledimage1" />
-      <input name="size" type="float" value="0.3000" />
-      <input name="filtertype" type="string" value="gaussian" />
-    </blur>
-    <tiledimage name="tiledimage1" type="color4">
-      <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="uvtiling" type="vector2" value="0.2000, 0.2000" />
-    </tiledimage>
-    <output name="out" type="color4" nodename="blur1" />
+    <output name="blur_vector3_out" type="vector3" nodename="blur_vector3" />
   </nodegraph>
   <nodegraph name="blur_vector4">
-    <blur name="blur1" type="vector4">
+    <tiledimage name="tiledimage1" type="vector4">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+    </tiledimage>
+    <blur name="blur_vector4" type="vector4">
       <input name="in" type="vector4" nodename="tiledimage1" />
-      <input name="size" type="float" value="0.3000" />
+      <input name="size" type="float" value="0.5" />
+      <input name="filtertype" type="string" value="box" />
+    </blur>
+    <output name="blur_vector4_out" type="vector4" nodename="blur_vector4" />
+  </nodegraph>
+  <nodegraph name="blur_cellnoise">
+    <texcoord name="texcoord1" type="vector2" />
+    <multiply name="multiply1" type="vector2">
+      <input name="in1" type="vector2" nodename="texcoord1" />
+      <input name="in2" type="float" value="100" />
+    </multiply>
+    <cellnoise2d name="cellnoise2d1" type="float">
+      <input name="texcoord" type="vector2" nodename="multiply1" />
+    </cellnoise2d>
+    <blur name="blur_cellnoise" type="float">
+      <input name="in" type="float" nodename="cellnoise2d1" />
+      <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="gaussian" />
     </blur>
-    <tiledimage name="tiledimage1" type="vector4">
-      <input name="file" type="filename" value="resources/Images/marble.png" />
-      <input name="uvtiling" type="vector2" value="0.4000, 0.4000" />
-    </tiledimage>
-    <output name="out" type="vector4" nodename="blur1" />
+    <output name="blur_cellnoise_out" type="float" nodename="blur_cellnoise" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
@@ -1,47 +1,34 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="hton_unconnected_graph">
-    <heighttonormal name="heighttonormal1" type="vector3">
-      <input name="in" type="float" value="1" />
-      <input name="scale" type="float" value="1" />
-    </heighttonormal>
-    <normalmap name="normalmap" type="vector3">
-      <input name="in" type="vector3" nodename="heighttonormal1" />
-    </normalmap>
-    <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1">
-      <input name="normal" type="vector3" nodename="normalmap" />
-    </standard_surface>
-    <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader" version="2.3">
-      <input name="normal" type="vector3" nodename="heighttonormal1" />
-    </UsdPreviewSurface>
-    <output name="const_outHeightToNormal" type="vector3" nodename="heighttonormal1" />
-    <output name="const_outNormalMap" type="vector3" nodename="normalmap" />
-    <output name="const_outStandardSurface" type="surfaceshader" nodename="standard_surface" />
-    <output name="const_outUSDSurface" type="surfaceshader" nodename="UsdPreviewSurface" />
-  </nodegraph>
-  <nodegraph name="hton_image_graph">
+  <nodegraph name="height_to_normal">
     <input name="file" type="filename" uniform="true" value="resources/Images/plain_heightmap.png" />
-    <heighttonormal name="heighttonormal1" type="vector3">
-      <input name="in" type="float" nodename="tiledimage" />
-      <input name="scale" type="float" value="0.2" />
-    </heighttonormal>
     <tiledimage name="tiledimage" type="float">
       <input name="file" type="filename" uniform="true" interfacename="file" value="resources/Images/plain_heightmap.png" />
       <input name="uvtiling" type="vector2" value="10, 10" />
     </tiledimage>
+    <heighttonormal name="heighttonormal" type="vector3">
+      <input name="in" type="float" nodename="tiledimage" />
+      <input name="scale" type="float" value="0.2" />
+    </heighttonormal>
     <normalmap name="normalmap" type="vector3">
-      <input name="in" type="vector3" nodename="heighttonormal1" />
-      <input name="scale" type="float" value="1" />
+      <input name="in" type="vector3" nodename="heighttonormal" />
     </normalmap>
-    <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1">
+    <standard_surface name="standard_surface" type="surfaceshader">
       <input name="normal" type="vector3" nodename="normalmap" />
     </standard_surface>
-    <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader" version="2.3">
-      <input name="normal" type="vector3" nodename="heighttonormal1" />
+    <multiply name="scale" type="vector3">
+      <input name="in1" type="vector3" nodename="heighttonormal" />
+      <input name="in2" type="float" value="2" />
+    </multiply>
+    <add name="bias" type="vector3">
+      <input name="in1" type="vector3" nodename="scale" />
+      <input name="in2" type="vector3" value="-1, -1, -1" />
+    </add>
+    <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader">
+      <input name="normal" type="vector3" nodename="bias" />
     </UsdPreviewSurface>
-    <output name="txt_outHeightToNormal" type="vector3" nodename="heighttonormal1" />
-    <output name="txt_outNormalMap" type="vector3" nodename="normalmap" />
-    <output name="txt_outStandardSurface" type="surfaceshader" nodename="standard_surface" />
-    <output name="txt_outUSDSurface" type="surfaceshader" nodename="UsdPreviewSurface" />
+    <output name="height_to_normal_out" type="vector3" nodename="heighttonormal" />
+    <output name="standard_surface_out" type="surfaceshader" nodename="standard_surface" />
+    <output name="usd_preview_surface_out" type="surfaceshader" nodename="UsdPreviewSurface" />
   </nodegraph>
 </materialx>

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -15,7 +15,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// as input, and return a 2 channel vector as output
 const string BlurNode::_sampleSizeFunctionUV = "mx_compute_sample_size_uv";
 
-const float BlurNode::_filterSize = 2.0;
+const float BlurNode::_filterSize = 1.0;
 const float BlurNode::_filterOffset = 0.0;
 
 const string BlurNode::BOX_FILTER = "box";


### PR DESCRIPTION
This changelist improves the render test suite for convolution nodes, clarifying the extent of their current implementation in MaterialX code generation.

Additionally, it restores the originally-intended value for blur filter size, which was lost in the upgrade from 1.37 to 1.38.